### PR TITLE
Feat/9/meeting 생성 수정 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ repositories {
 dependencies {
     // ============= Spring Boot 스타터 =============
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    //implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    //implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -23,7 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB404", "독서클럽을 찾을 수 없습니다."),
 
-    CLUB_MEMBER_NOT_FOUND(HttpStatus.FORBIDDEN, "CLUB_MEMBER403", "해당 클럽의 회원이 아닙니다."),
+    CLUB_MEMBER_ONLY(HttpStatus.FORBIDDEN, "CLUB_MEMBER403", "해당 클럽의 회원이 아닙니다."),
     CLUB_STAFF_ONLY(HttpStatus.FORBIDDEN, "CLUB_STAFF403", "독서클럽 운영진만 접근할 수 있습니다."),
 
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404", "독서모임을 찾을 수 없습니다."),

--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -15,11 +15,16 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 가장 일반적인 응답
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
-    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
-    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK404", "책을 찾을 수 없습니다.");
+    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK404", "책을 찾을 수 없습니다."),
+
+    CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB404", "독서클럽을 찾을 수 없습니다."),
+
+    CLUB_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB_MEMBER404", "해당 클럽의 회원이 아닙니다."),
+    CLUB_STAFF_ONLY(HttpStatus.FORBIDDEN, "CLUB_STAFF403", "독서클럽 운영진만 접근할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -23,7 +23,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB404", "독서클럽을 찾을 수 없습니다."),
 
-    CLUB_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB_MEMBER404", "해당 클럽의 회원이 아닙니다."),
+    CLUB_MEMBER_NOT_FOUND(HttpStatus.FORBIDDEN, "CLUB_MEMBER403", "해당 클럽의 회원이 아닙니다."),
     CLUB_STAFF_ONLY(HttpStatus.FORBIDDEN, "CLUB_STAFF403", "독서클럽 운영진만 접근할 수 있습니다."),
 
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404", "독서모임을 찾을 수 없습니다."),

--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -24,7 +24,10 @@ public enum ErrorStatus implements BaseErrorCode {
     CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB404", "독서클럽을 찾을 수 없습니다."),
 
     CLUB_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB_MEMBER404", "해당 클럽의 회원이 아닙니다."),
-    CLUB_STAFF_ONLY(HttpStatus.FORBIDDEN, "CLUB_STAFF403", "독서클럽 운영진만 접근할 수 있습니다.");
+    CLUB_STAFF_ONLY(HttpStatus.FORBIDDEN, "CLUB_STAFF403", "독서클럽 운영진만 접근할 수 있습니다."),
+
+    MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING404", "독서모임을 찾을 수 없습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/checkmo/config/WebConfig.java
+++ b/src/main/java/checkmo/config/WebConfig.java
@@ -1,3 +1,4 @@
+/*
 package checkmo.config;
 
 import checkmo.global.auth.CurrentMemberArgumentResolver;
@@ -19,3 +20,4 @@ public class WebConfig implements WebMvcConfigurer {
         resolvers.add(currentMemberArgumentResolver);
     }
 }
+ */

--- a/src/main/java/checkmo/domain/club/converter/ClubConverter.java
+++ b/src/main/java/checkmo/domain/club/converter/ClubConverter.java
@@ -1,8 +1,56 @@
 package checkmo.domain.club.converter;
 
+import checkmo.domain.club.entity.announcement.Notice;
+import checkmo.domain.club.entity.meeting.Meeting;
+import checkmo.domain.club.web.dto.meeting.MeetingRequestDTO;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ClubConverter {
+
+    // =====================================================
+    // ClubResponseDTO → ClubSharedDTO 변환
+    // =====================================================
+
+    // =====================================================
+    // Entity ↔ DTO 변환
+    // =====================================================
+
+    /**
+     * MeetingCreateRequestDTO -> Meeting 엔티티 변환
+     */
+    public static Meeting fromMeetingCreateRequestDTOToMeeting(
+            MeetingRequestDTO.MeetingCreateRequestDTO request
+    ) {
+        return Meeting.builder()
+                .title(request.getTitle())
+                .meetingTime(request.getMeetingTime())
+                .location(request.getLocation())
+                .content(request.getContent())
+                .generation(request.getGeneration())
+                .tag(request.getTag())
+                .build();
+    }
+
+    // =====================================================
+    // 기타 메서드
+    // =====================================================
+
+    /**
+     * Meeting 엔티티로부터 Notice 엔티티 변환(자동 생성)
+     */
+    public static Notice fromMeetingToNotice(Meeting meeting) {
+        return Notice.builder()
+                .title(meeting.getTitle())
+                .content(meeting.getContent())
+                .important(true)
+                .tag("모임")
+                .build();
+    }
+
+    // =====================================================
+    // Private Methods
+    // =====================================================
+
 }

--- a/src/main/java/checkmo/domain/club/converter/ClubConverter.java
+++ b/src/main/java/checkmo/domain/club/converter/ClubConverter.java
@@ -1,5 +1,6 @@
 package checkmo.domain.club.converter;
 
+import checkmo.domain.book.entity.Book;
 import checkmo.domain.club.entity.announcement.Notice;
 import checkmo.domain.club.entity.meeting.Meeting;
 import checkmo.domain.club.web.dto.meeting.MeetingRequestDTO;
@@ -21,7 +22,8 @@ public class ClubConverter {
      * MeetingCreateRequestDTO -> Meeting 엔티티 변환
      */
     public static Meeting fromMeetingCreateRequestDTOToMeeting(
-            MeetingRequestDTO.MeetingCreateRequestDTO request
+            MeetingRequestDTO.MeetingCreateRequestDTO request,
+            Book proxyBook
     ) {
         return Meeting.builder()
                 .title(request.getTitle())
@@ -30,6 +32,7 @@ public class ClubConverter {
                 .content(request.getContent())
                 .generation(request.getGeneration())
                 .tag(request.getTag())
+                .book(proxyBook)
                 .build();
     }
 

--- a/src/main/java/checkmo/domain/club/entity/Club.java
+++ b/src/main/java/checkmo/domain/club/entity/Club.java
@@ -55,4 +55,9 @@ public class Club extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "club", cascade = CascadeType.ALL)
     private List<Vote> votes = new ArrayList<>();
+
+    public void addMeeting(Meeting meeting) {
+        this.meetings.add(meeting);
+        meeting.setClub(this);
+    }
 }

--- a/src/main/java/checkmo/domain/club/entity/ClubMember.java
+++ b/src/main/java/checkmo/domain/club/entity/ClubMember.java
@@ -17,43 +17,38 @@ import java.util.List;
 @Entity
 public class ClubMember extends BaseEntity {
 
-    public enum ClubMemberStatus {
-        MEMBER, STAFF, PENDING, BLOCKED
-    }
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ClubMemberStatus clubMemberStatus;
-
     private String joinMessage;
-
     @Column(name = "club_id", insertable = false, updatable = false)
     private Long clubId;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id")
     private Club club;
-
     @Column(name = "member_id", insertable = false, updatable = false)
     private String memberId;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
-
     @Builder.Default
     @OneToMany(mappedBy = "clubMember", cascade = CascadeType.ALL)
     private List<BookReview> bookReviews = new ArrayList<>();
-
     @Builder.Default
     @OneToMany(mappedBy = "clubMember", cascade = CascadeType.ALL)
     private List<BookRecommend> bookRecommends = new ArrayList<>();
-
     @Builder.Default
     @OneToMany(mappedBy = "clubMember", cascade = CascadeType.ALL)
     private List<MemberTeam> memberTeams = new ArrayList<>();
+
+    public boolean isStaff() {
+        return this.clubMemberStatus == ClubMemberStatus.STAFF;
+    }
+
+    public enum ClubMemberStatus {
+        MEMBER, STAFF, PENDING, BLOCKED
+    }
 }

--- a/src/main/java/checkmo/domain/club/entity/announcement/Notice.java
+++ b/src/main/java/checkmo/domain/club/entity/announcement/Notice.java
@@ -29,5 +29,7 @@ public class Notice extends BaseEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_id")
+    @Setter
     private Meeting meeting;
+    
 }

--- a/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
+++ b/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
@@ -59,7 +59,7 @@ public class Meeting extends BaseEntity {
     @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)
     private List<Team> teams = new ArrayList<>();
 
-    @OneToOne(mappedBy = "meeting", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private Notice notice;
 
     @Builder.Default
@@ -99,6 +99,18 @@ public class Meeting extends BaseEntity {
     public void addNotice(Notice notice) {
         this.notice = notice;
         notice.setMeeting(this); // 주인 쪽에도 세팅
+    }
+
+    public void replaceNotice(Notice newNotice) {
+        // 기존 Notice 연결 끊기 (orphanRemoval = true면 자동 삭제됨)
+        if (this.notice != null) {
+            this.notice.setMeeting(null);
+        }
+
+        this.notice = newNotice;
+        if (newNotice != null) {
+            newNotice.setMeeting(this);
+        }
     }
 
 }

--- a/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
+++ b/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
@@ -1,7 +1,7 @@
 package checkmo.domain.club.entity.meeting;
 
 import checkmo.domain.book.entity.Book;
-import checkmo.domain.club.entity.*;
+import checkmo.domain.club.entity.Club;
 import checkmo.domain.club.entity.announcement.Notice;
 import checkmo.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -43,6 +43,7 @@ public class Meeting extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id")
+    @Setter
     private Club club;
 
     @Column(name = "book_id", insertable = false, updatable = false)
@@ -50,6 +51,7 @@ public class Meeting extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id")
+    @Setter
     private Book book; // null 허용
 
     @Builder.Default
@@ -82,4 +84,10 @@ public class Meeting extends BaseEntity {
             this.sumRate /= this.bookReviews.size();
         }
     }
+
+    public void addNotice(Notice notice) {
+        this.notice = notice;
+        notice.setMeeting(this); // 주인 쪽에도 세팅
+    }
+
 }

--- a/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
+++ b/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
@@ -86,6 +86,16 @@ public class Meeting extends BaseEntity {
         }
     }
 
+    public void updateMeeting(String title, LocalDateTime meetingTime,
+                              String location, String content, int generation, String tag) {
+        this.title = title;
+        this.meetingTime = meetingTime;
+        this.location = location;
+        this.content = content;
+        this.generation = generation;
+        this.tag = tag;
+    }
+
     public void addNotice(Notice notice) {
         this.notice = notice;
         notice.setMeeting(this); // 주인 쪽에도 세팅

--- a/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
+++ b/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
@@ -36,7 +36,8 @@ public class Meeting extends BaseEntity {
 
     private String tag;
 
-    private double sumRate; //미팅에 대한 평점 총합이 아닌, 모임이 진행된 책에 대한 평점 총합
+    @Builder.Default
+    private double sumRate = 0; //미팅에 대한 평점 총합이 아닌, 모임이 진행된 책에 대한 평점 총합
 
     @Column(name = "club_id", insertable = false, updatable = false)
     private Long clubId;

--- a/src/main/java/checkmo/domain/club/facade/ClubCommandFacade.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubCommandFacade.java
@@ -151,7 +151,7 @@ public interface ClubCommandFacade {
      * @param request  미팅 생성 요청 DTO
      * @return 생성된 미팅의 상세 정보 DTO
      */
-    MeetingResponseDTO.InProgressMeetingDetailDTO createMeeting(Long clubId, String memberId, MeetingRequestDTO.MeetingCreateRequestDTO request);
+    Long createMeeting(Long clubId, String memberId, MeetingRequestDTO.MeetingCreateRequestDTO request);
 
     /**
      * ClubMeetingCommandService

--- a/src/main/java/checkmo/domain/club/facade/ClubCommandFacade.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubCommandFacade.java
@@ -162,7 +162,7 @@ public interface ClubCommandFacade {
      * @param request   미팅 수정 요청 DTO
      * @return 수정된 미팅의 상세 정보 DTO
      */
-    MeetingResponseDTO.InProgressMeetingDetailDTO updateMeeting(Long meetingId, String memberId, MeetingRequestDTO.MeetingUpdateRequestDTO request);
+    Long updateMeeting(Long meetingId, String memberId, MeetingRequestDTO.MeetingUpdateRequestDTO request);
 
     /**
      * ClubMeetingCommandService

--- a/src/main/java/checkmo/domain/club/facade/ClubCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubCommandFacadeImpl.java
@@ -1,0 +1,128 @@
+package checkmo.domain.club.facade;
+
+import checkmo.domain.club.service.command.ClubMeetingCommandService;
+import checkmo.domain.club.web.dto.bookshelf.BookShelfRequestDTO;
+import checkmo.domain.club.web.dto.club.ClubRequestDTO;
+import checkmo.domain.club.web.dto.club.ClubResponseDTO;
+import checkmo.domain.club.web.dto.meeting.MeetingRequestDTO;
+import checkmo.domain.club.web.dto.meeting.MeetingResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ClubCommandFacadeImpl implements ClubCommandFacade {
+    private final ClubMeetingCommandService clubMeetingCommandService;
+
+    @Override
+    public ClubResponseDTO.ClubDetailDTO createClub(String memberId, ClubRequestDTO.ClubDetailDTO request) {
+        return null;
+    }
+
+    @Override
+    public ClubResponseDTO.ClubDetailDTO updateClub(Long clubId, String memberId, ClubRequestDTO.ClubDetailDTO request) {
+        return null;
+    }
+
+    @Override
+    public ClubResponseDTO.ClubInfoDTO joinClub(Long clubId, String memberId, ClubRequestDTO.ClubMemberJoinDTO request) {
+        return null;
+    }
+
+    @Override
+    public void approveJoinRequest(Long clubId, String memberId, Long clubMemberId) {
+
+    }
+
+    @Override
+    public ClubResponseDTO.ClubNoticeDetailDTO createNotice(Long clubId, String memberId, ClubRequestDTO.CreateClubNoticeDTO request) {
+        return null;
+    }
+
+    @Override
+    public void deleteNotice(Long clubId, String memberId, Long noticeId) {
+
+    }
+
+    @Override
+    public ClubResponseDTO.ClubNoticeDetailDTO createVote(Long clubId, String memberId, ClubRequestDTO.CreateClubVoteDTO request) {
+        return null;
+    }
+
+    @Override
+    public void deleteVote(Long clubId, String memberId, Long voteId) {
+
+    }
+
+    @Override
+    public ClubResponseDTO.ClubNoticeDetailDTO participateInPoll(Long clubId, String memberId, Long voteId, ClubRequestDTO.VoteResultDTO request) {
+        return null;
+    }
+
+    @Override
+    public ClubResponseDTO.BookRecommendDetailDTO recommendBook(Long clubId, String memberId, ClubRequestDTO.CreateBookRecommendDTO request) {
+        return null;
+    }
+
+    @Override
+    public ClubResponseDTO.BookRecommendDetailDTO updateBookRecommend(Long clubId, String memberId, Long bookRecommendId, ClubRequestDTO.UpdateBookRecommendDTO request) {
+        return null;
+    }
+
+    @Override
+    public void deleteRecommendedBook(Long clubId, String memberId, Long bookRecommendId) {
+
+    }
+
+    @Override
+    public Long createMeeting(Long clubId, String memberId, MeetingRequestDTO.MeetingCreateRequestDTO request) {
+        return clubMeetingCommandService.createMeeting(clubId, memberId, request);
+    }
+
+    @Override
+    public MeetingResponseDTO.InProgressMeetingDetailDTO updateMeeting(Long meetingId, String memberId, MeetingRequestDTO.MeetingUpdateRequestDTO request) {
+        return null;
+    }
+
+    @Override
+    public MeetingResponseDTO.TopicDTO createTopic(Long memberId, Long meetingId, MeetingRequestDTO.TopicDTO request) {
+        return null;
+    }
+
+    @Override
+    public MeetingResponseDTO.TopicDTO updateTopic(String memberId, Long meetingId, Long topicId, MeetingRequestDTO.TopicDTO request) {
+        return null;
+    }
+
+    @Override
+    public void deleteTopic(String memberId, Long meetingId, Long topicId) {
+
+    }
+
+    @Override
+    public void toggleTopic(String memberId, Long meetingId, MeetingRequestDTO.TopicManageDTO request) {
+
+    }
+
+    @Override
+    public void manageTeam(String memberId, Long meetingId, MeetingRequestDTO.TeamManageDTO request) {
+
+    }
+
+    @Override
+    public Long createBookReview(String memberId, Long meetingId, BookShelfRequestDTO.BookReviewDTO request) {
+        return 0L;
+    }
+
+    @Override
+    public Long updateBookReview(String memberId, Long meetingId, Long reviewId, BookShelfRequestDTO.BookReviewDTO request) {
+        return 0L;
+    }
+
+    @Override
+    public void deleteBookReview(String memberId, Long meetingId, Long reviewId) {
+
+    }
+}

--- a/src/main/java/checkmo/domain/club/facade/ClubCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubCommandFacadeImpl.java
@@ -82,8 +82,8 @@ public class ClubCommandFacadeImpl implements ClubCommandFacade {
     }
 
     @Override
-    public MeetingResponseDTO.InProgressMeetingDetailDTO updateMeeting(Long meetingId, String memberId, MeetingRequestDTO.MeetingUpdateRequestDTO request) {
-        return null;
+    public Long updateMeeting(Long meetingId, String memberId, MeetingRequestDTO.MeetingUpdateRequestDTO request) {
+        return clubMeetingCommandService.updateMeeting(meetingId, memberId, request);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
@@ -3,8 +3,8 @@ package checkmo.domain.club.repository;
 import checkmo.domain.club.entity.ClubMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
-    boolean existsByClubIdAndMemberId(Long clubId, String memberId);
+import java.util.Optional;
 
-    boolean existsByClubIdAndMemberIdAndClubMemberStatus(Long clubId, String memberId, ClubMember.ClubMemberStatus clubMemberStatus);
+public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
+    Optional<ClubMember> findByClubIdAndMemberId(Long clubId, String memberId);
 }

--- a/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandService.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandService.java
@@ -21,7 +21,7 @@ public interface ClubMeetingCommandService {
      *
      * ‼️ 내부에서 공지사항 자동으로 연결해서 생성해주는 로직 반드시 필요
      */
-     Long createMeeting(Long clubId, String memberId, MeetingRequestDTO.MeetingCreateRequestDTO request);
+    Long createMeeting(Long clubId, String memberId, MeetingRequestDTO.MeetingCreateRequestDTO request);
 
     /**
      * 독서모임의 미팅을 수정합니다.
@@ -65,6 +65,7 @@ public interface ClubMeetingCommandService {
      * 독서모임의 특정 팀이 발제를 수정합니다.
      *
      * 피그마 참고 페이지: #독서모임(사용자) - 책장 [특정 책]에서 [발제]추 시
+     *
      * @param memberId 발제 작성자의 ID -> 발제 작성자인지 확인하는 용도
      * @param meetingId 미팅 ID -> 미팅 ID만 알아도 어느 Club인지 알 수 있기 때문에 ClubId는 필요 없음
      * @param topicId 발제 ID

--- a/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
@@ -1,0 +1,119 @@
+package checkmo.domain.club.service.command;
+
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.book.entity.Book;
+import checkmo.domain.book.facade.BookCommandFacade;
+import checkmo.domain.book.facade.BookQueryFacade;
+import checkmo.domain.club.converter.ClubConverter;
+import checkmo.domain.club.entity.Club;
+import checkmo.domain.club.entity.ClubMember;
+import checkmo.domain.club.entity.announcement.Notice;
+import checkmo.domain.club.entity.meeting.Meeting;
+import checkmo.domain.club.repository.meeting.MeetingRepository;
+import checkmo.domain.club.service.query.ClubMemberQueryService;
+import checkmo.domain.club.service.query.ClubQueryService;
+import checkmo.domain.club.web.dto.bookshelf.BookShelfRequestDTO;
+import checkmo.domain.club.web.dto.club.ClubRequestDTO;
+import checkmo.domain.club.web.dto.meeting.MeetingRequestDTO;
+import checkmo.global.dto.BookSharedDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ClubMeetingCommandServiceImpl implements ClubMeetingCommandService {
+    private final BookCommandFacade bookCommandFacade;
+    private final BookQueryFacade bookQueryFacade;
+    private final ClubMemberQueryService clubMemberQueryService;
+    private final ClubQueryService clubQueryService;
+    private final ClubCommunicationCommandService clubCommunicationCommandService;
+    private final MeetingRepository meetingRepository;
+
+    @Override
+    public Long createMeeting(Long clubId, String memberId, MeetingRequestDTO.MeetingCreateRequestDTO request) {
+        // 1. 검증
+        Club club = clubQueryService.validateClub(clubId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
+        if (!clubMember.isStaff()) {
+            throw new GeneralException(ErrorStatus.CLUB_STAFF_ONLY);
+        }
+
+        // 2. 책 저장 후 프록시 가져오기
+        ClubRequestDTO.BookDetailDTO bookDetail = request.getBookDetail();
+        bookCommandFacade.saveBook(
+                BookSharedDTO.BookCreateRequestDTO.builder()
+                        .isbn(bookDetail.getIsbn())
+                        .title(bookDetail.getTitle())
+                        .author(bookDetail.getAuthor())
+                        .imgUrl(bookDetail.getImgUrl())
+                        .publisher(bookDetail.getPublisher())
+                        .description(bookDetail.getDescription())
+                        .build()
+        );
+        Book proxyBook = bookQueryFacade.findBookReferenceById(bookDetail.getIsbn());
+
+        // 3. 미팅 생성 후 Book 연결
+        Meeting meeting = ClubConverter.fromMeetingCreateRequestDTOToMeeting(request);
+        meeting.setBook(proxyBook);
+
+        // 4. 공지 생성
+        Notice notice = ClubConverter.fromMeetingToNotice(meeting);
+
+        // 5. 연관관계 설정
+        club.addMeeting(meeting);
+        meeting.addNotice(notice);
+
+        // 6. 명시적 저장
+        meetingRepository.save(meeting);
+
+        return meeting.getId();
+    }
+
+    @Override
+    public Long updateMeeting(Long meetingId, String memberId, MeetingRequestDTO.MeetingUpdateRequestDTO request) {
+        return 0L;
+    }
+
+    @Override
+    public Long createTopic(Long memberId, Long meetingId, MeetingRequestDTO.TopicDTO request) {
+        return 0L;
+    }
+
+    @Override
+    public Long toggleTopic(String memberId, Long meetingId, MeetingRequestDTO.TopicManageDTO request) {
+        return 0L;
+    }
+
+    @Override
+    public Long updateTopic(String memberId, Long meetingId, Long topicId, MeetingRequestDTO.TopicDTO request) {
+        return 0L;
+    }
+
+    @Override
+    public void deleteTopic(String memberId, Long meetingId, Long topicId) {
+
+    }
+
+    @Override
+    public Long manageTeam(String memberId, Long meetingId, MeetingRequestDTO.TeamManageDTO request) {
+        return 0L;
+    }
+
+    @Override
+    public Long createBookReview(String memberId, Long meetingId, BookShelfRequestDTO.BookReviewDTO request) {
+        return 0L;
+    }
+
+    @Override
+    public Long updateBookReview(String memberId, Long meetingId, Long reviewId, BookShelfRequestDTO.BookReviewDTO request) {
+        return 0L;
+    }
+
+    @Override
+    public void deleteBookReview(String memberId, Long meetingId, Long reviewId) {
+
+    }
+}

--- a/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
@@ -11,6 +11,7 @@ import checkmo.domain.club.entity.ClubMember;
 import checkmo.domain.club.entity.announcement.Notice;
 import checkmo.domain.club.entity.meeting.Meeting;
 import checkmo.domain.club.repository.meeting.MeetingRepository;
+import checkmo.domain.club.service.query.ClubMeetingQueryService;
 import checkmo.domain.club.service.query.ClubMemberQueryService;
 import checkmo.domain.club.service.query.ClubQueryService;
 import checkmo.domain.club.web.dto.bookshelf.BookShelfRequestDTO;
@@ -29,7 +30,7 @@ public class ClubMeetingCommandServiceImpl implements ClubMeetingCommandService 
     private final BookQueryFacade bookQueryFacade;
     private final ClubMemberQueryService clubMemberQueryService;
     private final ClubQueryService clubQueryService;
-    private final ClubCommunicationCommandService clubCommunicationCommandService;
+    private final ClubMeetingQueryService clubMeetingQueryService;
     private final MeetingRepository meetingRepository;
 
     @Override
@@ -74,7 +75,27 @@ public class ClubMeetingCommandServiceImpl implements ClubMeetingCommandService 
 
     @Override
     public Long updateMeeting(Long meetingId, String memberId, MeetingRequestDTO.MeetingUpdateRequestDTO request) {
-        return 0L;
+        Meeting meeting = clubMeetingQueryService.validateMeeting(meetingId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
+        if (!clubMember.isStaff()) {
+            throw new GeneralException(ErrorStatus.CLUB_STAFF_ONLY);
+        }
+
+        meeting.updateMeeting(
+                request.getTitle(),
+                request.getMeetingTime(),
+                request.getLocation(),
+                request.getContent(),
+                request.getGeneration(),
+                request.getTag()
+        );
+
+        Notice newNotice = ClubConverter.fromMeetingToNotice(meeting);
+        meeting.replaceNotice(newNotice);
+
+        meetingRepository.save(meeting);
+
+        return meeting.getId();
     }
 
     @Override

--- a/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
@@ -15,9 +15,7 @@ import checkmo.domain.club.service.query.ClubMeetingQueryService;
 import checkmo.domain.club.service.query.ClubMemberQueryService;
 import checkmo.domain.club.service.query.ClubQueryService;
 import checkmo.domain.club.web.dto.bookshelf.BookShelfRequestDTO;
-import checkmo.domain.club.web.dto.club.ClubRequestDTO;
 import checkmo.domain.club.web.dto.meeting.MeetingRequestDTO;
-import checkmo.global.dto.BookSharedDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,18 +41,8 @@ public class ClubMeetingCommandServiceImpl implements ClubMeetingCommandService 
         }
 
         // 2. 책 저장 후 프록시 가져오기
-        ClubRequestDTO.BookDetailDTO bookDetail = request.getBookDetail();
-        bookCommandFacade.saveBook(
-                BookSharedDTO.BookCreateRequestDTO.builder()
-                        .isbn(bookDetail.getIsbn())
-                        .title(bookDetail.getTitle())
-                        .author(bookDetail.getAuthor())
-                        .imgUrl(bookDetail.getImgUrl())
-                        .publisher(bookDetail.getPublisher())
-                        .description(bookDetail.getDescription())
-                        .build()
-        );
-        Book proxyBook = bookQueryFacade.findBookReferenceById(bookDetail.getIsbn());
+        bookCommandFacade.saveBook(request.getBookInfo());
+        Book proxyBook = bookQueryFacade.findBookReferenceById(request.getBookInfo().getIsbn());
 
         // 3. 미팅 생성 후 Book 연결
         Meeting meeting = ClubConverter.fromMeetingCreateRequestDTOToMeeting(request);

--- a/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
@@ -44,9 +44,8 @@ public class ClubMeetingCommandServiceImpl implements ClubMeetingCommandService 
         bookCommandFacade.saveBook(request.getBookInfo());
         Book proxyBook = bookQueryFacade.findBookReferenceById(request.getBookInfo().getIsbn());
 
-        // 3. 미팅 생성 후 Book 연결
-        Meeting meeting = ClubConverter.fromMeetingCreateRequestDTOToMeeting(request);
-        meeting.setBook(proxyBook);
+        // 3. 미팅 생성 후 proxyBook 연결
+        Meeting meeting = ClubConverter.fromMeetingCreateRequestDTOToMeeting(request, proxyBook);
 
         // 4. 공지 생성
         Notice notice = ClubConverter.fromMeetingToNotice(meeting);

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryService.java
@@ -1,5 +1,7 @@
 package checkmo.domain.club.service.query;
 
+import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.club.entity.meeting.Meeting;
 import checkmo.domain.club.web.dto.meeting.MeetingResponseDTO;
 
 /**
@@ -51,4 +53,13 @@ public interface ClubMeetingQueryService {
      * @return 조회한 팀 정보 DTO
      */
     MeetingResponseDTO.TeamDTO findTeamsByMeeting(Long meetingId, Integer teamNumber);
+
+    /**
+     * 독서모임이 존재하는지 확인합니다.
+     *
+     * @param meetingId 미팅 ID
+     * @return Meeting 존재하는 미팅 객체
+     * @throws GeneralException 미팅이 존재하지 않을 경우
+     */
+    Meeting validateMeeting(Long meetingId) throws GeneralException;
 }

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
@@ -1,0 +1,43 @@
+package checkmo.domain.club.service.query;
+
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.club.entity.meeting.Meeting;
+import checkmo.domain.club.repository.meeting.MeetingRepository;
+import checkmo.domain.club.web.dto.meeting.MeetingResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
+    private final MeetingRepository meetingRepository;
+
+    @Override
+    public MeetingResponseDTO.InProgressMeetingDetailDTO findMeetingById(Long meetingId) {
+        return null;
+    }
+
+    @Override
+    public MeetingResponseDTO.MeetingListDTO findAllMeetingsByClub(Long clubId, Long cursorId) {
+        return null;
+    }
+
+    @Override
+    public MeetingResponseDTO.TopicListDTO findTopicsByMeeting(Long meetingId, Long cursorId) {
+        return null;
+    }
+
+    @Override
+    public MeetingResponseDTO.TeamDTO findTeamsByMeeting(Long meetingId, Integer teamNumber) {
+        return null;
+    }
+
+    @Override
+    public Meeting validateMeeting(Long meetingId) throws GeneralException {
+        return meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEETING_NOT_FOUND));
+    }
+}

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryService.java
@@ -1,5 +1,8 @@
 package checkmo.domain.club.service.query;
 
+import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.club.entity.ClubMember;
+
 /**
  * 독서클럽 회원에 대한 조회 서비스
  * <p>
@@ -12,17 +15,9 @@ public interface ClubMemberQueryService {
      *
      * @param clubId   독서동아리 id
      * @param memberId 회원 id
-     * @return true: 독서동아리 회원, false: 회원 아님
+     * @return ClubMember 객체
+     * @throws GeneralException 클럽 회원이 존재하지 않을 경우
      */
-    boolean isClubMember(Long clubId, String memberId);
-
-    /**
-     * 독서클럽의 특정 회원이 운영진(STAFF)인지 확인합니다.(권한 확인용)
-     *
-     * @param clubId
-     * @param memberId
-     * @return true: 운영진, false: 운영진 아님
-     */
-    boolean isClubStaff(Long clubId, String memberId);
+    ClubMember validateClubMember(Long clubId, String memberId) throws GeneralException;
 
 }

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
@@ -14,11 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClubMemberQueryServiceImpl implements ClubMemberQueryService {
 
     private final ClubMemberRepository clubMemberRepository;
-    
+
     @Override
     public ClubMember validateClubMember(Long clubId, String memberId) throws GeneralException {
         return clubMemberRepository.findByClubIdAndMemberId(clubId, memberId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.CLUB_MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CLUB_MEMBER_ONLY));
     }
 
 }

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package checkmo.domain.club.service.query;
 
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.club.entity.ClubMember;
 import checkmo.domain.club.repository.ClubMemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,15 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClubMemberQueryServiceImpl implements ClubMemberQueryService {
 
     private final ClubMemberRepository clubMemberRepository;
-
+    
     @Override
-    public boolean isClubMember(Long clubId, String memberId) {
-        return clubMemberRepository.existsByClubIdAndMemberId(clubId, memberId);
-    }
-
-    @Override
-    public boolean isClubStaff(Long clubId, String memberId) {
-        return clubMemberRepository.existsByClubIdAndMemberIdAndClubMemberStatus(clubId, memberId, ClubMember.ClubMemberStatus.STAFF);
+    public ClubMember validateClubMember(Long clubId, String memberId) throws GeneralException {
+        return clubMemberRepository.findByClubIdAndMemberId(clubId, memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CLUB_MEMBER_NOT_FOUND));
     }
 
 }

--- a/src/main/java/checkmo/domain/club/service/query/ClubQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubQueryService.java
@@ -108,4 +108,13 @@ public interface ClubQueryService {
      * @param noticeId 공지사항 ID
      */
     ClubResponseDTO.ClubNoticeDetailDTO getNoticeDetail(Long clubId, Long noticeId);
+
+    /**
+     * 독서 클럽이 존재하는지 검증합니다.
+     *
+     * @param clubId 독서 클럽 ID
+     * @return Club 검증된 독서 클럽 객체
+     * @throws GeneralException 클럽이 존재하지 않는 경우
+     */
+    Club validateClub(Long clubId) throws GeneralException;
 }

--- a/src/main/java/checkmo/domain/club/service/query/ClubQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubQueryService.java
@@ -1,5 +1,7 @@
 package checkmo.domain.club.service.query;
 
+import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.club.entity.Club;
 import checkmo.domain.club.web.dto.club.ClubResponseDTO;
 
 /**
@@ -26,6 +28,7 @@ public interface ClubQueryService {
      * 내가 가입한 독서 클럽 목록을 전체 조회합니다.
      *
      * 피그마 참고 페이지 : #독서모임 - 내 모임 바로가기
+     *
      * @param memberId 회원 ID -> 로그인한 회원의 ID를 사용
      * @return 내가 가입한 독서 클럽 목록 DTO
      */
@@ -35,6 +38,7 @@ public interface ClubQueryService {
      * 내가 가입한 독서 클럽 목록을 size 개수만큼 조회합니다.
      *
      * 피그마 참고 페이지 : #독서모임 - 내 모임 바로가기
+     *
      * @param memberId 회원 ID -> 로그인한 회원의 ID를 사용
      * @param size 조회할 개수
      * @return 내가 가입한 독서 클럽 목록 DTO

--- a/src/main/java/checkmo/domain/club/service/query/ClubQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubQueryServiceImpl.java
@@ -1,0 +1,68 @@
+package checkmo.domain.club.service.query;
+
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.club.entity.Club;
+import checkmo.domain.club.repository.ClubRepository;
+import checkmo.domain.club.web.dto.club.ClubResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ClubQueryServiceImpl implements ClubQueryService {
+    private final ClubRepository clubRepository;
+
+    @Override
+    public ClubResponseDTO.ClubListDTO getClubList(String keyword, int region, int participants, Long cursorId) {
+        return null;
+    }
+
+    @Override
+    public ClubResponseDTO.MyClubListDTO getMyClubList(String memberId) {
+        return null;
+    }
+
+    @Override
+    public ClubResponseDTO.MyClubListDTO getMyClubList(String memberId, int size) {
+        return null;
+    }
+
+    @Override
+    public ClubResponseDTO.ClubMemberListDTO getClubMemberListByStatus(Long clubId, String memberId, String clubMemberStatus, Long cursorId) {
+        return null;
+    }
+
+    @Override
+    public ClubResponseDTO.ClubDetailDTO getClubInfo(Long clubId, String memberId) {
+        return null;
+    }
+
+    @Override
+    public boolean isDuplicateClubName(String clubName) {
+        return false;
+    }
+
+    @Override
+    public ClubResponseDTO.ClubNoticeListDTO getLatestNotices(Long clubId, String memberId, int size) {
+        return null;
+    }
+
+    @Override
+    public ClubResponseDTO.ClubNoticeListDTO getLatestNotices(Long clubId, String memberId, Long cursorId) {
+        return null;
+    }
+
+    @Override
+    public ClubResponseDTO.ClubNoticeDetailDTO getNoticeDetail(Long clubId, Long noticeId) {
+        return null;
+    }
+
+    @Override
+    public Club validateClub(Long clubId) throws GeneralException {
+        return clubRepository.findById(clubId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.CLUB_NOT_FOUND));
+    }
+}

--- a/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
@@ -27,8 +27,8 @@ public class ClubMeetingController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "독서클럽 운영진만 접근할 수 있습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 클럽의 회원이 아닙니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "독서클럽을 찾을 수 없습니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 클럽의 회원이 아닙니다."),
     })
     @PostMapping("/api/clubs/{clubId}/meetings")
     public ApiResponse<Long> createMeeting(
@@ -47,7 +47,7 @@ public class ClubMeetingController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "독서클럽 운영진만 접근할 수 있습니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 클럽의 회원이 아닙니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 클럽의 회원이 아닙니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 정기 독서모임을 찾을 수 없습니다."),
     })
     @PatchMapping("/api/meetings/{meetingId}")

--- a/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
@@ -1,9 +1,16 @@
 package checkmo.domain.club.web.controller;
 
+import checkmo.apiPayload.ApiResponse;
+import checkmo.domain.club.facade.ClubCommandFacade;
+import checkmo.domain.club.web.dto.meeting.MeetingRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping()
@@ -11,8 +18,28 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "모임 토론", description = "독서 모임 미팅, 발제, 토론조 관리 API")
 public class ClubMeetingController {
 
-    // 미팅 관리
-    // POST /api/clubs/{clubId}/meetings - Meeting 생성
+    private final ClubCommandFacade clubCommandFacade;
+
+    @Operation(summary = "정기 독서모임 생성 API", description = "정기 독서모임을 생성합니다.")
+    @Parameters({
+            @Parameter(name = "clubId", description = "정기 독서 모임을 생성할 독서클럽 ID", required = true, example = "1"),
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "독서클럽 운영진만 접근할 수 있습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "독서클럽을 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 클럽의 회원이 아닙니다."),
+    })
+    @PostMapping("/api/clubs/{clubId}/meetings")
+    public ApiResponse<Long> createMeeting(
+            @PathVariable Long clubId,
+            @RequestBody @Valid MeetingRequestDTO.MeetingCreateRequestDTO request,
+            @RequestParam String memberId // TODO: @CurrentId로 추후 변경 예정
+    ) {
+        Long meetingId = clubCommandFacade.createMeeting(clubId, memberId, request);
+        return ApiResponse.onSuccess(meetingId);
+    }
+
     // GET /api/clubs/{clubId}/meetings - Meeting 전체 보기
     // GET /api/meetings/{meetingId} - Meeting 상세 보기
 

--- a/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
@@ -40,6 +40,26 @@ public class ClubMeetingController {
         return ApiResponse.onSuccess(meetingId);
     }
 
+    @Operation(summary = "정기 독서모임 수정 API", description = "정기 독서모임을 수정합니다.")
+    @Parameters({
+            @Parameter(name = "meetingId", description = "수정할 정기 독서 모임 ID", required = true, example = "1"),
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "독서클럽 운영진만 접근할 수 있습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 클럽의 회원이 아닙니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 정기 독서모임을 찾을 수 없습니다."),
+    })
+    @PatchMapping("/api/meetings/{meetingId}")
+    public ApiResponse<Long> updateMeeting(
+            @PathVariable Long meetingId,
+            @RequestBody @Valid MeetingRequestDTO.MeetingUpdateRequestDTO request,
+            @RequestParam String memberId // TODO: @CurrentId로 추후 변경 예정
+    ) {
+        Long updateMeetingId = clubCommandFacade.updateMeeting(meetingId, memberId, request);
+        return ApiResponse.onSuccess(updateMeetingId);
+    }
+
     // GET /api/clubs/{clubId}/meetings - Meeting 전체 보기
     // GET /api/meetings/{meetingId} - Meeting 상세 보기
 

--- a/src/main/java/checkmo/domain/club/web/dto/club/ClubRequestDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/club/ClubRequestDTO.java
@@ -1,5 +1,6 @@
 package checkmo.domain.club.web.dto.club;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -82,11 +83,17 @@ public class ClubRequestDTO {
     @Getter
     @NoArgsConstructor
     public static class BookDetailDTO {
+        @NotBlank(message = "ISBN 번호는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
         private String isbn; // ISBN 번호
+        @NotBlank(message = "책 제목은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
         private String title; // 책 제목
+        @NotBlank(message = "저자는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
         private String author; // 저자
+        @NotBlank(message = "책 이미지 URL은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
         private String imgUrl; // 책 이미지 URL
+        @NotBlank(message = "출판사는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
         private String publisher; // 출판사
+        @NotBlank(message = "책 설명은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
         private String description; // 책 설명
     }
 

--- a/src/main/java/checkmo/domain/club/web/dto/club/ClubRequestDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/club/ClubRequestDTO.java
@@ -1,6 +1,6 @@
 package checkmo.domain.club.web.dto.club;
 
-import jakarta.validation.constraints.NotBlank;
+import checkmo.global.dto.BookSharedDTO;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -74,27 +74,10 @@ public class ClubRequestDTO {
     @NoArgsConstructor
     public static class CreateBookRecommendDTO {
         private String title;
-        private BookDetailDTO bookDetail; // 책 정보
+        private BookSharedDTO.BookCreateRequestDTO bookDetail; // 책 정보
         private String content; // 추천 내용
         private double rate; // 평점
         private String tag; // 추천 태그
-    }
-
-    @Getter
-    @NoArgsConstructor
-    public static class BookDetailDTO {
-        @NotBlank(message = "ISBN 번호는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
-        private String isbn; // ISBN 번호
-        @NotBlank(message = "책 제목은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
-        private String title; // 책 제목
-        @NotBlank(message = "저자는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
-        private String author; // 저자
-        @NotBlank(message = "책 이미지 URL은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
-        private String imgUrl; // 책 이미지 URL
-        @NotBlank(message = "출판사는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
-        private String publisher; // 출판사
-        @NotBlank(message = "책 설명은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
-        private String description; // 책 설명
     }
 
     @Getter

--- a/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
@@ -16,17 +16,17 @@ public class MeetingRequestDTO {
     @Getter
     @NoArgsConstructor
     public static class MeetingCreateRequestDTO {
-        @NotBlank(message = "독서모임 제목은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        @NotBlank(message = "독서모임 제목은 필수 입력입니다.")
         private String title; // 독서모임 제목
         @NotNull(message = "미팅 날짜, 시간은 null이 될 수 없습니다.")
         private LocalDateTime meetingTime; // 미팅 날짜, 시간
-        @NotBlank(message = "독서모임 장소는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        @NotBlank(message = "독서모임 장소는 필수 입력입니다.")
         private String location; // 모임 장소
-        @NotBlank(message = "독서모임 설명은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        @NotBlank(message = "독서모임 설명은 필수 입력입니다.")
         private String content;  // 모임 내용 설명 (공지사항 내용)
         @Min(value = 1, message = "기수는 1 이상의 정수여야 합니다.")
         private int generation;  // 기수
-        @NotBlank(message = "독서모임 태그는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        @NotBlank(message = "독서모임 태그는 필수 입력입니다.")
         private String tag; // 태그
         @Valid
         @NotNull(message = "책 정보는 null이 될 수 없습니다.")
@@ -36,17 +36,17 @@ public class MeetingRequestDTO {
     @Getter
     @NoArgsConstructor
     public static class MeetingUpdateRequestDTO {
-        @NotBlank(message = "독서모임 제목은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        @NotBlank(message = "독서모임 제목은 필수 입력입니다.")
         private String title; // 독서모임 제목
         @NotNull(message = "미팅 날짜, 시간은 null이 될 수 없습니다.")
         private LocalDateTime meetingTime; // 미팅 날짜, 시간
-        @NotBlank(message = "독서모임 장소는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        @NotBlank(message = "독서모임 장소는 필수 입력입니다.")
         private String location; // 모임 장소
-        @NotBlank(message = "독서모임 설명은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        @NotBlank(message = "독서모임 설명은 필수 입력입니다.")
         private String content;  // 모임 내용 설명 (공지사항 내용)
         @Min(value = 1, message = "기수는 1 이상의 정수여야 합니다.")
         private int generation;  // 기수
-        @NotBlank(message = "독서모임 태그는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        @NotBlank(message = "독서모임 태그는 필수 입력입니다.")
         private String tag; // 태그
     }
 

--- a/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
@@ -30,7 +30,7 @@ public class MeetingRequestDTO {
         private String tag; // 태그
         @Valid
         @NotNull(message = "책 정보는 null이 될 수 없습니다.")
-        private ClubRequestDTO.BookDetailDTO bookDetail; // 책 정보
+        private BookSharedDTO.BookCreateRequestDTO bookInfo;
     }
 
     @Getter

--- a/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
@@ -35,11 +35,18 @@ public class MeetingRequestDTO {
     @Getter
     @NoArgsConstructor
     public static class MeetingUpdateRequestDTO {
-        private String title;
-        private String content; // 모임 내용 설명 (공지사항 내용)
+        @NotBlank(message = "독서모임 제목은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        private String title; // 독서모임 제목
+        @NotNull(message = "미팅 날짜, 시간은 null이 될 수 없습니다.")
         private LocalDateTime meetingTime; // 미팅 날짜, 시간
+        @NotBlank(message = "독서모임 장소는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
         private String location; // 모임 장소
-        private int generation; // 기수
+        @NotBlank(message = "독서모임 설명은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        private String content;  // 모임 내용 설명 (공지사항 내용)
+        @Min(value = 1, message = "기수는 1 이상의 정수여야 합니다.")
+        private int generation;  // 기수
+        @NotBlank(message = "독서모임 태그는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        private String tag; // 태그
     }
 
     @Getter

--- a/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
@@ -29,6 +29,7 @@ public class MeetingRequestDTO {
         @NotBlank(message = "독서모임 태그는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
         private String tag; // 태그
         @Valid
+        @NotNull(message = "책 정보는 null이 될 수 없습니다.")
         private ClubRequestDTO.BookDetailDTO bookDetail; // 책 정보
     }
 

--- a/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
@@ -1,6 +1,10 @@
 package checkmo.domain.club.web.dto.meeting;
 
 import checkmo.domain.club.web.dto.club.ClubRequestDTO;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,12 +16,20 @@ public class MeetingRequestDTO {
     @Getter
     @NoArgsConstructor
     public static class MeetingCreateRequestDTO {
-        private String title;
-        private String content;  // 모임 내용 설명 (공지사항 내용)
+        @NotBlank(message = "독서모임 제목은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        private String title; // 독서모임 제목
+        @NotNull(message = "미팅 날짜, 시간은 null이 될 수 없습니다.")
         private LocalDateTime meetingTime; // 미팅 날짜, 시간
+        @NotBlank(message = "독서모임 장소는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
         private String location; // 모임 장소
-        private ClubRequestDTO.BookDetailDTO bookDetail; // 책 정보
+        @NotBlank(message = "독서모임 설명은 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        private String content;  // 모임 내용 설명 (공지사항 내용)
+        @Min(value = 1, message = "기수는 1 이상의 정수여야 합니다.")
         private int generation;  // 기수
+        @NotBlank(message = "독서모임 태그는 null, 빈 문자열(\"\"), 공백 문자(\" \")까지도 모두 허용하지 않습니다.")
+        private String tag; // 태그
+        @Valid
+        private ClubRequestDTO.BookDetailDTO bookDetail; // 책 정보
     }
 
     @Getter

--- a/src/main/java/checkmo/global/auth/CurrentMemberArgumentResolver.java
+++ b/src/main/java/checkmo/global/auth/CurrentMemberArgumentResolver.java
@@ -1,3 +1,4 @@
+/*
 package checkmo.global.auth;
 
 import checkmo.domain.member.entity.Member;
@@ -80,3 +81,4 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
         return null;
     }
 }
+ */


### PR DESCRIPTION
## 🚀 변경사항
- 독서모임 생성/수정 API
- 앞선 #4  에서 구현한 검증 메서드를 실제로 사용하니까 boolean 값을 받고 if문으로 에러 던져주는 로직을 작성하게 되더라고요.
아무래도 해당 비즈니스 로직 자체는 변경되지 않을 것 같고, 
UI상 클럽회원 검증 실패, 운영진 검증 실패인지 구분해서 에러 메시지를 던져주는 게 좋을 것 같아서
클럽 회원/운영진 여부 검증 메서드를 변경했습니다 😂
``` 
ClubMemberQueryService{
    @Override
    public ClubMember validateClubMember(Long clubId, String memberId) throws GeneralException {
        return clubMemberRepository.findByClubIdAndMemberId(clubId, memberId)
                .orElseThrow(() -> new GeneralException(ErrorStatus.CLUB_MEMBER_NOT_FOUND));
    }
}

ClubMember{
    public boolean isStaff() {
        return this.clubMemberStatus == ClubMemberStatus.STAFF;
    }
}
```

아래처럼 사용하시면 될 것 같아요!
```
// 1. 검증
Club club = clubQueryService.validateClub(clubId);
ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
if (!clubMember.isStaff()) {
    throw new GeneralException(ErrorStatus.CLUB_STAFF_ONLY);
}
```


## 🔗 관련 이슈
- Closes #9 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->
- 명시적으로 notice를 삭제하지 않고 notice가 고아객체가 될 경우 삭제되도록 설정했습니다 괜찮나요??
````
Meeting {
  @OneToOne(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
  private Notice notice;

  public void replaceNotice(Notice newNotice) {
        // 기존 Notice 연결 끊기 (orphanRemoval = true면 자동 삭제됨)
        if (this.notice != null) {
            this.notice.setMeeting(null);
        }

        this.notice = newNotice;
        if (newNotice != null) {
            newNotice.setMeeting(this);
        }
    }
}
````
