### PR TITLE
Feat/5/email verification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     // ============= 개발 도구 =============
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -19,7 +19,11 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
-    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK404", "책을 찾을 수 없습니다.");
+    BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK404", "책을 찾을 수 없습니다."),
+
+    EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "EMAIL_401", "인증번호가 만료되었습니다."),
+    EMAIL_VERIFICATION_CODE_INVALID(HttpStatus.BAD_REQUEST, "EMAIL_402", "잘못된 인증번호입니다."),
+    EMAIL_VERIFICATION_CODE_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "EMAIL_403", "이미 인증된 이메일입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -23,7 +23,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "EMAIL_401", "인증번호가 만료되었습니다."),
     EMAIL_VERIFICATION_CODE_INVALID(HttpStatus.BAD_REQUEST, "EMAIL_402", "잘못된 인증번호입니다."),
-    EMAIL_VERIFICATION_CODE_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "EMAIL_403", "이미 인증된 이메일입니다.");
+    EMAIL_VERIFICATION_CODE_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "EMAIL_403", "이미 인증된 이메일입니다."),
+    EMAIL_VERIFICATION_CODE_ALREADY_SENT(HttpStatus.BAD_REQUEST, "EMAIL_404", "이미 인증번호가 발송되었습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/checkmo/config/MailConfig.java
+++ b/src/main/java/checkmo/config/MailConfig.java
@@ -1,0 +1,38 @@
+package checkmo.config;
+
+import checkmo.config.properties.MailProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@RequiredArgsConstructor
+public class MailConfig {
+
+    private final MailProperties mailProperties;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+
+        mailSender.setHost(mailProperties.getSmtp().getHost());
+        mailSender.setPort(mailProperties.getSmtp().getPort());
+
+        mailSender.setUsername(mailProperties.getAuth().getUsername());
+        mailSender.setPassword(mailProperties.getAuth().getPassword());
+
+        Properties props = mailSender.getJavaMailProperties();
+        props.put("mail.transport.protocol", "smtp");
+        props.put("mail.smtp.auth", mailProperties.getAuth().isEnable());
+        props.put("mail.smtp.starttls.enable", mailProperties.getSmtp().isStarttlsEnable());
+        props.put("mail.smtp.timeout", mailProperties.getSmtp().getTimeout());
+        props.put("mail.smtp.connectiontimeout", mailProperties.getSmtp().getConnectionTimeout());
+        props.put("mail.smtp.writetimeout", mailProperties.getSmtp().getWriteTimeout());
+
+        return mailSender;
+    }
+}

--- a/src/main/java/checkmo/config/RedisConfig.java
+++ b/src/main/java/checkmo/config/RedisConfig.java
@@ -32,7 +32,6 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
-        // yml 파일에서 읽어온 값으로 설정
         config.setHostName(redisProperties.getHost());
         config.setPort(redisProperties.getPort());
         config.setPassword(redisProperties.getPassword());

--- a/src/main/java/checkmo/config/RedisConfig.java
+++ b/src/main/java/checkmo/config/RedisConfig.java
@@ -2,6 +2,8 @@ package checkmo.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -9,6 +11,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
@@ -19,7 +24,21 @@ import java.util.Map;
 
 @Configuration
 @EnableCaching
+@RequiredArgsConstructor
 public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        // yml 파일에서 읽어온 값으로 설정
+        config.setHostName(redisProperties.getHost());
+        config.setPort(redisProperties.getPort());
+        config.setPassword(redisProperties.getPassword());
+        config.setDatabase(redisProperties.getDatabase());
+        return new LettuceConnectionFactory(config);
+    }
 
     // RedisTemplate을 사용하기 위한 설정
     @Bean

--- a/src/main/java/checkmo/config/SecurityConfig.java
+++ b/src/main/java/checkmo/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package checkmo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll() // Swagger UI 접근 허용
+                        .requestMatchers("/**").permitAll() // 추후 삭제 예정
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/checkmo/config/properties/MailProperties.java
+++ b/src/main/java/checkmo/config/properties/MailProperties.java
@@ -1,0 +1,62 @@
+package checkmo.config.properties;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "mail")
+public class MailProperties {
+
+    @Valid
+    private Smtp smtp = new Smtp();
+
+    @Valid
+    private Auth auth = new Auth();
+
+    @Getter
+    @Setter
+    public static class Smtp {
+
+        @NotBlank(message = "SMTP 호스트는 필수입니다")
+        private String host = "smtp.gmail.com";
+
+        @Positive(message = "포트는 양수여야 합니다")
+        @Min(value = 1, message = "포트는 1 이상이어야 합니다")
+        @Max(value = 65535, message = "포트는 65535 이하여야 합니다")
+        private int port = 587;
+
+        @Positive(message = "타임아웃은 양수여야 합니다")
+        @Min(value = 1000, message = "타임아웃은 1000ms 이상이어야 합니다")
+        private int timeout = 5000;
+
+        @Positive(message = "연결 타임아웃은 양수여야 합니다")
+        @Min(value = 1000, message = "연결 타임아웃은 1000ms 이상이어야 합니다")
+        private int connectionTimeout = 5000;
+
+        @Positive(message = "쓰기 타임아웃은 양수여야 합니다")
+        @Min(value = 1000, message = "쓰기 타임아웃은 1000ms 이상이어야 합니다")
+        private int writeTimeout = 5000;
+
+        private boolean starttlsEnable = true;
+    }
+
+    @Getter
+    @Setter
+    public static class Auth {
+
+        @NotBlank(message = "이메일 사용자명은 필수입니다")
+        @Email(message = "유효한 이메일 형식이어야 합니다")
+        private String username;
+
+        @NotBlank(message = "이메일 비밀번호는 필수입니다")
+        private String password;
+
+        private boolean enable = true;
+    }
+}

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
@@ -1,0 +1,85 @@
+package checkmo.domain.member.facade;
+
+import checkmo.domain.member.service.command.MemberRegistrationCommandService;
+import checkmo.domain.member.web.dto.MemberRequestDTO;
+import checkmo.domain.member.web.dto.MemberResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberCommandFacadeImpl implements MemberCommandFacade{
+
+    private final MemberRegistrationCommandService memberRegistrationCommandService;
+
+    @Override
+    public void sendEmailVerification(String email) {
+        memberRegistrationCommandService.sendEmailVerification(email);
+    }
+
+    @Override
+    public boolean verifyEmailCode(MemberRequestDTO.EmailVerificationRequestDTO request) {
+        return memberRegistrationCommandService.verifyEmailCode(request);
+    }
+
+    @Override
+    public MemberResponseDTO.SignUpResponseDTO signUp(MemberRequestDTO.SignUpRequestDTO request) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void addAdditionalInfo(MemberRequestDTO.AdditionalInfoDTO request) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void login(String email, String password) {
+    }
+
+    @Override
+    public void logout(String token) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void reactivateMember() {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public MemberResponseDTO.MemberProfileResponseDTO updateMemberProfile(String memberId, MemberRequestDTO.MemberProfileUpdateRequestDTO request) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void updatePassword(String memberId, MemberRequestDTO.PasswordUpdateRequestDTO request) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void deactivateMember(String memberId) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void deleteMember(String memberId) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void followMember(String memberId, String targetNickname) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void unfollowMember(String memberId, String targetNickname) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void unfollowingMember(String memberId, String targetNickname) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+}

--- a/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
@@ -29,13 +29,18 @@ public class MemberRegistrationCommandServiceImpl implements MemberRegistrationC
     @Override
     public void sendEmailVerification(String email) {
 
+        // 이미 인증번호가 Redis에 존재하면 예외 처리
+        String redisKey = EMAIL_VERIFICATION_PREFIX + email;
+        if (Boolean.TRUE.equals(redisTemplate.hasKey(redisKey))) {
+            throw new GeneralException(ErrorStatus.EMAIL_VERIFICATION_CODE_ALREADY_SENT);
+        }
+
         // TODO: 이미 회원가입이 완료된 이메일인지 확인하는 로직 추가
 
         // 6자리 랜덤 인증번호 생성
         String verificationCode = String.format("%06d", secureRandom.nextInt(1000000));
 
         // Redis에 인증번호 저장
-        String redisKey = EMAIL_VERIFICATION_PREFIX + email;
         Map<String, Object> verificationData = new HashMap<>();
         verificationData.put("code", verificationCode);
         verificationData.put("verified", false);

--- a/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
@@ -30,6 +30,9 @@ public class MemberRegistrationCommandServiceImpl implements MemberRegistrationC
 
     @Override
     public void sendEmailVerification(String email) {
+
+        // TODO: 이미 회원가입이 완료된 이메일인지 확인하는 로직 추가
+
         // 6자리 랜덤 인증번호 생성
         String verificationCode = String.format("%06d", secureRandom.nextInt(1000000));
 
@@ -57,7 +60,7 @@ public class MemberRegistrationCommandServiceImpl implements MemberRegistrationC
             message.setTo(email); // 받는 사람 이메일
             message.setSubject("책모 회원가입 인증번호"); // 이메일 제목
             message.setText("인증번호: " + verificationCode + "\n\n" +
-                            "인증번호는 5분간 유효합니다."); // 이메일 본문
+                "인증번호는 10분간 유효합니다."); // 이메일 본문
 
             // 이메일 발송
             javaMailSender.send(message);
@@ -69,7 +72,7 @@ public class MemberRegistrationCommandServiceImpl implements MemberRegistrationC
     }
 
     @Override
-    public boolean verifyEmailCode(MemberRequestDTO.EmailVerificationRequestDTO request){
+    public boolean verifyEmailCode(MemberRequestDTO.EmailVerificationRequestDTO request) {
 
         String redisKey = EMAIL_VERIFICATION_PREFIX + request.getEmail();
 

--- a/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
@@ -1,0 +1,88 @@
+package checkmo.domain.member.service.command;
+
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.member.web.dto.MemberRequestDTO;
+import checkmo.domain.member.web.dto.MemberResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberRegistrationCommandServiceImpl implements MemberRegistrationCommandService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final JavaMailSender javaMailSender;
+
+    private static final String EMAIL_VERIFICATION_PREFIX = "verification:";
+    private static final Duration EMAIL_VERIFICATION_TTL = Duration.ofMinutes(10); // 10분
+    private static final SecureRandom secureRandom = new SecureRandom();
+
+    @Override
+    public void sendEmailVerification(String email) {
+        // 6자리 랜덤 인증번호 생성
+        String verificationCode = String.format("%06d", secureRandom.nextInt(1000000));
+
+        // Redis에 인증번호 저장
+        String redisKey = EMAIL_VERIFICATION_PREFIX + email;
+        Map<String, Object> verificationData = new HashMap<>();
+        verificationData.put("code", verificationCode);
+        verificationData.put("verified", false);
+
+        redisTemplate.opsForHash().putAll(redisKey, verificationData);
+        redisTemplate.expire(redisKey, EMAIL_VERIFICATION_TTL);
+
+        // 이메일 발송 (내부 메서드로)
+        sendEmailInternal(email, verificationCode);
+
+        log.info("Verification code sent to email: {}", email);
+    }
+
+    // 이메일 발송 내부 메서드
+    @Async
+    protected void sendEmailInternal(String email, String verificationCode) {
+        try {
+            // 이메일 메시지 생성
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(email); // 받는 사람 이메일
+            message.setSubject("책모 회원가입 인증번호"); // 이메일 제목
+            message.setText("인증번호: " + verificationCode + "\n\n" +
+                            "인증번호는 5분간 유효합니다."); // 이메일 본문
+
+            // 이메일 발송
+            javaMailSender.send(message);
+            log.info("이메일 발송 성공: {}", email);
+        } catch (Exception e) {
+            log.error("이메일 발송 실패: email={}, error={}", email, e.getMessage());
+            throw new RuntimeException("Failed to send verification email", e);
+        }
+    }
+
+    @Override
+    public boolean verifyEmailCode(MemberRequestDTO.EmailVerificationRequestDTO request){
+        //TODO: 이메일 인증 확인 로직 구현
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public MemberResponseDTO.SignUpResponseDTO signUp(MemberRequestDTO.SignUpRequestDTO request) {
+        // TODO: 회원 가입 로직 구현
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void addAdditionalInfo(MemberRequestDTO.AdditionalInfoDTO request) {
+        // TODO: 회원 추가 정보 입력 로직 구현
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+}

--- a/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
@@ -70,8 +70,32 @@ public class MemberRegistrationCommandServiceImpl implements MemberRegistrationC
 
     @Override
     public boolean verifyEmailCode(MemberRequestDTO.EmailVerificationRequestDTO request){
-        //TODO: 이메일 인증 확인 로직 구현
-        throw new UnsupportedOperationException("추후 구현 예정");
+
+        String redisKey = EMAIL_VERIFICATION_PREFIX + request.getEmail();
+
+        // redis에서 인증 정보 조회
+        String storedCode = (String) redisTemplate.opsForHash().get(redisKey, "code");
+        Boolean isVerified = (Boolean) redisTemplate.opsForHash().get(redisKey, "verified");
+
+        // 인증번호가 만료된 경우
+        if (storedCode == null) {
+            throw new GeneralException(ErrorStatus.EMAIL_VERIFICATION_CODE_EXPIRED);
+        }
+
+        // 인증번호가 일치하지 않는 경우
+        if (!request.getVerificationCode().equals(storedCode)) {
+            throw new GeneralException(ErrorStatus.EMAIL_VERIFICATION_CODE_INVALID);
+        }
+
+        // 이미 인증된 경우
+        if (Boolean.TRUE.equals(isVerified)) {
+            throw new GeneralException(ErrorStatus.EMAIL_VERIFICATION_CODE_ALREADY_VERIFIED);
+        }
+
+        // 인증 성공 시 verified 상태 업데이트
+        redisTemplate.opsForHash().put(redisKey, "verified", true);
+
+        return true;
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
@@ -2,14 +2,12 @@ package checkmo.domain.member.service.command;
 
 import checkmo.apiPayload.code.status.ErrorStatus;
 import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.member.service.common.EmailSender;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import java.security.SecureRandom;
 import java.time.Duration;
@@ -22,7 +20,7 @@ import java.util.Map;
 public class MemberRegistrationCommandServiceImpl implements MemberRegistrationCommandService {
 
     private final RedisTemplate<String, Object> redisTemplate;
-    private final JavaMailSender javaMailSender;
+    private final EmailSender emailSender;
 
     private static final String EMAIL_VERIFICATION_PREFIX = "verification:";
     private static final Duration EMAIL_VERIFICATION_TTL = Duration.ofMinutes(10); // 10분
@@ -45,30 +43,10 @@ public class MemberRegistrationCommandServiceImpl implements MemberRegistrationC
         redisTemplate.opsForHash().putAll(redisKey, verificationData);
         redisTemplate.expire(redisKey, EMAIL_VERIFICATION_TTL);
 
-        // 이메일 발송 (내부 메서드로)
-        sendEmailInternal(email, verificationCode);
+        // 이메일 발송 메서드 호출
+        emailSender.sendEmail(email, verificationCode);
 
         log.info("Verification code sent to email: {}", email);
-    }
-
-    // 이메일 발송 내부 메서드
-    @Async
-    protected void sendEmailInternal(String email, String verificationCode) {
-        try {
-            // 이메일 메시지 생성
-            SimpleMailMessage message = new SimpleMailMessage();
-            message.setTo(email); // 받는 사람 이메일
-            message.setSubject("책모 회원가입 인증번호"); // 이메일 제목
-            message.setText("인증번호: " + verificationCode + "\n\n" +
-                "인증번호는 10분간 유효합니다."); // 이메일 본문
-
-            // 이메일 발송
-            javaMailSender.send(message);
-            log.info("이메일 발송 성공: {}", email);
-        } catch (Exception e) {
-            log.error("이메일 발송 실패: email={}, error={}", email, e.getMessage());
-            throw new RuntimeException("Failed to send verification email", e);
-        }
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/service/common/EmailSender.java
+++ b/src/main/java/checkmo/domain/member/service/common/EmailSender.java
@@ -1,0 +1,33 @@
+package checkmo.domain.member.service.common;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailSender {
+
+    private final JavaMailSender javaMailSender;
+
+    // 이메일 발송 메서드
+    @Async
+    public void sendEmail(String email, String verificationCode) {
+        try {
+            // 이메일 메시지 생성
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(email); // 받는 사람 이메일
+            message.setSubject("책모 회원가입 인증번호"); // 이메일 제목
+            message.setText("인증번호: " + verificationCode + "\n\n" + "인증번호는 10분간 유효합니다."); // 이메일 본문
+            javaMailSender.send(message); // 이메일 발송
+            log.info("이메일 발송 성공: {}", email);
+        } catch (Exception e) {
+            log.error("이메일 발송 실패: email={}, error={}", email, e.getMessage());
+            throw new RuntimeException("Failed to send verification email", e);
+        }
+    }
+}

--- a/src/main/java/checkmo/domain/member/web/controller/AuthController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/AuthController.java
@@ -4,12 +4,17 @@ import checkmo.apiPayload.ApiResponse;
 import checkmo.domain.member.facade.MemberCommandFacade;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -21,11 +26,12 @@ public class AuthController {
 
     // 이메일 인증 요청
     @Operation(summary = "이메일 인증번호 요청", description = "회원가입 시 이메일 인증번호를 요청합니다.")
+    @Parameter(name = "email", description = "인증을 요청할 이메일 주소", required = true, example = "test@example.com")
     @PostMapping("/email-verification")
     public ApiResponse<String> sendEmailVerification(@RequestParam
-                                                         @Email(message = "유효한 이메일 주소를 입력해주세요")
-                                                         @NotBlank(message = "이메일은 필수입니다")
-                                                         String email) {
+                                                     @Email(message = "유효한 이메일 주소를 입력해주세요")
+                                                     @NotBlank(message = "이메일은 필수입니다")
+                                                     String email) {
         memberCommandFacade.sendEmailVerification(email);
         return ApiResponse.onSuccess("인증번호가 이메일로 발송되었습니다.");
     }

--- a/src/main/java/checkmo/domain/member/web/controller/AuthController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/AuthController.java
@@ -30,9 +30,13 @@ public class AuthController {
         return ApiResponse.onSuccess("인증번호가 이메일로 발송되었습니다.");
     }
 
-    // 이메일 인증 관련
-    // POST /api/auth/email-verification - 이메일 인증 요청
-    // POST /api/auth/email-verification/confirm - 이메일 인증 확인
+    // 이메일 인증 확인
+    @Operation(summary = "이메일 인증번호 확인", description = "이메일 인증번호를 확인합니다.")
+    @PostMapping("/email-verification/confirm")
+    public ApiResponse<Boolean> verifyEmailCode(@Valid @RequestBody MemberRequestDTO.EmailVerificationRequestDTO request) {
+        boolean isVerified = memberCommandFacade.verifyEmailCode(request);
+        return ApiResponse.onSuccess(isVerified);
+    }
 
     // 회원가입 관련
     // POST /api/auth/signup - 회원가입

--- a/src/main/java/checkmo/domain/member/web/controller/AuthController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/AuthController.java
@@ -1,15 +1,34 @@
 package checkmo.domain.member.web.controller;
 
+import checkmo.apiPayload.ApiResponse;
+import checkmo.domain.member.facade.MemberCommandFacade;
+import checkmo.domain.member.web.dto.MemberRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping()
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 @Tag(name = "인증", description = "회원가입, 로그인, 로그아웃, 이메일 인증, 소셜 로그인 관련 API")
 public class AuthController {
+
+    private final MemberCommandFacade memberCommandFacade;
+
+    // 이메일 인증 요청
+    @Operation(summary = "이메일 인증번호 요청", description = "회원가입 시 이메일 인증번호를 요청합니다.")
+    @PostMapping("/email-verification")
+    public ApiResponse<String> sendEmailVerification(@RequestParam
+                                                         @Email(message = "유효한 이메일 주소를 입력해주세요")
+                                                         @NotBlank(message = "이메일은 필수입니다")
+                                                         String email) {
+        memberCommandFacade.sendEmailVerification(email);
+        return ApiResponse.onSuccess("인증번호가 이메일로 발송되었습니다.");
+    }
 
     // 이메일 인증 관련
     // POST /api/auth/email-verification - 이메일 인증 요청

--- a/src/main/java/checkmo/domain/member/web/dto/MemberRequestDTO.java
+++ b/src/main/java/checkmo/domain/member/web/dto/MemberRequestDTO.java
@@ -31,6 +31,8 @@ public class MemberRequestDTO {
         private String newPassword;
     }
 
+    @Getter
+    @NoArgsConstructor
     public static class EmailVerificationRequestDTO {
         @NotBlank(message = "이메일은 필수입니다")
         @Email(message = "유효한 이메일 형식이 아닙니다")

--- a/src/main/java/checkmo/global/auth/CurrentId.java
+++ b/src/main/java/checkmo/global/auth/CurrentId.java
@@ -1,4 +1,16 @@
 package checkmo.global.auth;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
+@Schema(hidden = true)
 public @interface CurrentId {
 }

--- a/src/main/java/checkmo/global/auth/CurrentMember.java
+++ b/src/main/java/checkmo/global/auth/CurrentMember.java
@@ -1,4 +1,16 @@
 package checkmo.global.auth;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
+@Schema(hidden = true)
 public @interface CurrentMember {
 }

--- a/src/main/resources/application-mail.yml
+++ b/src/main/resources/application-mail.yml
@@ -1,0 +1,12 @@
+mail:
+  smtp:
+    host: smtp.gmail.com
+    port: 587
+    timeout: 5000
+    connection-timeout: 5000
+    write-timeout: 5000
+    starttls-enable: true
+  auth:
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    enable: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,4 @@ spring:
       - db # 배포 후에는 prod로 변경
       - redis # TODO: 배포시 Redis를 EC2 내부에서 쓸 지, Elasticache를 쓸 지 결정
       - aladin
+      - mail


### PR DESCRIPTION
## 🚀 변경사항
- 이메일 인증 및 확인 기능 구현
- 인증번호는 6자리 랜덤 숫자, Redis에 10분간 저장
- SMTP 설정 클래스들 추가 및 SecurityConfig에 스웨거 예외 경로로 설정
- 노션 .env 파일에 추가된 내용 확인해주세요! (MAIL_USERNAME, MAIL_PASSWORD)

## 🔗 관련 이슈
- Closes #5 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
더 예외처리 필요한 부분 없는지 봐주시면 감사하겠습니다!
그리고 이메일 발송 로직을 `@Async`로 비동기 처리하기 위해 외부 컴포넌트로 분리했습니다. 해당 클래스를 일단 member.service.common 패키지를 새로 만들어서 거기에 위치시켰는데 더 나은 위치나 네이밍 있을까요??