### PR TITLE
✨feat: ClubMemberQueryService에 독서클럽 운영진/회원 검증 메서드 추가

### DIFF
--- a/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
@@ -4,4 +4,7 @@ import checkmo.domain.club.entity.ClubMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
+    boolean existsByClubIdAndMemberId(Long clubId, String memberId);
+
+    boolean existsByClubIdAndMemberIdAndClubMemberStatus(Long clubId, String memberId, ClubMember.ClubMemberStatus clubMemberStatus);
 }

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryService.java
@@ -1,0 +1,28 @@
+package checkmo.domain.club.service.query;
+
+/**
+ * 독서클럽 회원에 대한 조회 서비스
+ * <p>
+ * 독서클럽 회원의 권한 확인 및 회원 존재 확인 기능을 담당합니다.
+ */
+public interface ClubMemberQueryService {
+
+    /**
+     * 독서클럽 회원인지 확인합니다.
+     *
+     * @param clubId   독서동아리 id
+     * @param memberId 회원 id
+     * @return true: 독서동아리 회원, false: 회원 아님
+     */
+    boolean isClubMember(Long clubId, String memberId);
+
+    /**
+     * 독서클럽의 특정 회원이 운영진(STAFF)인지 확인합니다.(권한 확인용)
+     *
+     * @param clubId
+     * @param memberId
+     * @return true: 운영진, false: 운영진 아님
+     */
+    boolean isClubStaff(Long clubId, String memberId);
+
+}

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
@@ -1,0 +1,26 @@
+package checkmo.domain.club.service.query;
+
+import checkmo.domain.club.entity.ClubMember;
+import checkmo.domain.club.repository.ClubMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubMemberQueryServiceImpl implements ClubMemberQueryService {
+
+    private final ClubMemberRepository clubMemberRepository;
+
+    @Override
+    public boolean isClubMember(Long clubId, String memberId) {
+        return clubMemberRepository.existsByClubIdAndMemberId(clubId, memberId);
+    }
+
+    @Override
+    public boolean isClubStaff(Long clubId, String memberId) {
+        return clubMemberRepository.existsByClubIdAndMemberIdAndClubMemberStatus(clubId, memberId, ClubMember.ClubMemberStatus.STAFF);
+    }
+
+}


### PR DESCRIPTION
## 🚀 변경사항
어노테이션 기반 검증 로직을 향후 계획으로 변경하면서,
Club 도메인 내부에서 반복적으로 필요한 검증 메서드를
ClubMemberQueryService에 추가했습니다.

1. 독서클럽 회원 여부 boolean 반환
2. 독서클럽 운영진 여부 boolean 반환

## 🔗 관련 이슈
- Closes #4 

## ✅ 체크리스트
- [ ] 로컬에서 테스트 완료
- [ ] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->
