### PR TITLE
Feat/30/book story list

### DIFF
--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -22,6 +22,10 @@ public enum ErrorStatus implements BaseErrorCode {
     // 책
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK_4004", "책을 찾을 수 없습니다."),
 
+    //책이야기
+    BOOK_STORY_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK_STORY_4004", "책 이야기를 찾을 수 없습니다."),
+    BOOK_STORY_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "BOOK_STORY_4005", "책 이야기 수정/삭제 권한이 없습니다."),
+
     // 모임
     CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB_4004", "독서클럽을 찾을 수 없습니다."),
     CLUB_DUPLICATED_NAME(HttpStatus.BAD_REQUEST, "CLUB_4001", "이미 존재하는 독서클럽 이름입니다."),

--- a/src/main/java/checkmo/domain/bookStory/facade/BookStoryQueryFacade.java
+++ b/src/main/java/checkmo/domain/bookStory/facade/BookStoryQueryFacade.java
@@ -19,25 +19,15 @@ public interface BookStoryQueryFacade {
     BookStorySharedDTO.BookStoryResponse getBookStory(String memberId, Long bookStoryId);
 
     /**
-     * 특정 회원의 책 이야기 목록을 커서 기반으로 조회합니다. (외부용)
-     * 여기서 특정 회원은 나 일수도, 다른 회원일 수도 있습니다.
-     *
-     * @param memberId 조회하는 회원의 ID
-     * @param targetMemberNickname 조회할 회원의 닉네임
-     * @param cursorId 페이징을 위한 커서 ID (처음에는 null)
-     * @return 조회된 책 이야기 목록 DTO
-     */
-    BookStorySharedDTO.BookStoryListResponse getBookStoriesByNickname(String memberId, String targetMemberNickname, Long cursorId);
-
-    /**
      * scope에 따라 책 이야기 목록을 조회합니다. (내부용)
      * 비즈니스 로직을 Facade에서 처리하여 컨트롤러는 단순히 호출만 담당
      *
      * @param memberId 조회하는 회원의 ID
-     * @param scope    조회 범위 ("all", "my", "club")
-     * @param clubId   클럽 ID (scope가 "club"일 때 필수)
+     * @param scope    조회 범위 ("ALL", "MY", "FOLLOWING", "CLUB", "TARGET")
+     * @param clubId   클럽 ID (scope가 "CLUB"일 때 필수)
+     * @param targetMemberNickname 대상 회원 닉네임 (scope가 "TARGET"일 때 필수)
      * @param cursorId     페이지 번호 (1부터 시작)
      * @return scope에 따른 책 이야기 목록 DTO
      */
-    BookStorySharedDTO.BookStoryListResponse getBookStoriesByScope(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, Long cursorId);
+    BookStorySharedDTO.BookStoryListResponse getBookStoriesByScope(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, String targetMemberNickname, Long cursorId);
 }

--- a/src/main/java/checkmo/domain/bookStory/facade/BookStoryQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/bookStory/facade/BookStoryQueryFacadeImpl.java
@@ -1,5 +1,7 @@
 package checkmo.domain.bookStory.facade;
 
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.bookStory.converter.BookStoryConverter;
 import checkmo.domain.bookStory.entity.BookStory;
 import checkmo.domain.bookStory.service.query.BookStoryQueryService;
@@ -75,7 +77,7 @@ public class BookStoryQueryFacadeImpl implements BookStoryQueryFacade {
             myClubInfoDTO = myClubList.getClubList().stream()
                     .filter(club -> club.getClubId().equals(clubId))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 클럽이거나 가입하지 않은 클럽입니다."));
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.CLUB_NOT_FOUND));
         }
 
         // 6. 스코프 정보 변환 (CLUB 스코프인 경우 선택된 클럽 정보 포함)

--- a/src/main/java/checkmo/domain/bookStory/facade/BookStoryQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/bookStory/facade/BookStoryQueryFacadeImpl.java
@@ -4,6 +4,7 @@ import checkmo.domain.bookStory.converter.BookStoryConverter;
 import checkmo.domain.bookStory.entity.BookStory;
 import checkmo.domain.bookStory.service.query.BookStoryQueryService;
 import checkmo.domain.bookStory.web.dto.BookStoryRequestDTO;
+import checkmo.domain.member.facade.MemberQueryFacade;
 import checkmo.global.dto.BookSharedDTO;
 import checkmo.global.dto.BookStorySharedDTO;
 import checkmo.global.dto.ClubSharedDTO;
@@ -23,6 +24,7 @@ public class BookStoryQueryFacadeImpl implements BookStoryQueryFacade {
     public static final int DEFAULT_PAGE_SIZE = 10;
 
     private final BookStoryQueryService bookStoryQueryService;
+    private final MemberQueryFacade memberQueryFacade;
 
     @Override
     public BookStorySharedDTO.BookStoryResponse getBookStory(String memberId, Long bookStoryId) {
@@ -30,14 +32,15 @@ public class BookStoryQueryFacadeImpl implements BookStoryQueryFacade {
     }
 
     @Override
-    public BookStorySharedDTO.BookStoryListResponse getBookStoriesByNickname(String memberId, String targetMemberNickname, Long cursorId) {
-        return null;
-    }
-
-    @Override
-    public BookStorySharedDTO.BookStoryListResponse getBookStoriesByScope(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, Long cursorId) {
-        // 1. 책이야기 목록 조회
-        List<BookStory> bookStories = bookStoryQueryService.findBookStories(memberId, scope, clubId, cursorId, DEFAULT_PAGE_SIZE);
+    public BookStorySharedDTO.BookStoryListResponse getBookStoriesByScope(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, String targetMemberNickname, Long cursorId) {
+        // 1. TARGET 스코프인 경우 닉네임으로 targetMemberId 조회
+        String targetMemberId = null;
+        if (scope == BookStoryRequestDTO.BookStoryScope.TARGET) {
+            targetMemberId = memberQueryFacade.getMemberIdByNickname(targetMemberNickname);
+        }
+        
+        // 2. 책이야기 목록 조회 (페이지 사이즈 +1을 서비스에서 처리함)
+        List<BookStory> bookStories = bookStoryQueryService.findBookStories(memberId, scope, clubId, targetMemberId, cursorId, DEFAULT_PAGE_SIZE);
 
         // 2. Facade에서 페이지네이션 로직 처리
         boolean hasNext = bookStories.size() > DEFAULT_PAGE_SIZE;

--- a/src/main/java/checkmo/domain/bookStory/repository/BookStoryQueryRepository.java
+++ b/src/main/java/checkmo/domain/bookStory/repository/BookStoryQueryRepository.java
@@ -6,5 +6,5 @@ import checkmo.domain.bookStory.web.dto.BookStoryRequestDTO;
 import java.util.List;
 
 public interface BookStoryQueryRepository {
-    List<BookStory> searchBookStories(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, Long cursorId, int pageSize);
+    List<BookStory> searchBookStories(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, String targetMemberId, Long cursorId, int pageSize);
 }

--- a/src/main/java/checkmo/domain/bookStory/repository/BookStoryQueryRepositoryImpl.java
+++ b/src/main/java/checkmo/domain/bookStory/repository/BookStoryQueryRepositoryImpl.java
@@ -21,12 +21,13 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
     private final JPAQueryFactory JpaQueryFactory;
 
     @Override
-    public List<BookStory> searchBookStories(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, Long cursorId, int pageSize) {
+    public List<BookStory> searchBookStories(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, String targetMemberId, Long cursorId, int pageSize) {
         return switch (scope) {
             case ALL -> findAllBookStories(cursorId, pageSize);
             case MY -> findMyBookStories(memberId, cursorId, pageSize);
             case FOLLOWING -> findFollowBookStories(memberId, cursorId, pageSize);
             case CLUB -> findClubBookStories(memberId, clubId, cursorId, pageSize);
+            case TARGET -> findTargetMemberBookStories(targetMemberId, cursorId, pageSize);
         };
     }
 
@@ -89,6 +90,22 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
             .where(
                 createCursorExp(cursorId),
                 bookStory.memberId.in(clubMemberIds)
+            )
+            .orderBy(bookStory.id.desc())
+            .limit(pageSize)
+            .fetch();
+    }
+
+    private List<BookStory> findTargetMemberBookStories(String targetMemberId, Long cursorId, int pageSize) {
+        if (targetMemberId == null) {
+            throw new IllegalArgumentException("scope가 target인 경우 targetMemberId는 필수입니다.");
+        }
+        
+        return JpaQueryFactory
+            .selectFrom(bookStory)
+            .where(
+                createCursorExp(cursorId),
+                bookStory.memberId.eq(targetMemberId)
             )
             .orderBy(bookStory.id.desc())
             .limit(pageSize)

--- a/src/main/java/checkmo/domain/bookStory/service/command/BookStoryCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/bookStory/service/command/BookStoryCommandServiceImpl.java
@@ -1,5 +1,7 @@
 package checkmo.domain.bookStory.service.command;
 
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.book.entity.Book;
 import checkmo.domain.book.facade.BookCommandFacade;
 import checkmo.domain.book.facade.BookQueryFacade;
@@ -44,10 +46,10 @@ public class BookStoryCommandServiceImpl implements BookStoryCommandService {
     @Transactional
     public Long updateBookStory(String memberId, Long bookStoryId, BookStoryRequestDTO.BookStoryUpdateRequestDTO request) {
         BookStory bookStory = bookStoryRepository.findById(bookStoryId)
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 책이야기가 존재하지 않습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_STORY_NOT_FOUND));
 
         if (!bookStory.getMemberId().equals(memberId)) {
-            throw new IllegalArgumentException("해당 책이야기를 수정할 권한이 없습니다.");
+            throw new GeneralException(ErrorStatus.BOOK_STORY_NOT_AUTHORIZED);
         }
 
         return bookStory.updateDescription(request.getDescription());
@@ -57,10 +59,10 @@ public class BookStoryCommandServiceImpl implements BookStoryCommandService {
     @Transactional
     public void deleteBookStory(String memberId, Long bookStoryId) {
         BookStory bookStory = bookStoryRepository.findById(bookStoryId)
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 책이야기가 존재하지 않습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_STORY_NOT_FOUND));
 
         if (!bookStory.getMemberId().equals(memberId)) {
-            throw new IllegalArgumentException("해당 책이야기를 삭제할 권한이 없습니다.");
+            throw new GeneralException(ErrorStatus.BOOK_STORY_NOT_AUTHORIZED);
         }
 
         bookStoryRepository.delete(bookStory);

--- a/src/main/java/checkmo/domain/bookStory/service/command/BookStorySocialCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/bookStory/service/command/BookStorySocialCommandServiceImpl.java
@@ -1,5 +1,7 @@
 package checkmo.domain.bookStory.service.command;
 
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.bookStory.entity.BookStory;
 import checkmo.domain.bookStory.entity.BookStoryLiked;
 import checkmo.domain.bookStory.repository.BookStoryLikedRepository;
@@ -26,7 +28,7 @@ public class BookStorySocialCommandServiceImpl implements BookStorySocialCommand
     public boolean toggleLikeOnBookStory(String memberId, Long bookStoryId) {
 
         BookStory bookStory = bookStoryRepository.findById(bookStoryId)
-                .orElseThrow(() -> new IllegalArgumentException(bookStoryId + "에 해당하는 책이야기를 찾을 수 없습니다"));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_STORY_NOT_FOUND));
 
         Member proxyMember = memberQueryFacade.findMemberReferenceById(memberId);
 

--- a/src/main/java/checkmo/domain/bookStory/service/query/BookStoryQueryService.java
+++ b/src/main/java/checkmo/domain/bookStory/service/query/BookStoryQueryService.java
@@ -19,14 +19,15 @@ public interface BookStoryQueryService {
      * 조건에 맞는 책 이야기 엔티티 목록을 조회 (페이지네이션을 위해 +1개 더 조회)
      *
      * @param memberId 조회하는 회원의 ID
-     * @param scope 조회 범위 ("ALL", "NY", "FOLLOWING", "CLUB")
+     * @param scope 조회 범위 ("ALL", "MY", "FOLLOWING", "CLUB", "TARGET")
      * @param clubId 클럽 ID (scope가 "CLUB"일 때 필수)
+     * @param targetMemberId 대상 회원 ID (scope가 "TARGET"일 때 필수)
      * @param cursorId 페이지네이션을 위한 커서 ID (처음에는 null)
      * @param pageSize 페이지 크기
      *
      * @return 조회된 책 이야기 엔티티 목록
      */
-    List<BookStory> findBookStories(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, Long cursorId, int pageSize);
+    List<BookStory> findBookStories(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, String targetMemberId, Long cursorId, int pageSize);
 
     /**
      * 조회된 책 이야기 목록에 대한 '좋아요' 여부를 확인
@@ -75,14 +76,4 @@ public interface BookStoryQueryService {
      * @return 조회된 책 이야기의 DTO
      */
     BookStorySharedDTO.BookStoryResponse getBookStory(String memberId, Long bookStoryId);
-
-    /**
-     * 특정 회원의 책 이야기 목록을 커서 기반으로 조회합니다.
-     *
-     * @param memberId 조회할 회원의 ID
-     * @param cursorId 페이징을 위한 커서 ID (처음에는 null)
-     *
-     * @return 조회된 책 이야기 목록 DTO
-     */
-    BookStorySharedDTO.BookStoryListResponse getMyBookStoriesByNickname(String memberId, String targetMemberNickname, Long cursorId);
 }

--- a/src/main/java/checkmo/domain/bookStory/service/query/BookStoryQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/bookStory/service/query/BookStoryQueryServiceImpl.java
@@ -34,9 +34,9 @@ public class BookStoryQueryServiceImpl implements BookStoryQueryService {
     private final BookStoryLikedRepository bookStoryLikedRepository;
 
     @Override
-    public List<BookStory> findBookStories(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, Long cursorId, int pageSize) {
+    public List<BookStory> findBookStories(String memberId, BookStoryRequestDTO.BookStoryScope scope, Long clubId, String targetMemberId, Long cursorId, int pageSize) {
         // TODO: 현재 내부에서 외부 도메인의 Q클래스를 호출해서 QueryDSL 사용하고 있는데, 이 부분도 리팩토링 필요
-        return bookStoryRepository.searchBookStories(memberId, scope, clubId, cursorId, pageSize + 1);
+        return bookStoryRepository.searchBookStories(memberId, scope, clubId, targetMemberId, cursorId, pageSize + 1);
     }
 
     @Override
@@ -90,10 +90,5 @@ public class BookStoryQueryServiceImpl implements BookStoryQueryService {
                 memberQueryFacade.getMemberWithFollowStatusForShare(bookStory.getMemberId(), memberId),
                 bookStoryLikedRepository.existsByMemberIdAndBookStoryId(memberId, bookStory.getId())
         );
-    }
-
-    @Override
-    public BookStorySharedDTO.BookStoryListResponse getMyBookStoriesByNickname(String memberId, String targetMemberNickname, Long cursorId) {
-        return null;
     }
 }

--- a/src/main/java/checkmo/domain/bookStory/service/query/BookStoryQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/bookStory/service/query/BookStoryQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package checkmo.domain.bookStory.service.query;
 
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.book.facade.BookQueryFacade;
 import checkmo.domain.bookStory.converter.BookStoryConverter;
 import checkmo.domain.bookStory.entity.BookStory;
@@ -81,7 +83,7 @@ public class BookStoryQueryServiceImpl implements BookStoryQueryService {
     @Override
     public BookStorySharedDTO.BookStoryResponse getBookStory(String memberId, Long bookStoryId) {
         BookStory bookStory = bookStoryRepository.findById(bookStoryId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 책 이야기입니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BOOK_STORY_NOT_FOUND));
 
         return BookStoryConverter.fromBookStoryToResponse(
                 bookStory,

--- a/src/main/java/checkmo/domain/bookStory/web/controller/BookStoryController.java
+++ b/src/main/java/checkmo/domain/bookStory/web/controller/BookStoryController.java
@@ -47,11 +47,13 @@ public class BookStoryController {
                             "• ALL: 전체 책이야기\n" +
                             "• FOLLOWING: 팔로우한 회원의 책이야기\n" +
                             "• MY: 내 책이야기\n" +
-                            "• CLUB: 특정 클럽 책이야기 (clubId 필수)",
+                            "• CLUB: 특정 클럽 책이야기 (clubId 필수)\n" +
+                            "• TARGET: 특정 회원의 책이야기 (targetMemberNickname 필수)",
                     required = true,
                     example = "ALL"
             ),
             @Parameter(name = "clubId", description = "조회하는 Club ID (scope가 CLUB일 때 필수)", required = false, example = "1"),
+            @Parameter(name = "targetMemberNickname", description = "조회할 회원의 닉네임 (scope가 TARGET일 때 필수)", required = false, example = "MODUGGAGI"),
             @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "10")
     })
     @ApiResponses({
@@ -64,13 +66,18 @@ public class BookStoryController {
             @CurrentId String memberId,
             @RequestParam(required = false, defaultValue = "ALL") BookStoryRequestDTO.BookStoryScope scope,
             @RequestParam(required = false) Long clubId,
+            @RequestParam(required = false) String targetMemberNickname,
             @RequestParam(required = false) Long cursorId
     ) {
         if (scope == BookStoryRequestDTO.BookStoryScope.CLUB && clubId == null) {
             throw new IllegalArgumentException("scope가 CLUB일 때는 clubId 파라미터가 필수입니다.");
         }
 
-        var bookStoriesByScope = bookStoryQueryFacade.getBookStoriesByScope(memberId, scope, clubId, cursorId);
+        if (scope == BookStoryRequestDTO.BookStoryScope.TARGET && targetMemberNickname == null) {
+            throw new IllegalArgumentException("scope가 TARGET일 때는 targetMemberNickname 파라미터가 필수입니다.");
+        }
+
+        var bookStoriesByScope = bookStoryQueryFacade.getBookStoriesByScope(memberId, scope, clubId, targetMemberNickname, cursorId);
         return ApiResponse.onSuccess(bookStoriesByScope);
     }
 

--- a/src/main/java/checkmo/domain/bookStory/web/controller/BookStoryController.java
+++ b/src/main/java/checkmo/domain/bookStory/web/controller/BookStoryController.java
@@ -4,6 +4,7 @@ import checkmo.apiPayload.ApiResponse;
 import checkmo.domain.bookStory.facade.BookStoryCommandFacade;
 import checkmo.domain.bookStory.facade.BookStoryQueryFacade;
 import checkmo.domain.bookStory.web.dto.BookStoryRequestDTO;
+import checkmo.global.auth.CurrentId;
 import checkmo.global.dto.BookStorySharedDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -31,7 +32,7 @@ public class BookStoryController {
     })
     @PostMapping
     public ApiResponse<Long> createBookStory(
-            @RequestParam String memberId, // TODO: 스프링 시큐리티 구현 후 제거 예정
+            @CurrentId String memberId,
             @Valid @RequestBody BookStoryRequestDTO.BookStoryCreateRequestDTO request
     ) {
         Long bookStoryId = bookStoryCommandFacade.createBookStory(memberId, request);
@@ -60,7 +61,7 @@ public class BookStoryController {
     })
     @GetMapping
     public ApiResponse<BookStorySharedDTO.BookStoryListResponse> getBookStories(
-            @RequestParam String memberId, // TODO: 스프링 시큐리티 구현 후 제거 예정
+            @CurrentId String memberId,
             @RequestParam(required = false, defaultValue = "ALL") BookStoryRequestDTO.BookStoryScope scope,
             @RequestParam(required = false) Long clubId,
             @RequestParam(required = false) Long cursorId
@@ -83,7 +84,7 @@ public class BookStoryController {
     })
     @GetMapping("/{bookStoryId}")
     public ApiResponse<BookStorySharedDTO.BookStoryResponse> getBookStory(
-            @RequestParam String memberId, // TODO: 스프링 시큐리티 구현 후 제거 예정
+            @CurrentId String memberId,
             @PathVariable Long bookStoryId
     ) {
         var bookStory = bookStoryQueryFacade.getBookStory(memberId, bookStoryId);
@@ -100,7 +101,7 @@ public class BookStoryController {
     })
     @PostMapping("/{bookStoryId}/like")
     public ApiResponse<Long> toggleLikeBookStory(
-            @RequestParam String memberId, // TODO: 스프링 시큐리티 구현 후 제거 예정
+            @CurrentId String memberId,
             @PathVariable Long bookStoryId
     ) {
         boolean isLiked = bookStoryCommandFacade.toggleLikeOnBookStory(memberId, bookStoryId);
@@ -123,7 +124,7 @@ public class BookStoryController {
     })
     @PatchMapping("/{bookStoryId}")
     public ApiResponse<Long> updateBookStory(
-            @RequestParam String memberId, // TODO: 스프링 시큐리티 구현 후 제거 예정
+            @CurrentId String memberId,
             @PathVariable Long bookStoryId,
             @Valid @RequestBody BookStoryRequestDTO.BookStoryUpdateRequestDTO request
     ) {
@@ -142,7 +143,7 @@ public class BookStoryController {
     })
     @DeleteMapping("/{bookStoryId}")
     public ApiResponse<String> deleteBookStory(
-            @RequestParam String memberId, // TODO: 스프링 시큐리티 구현 후 제거 예정
+            @CurrentId String memberId,
             @PathVariable Long bookStoryId
     ) {
         bookStoryCommandFacade.deleteBookStory(memberId, bookStoryId);

--- a/src/main/java/checkmo/domain/bookStory/web/dto/BookStoryRequestDTO.java
+++ b/src/main/java/checkmo/domain/bookStory/web/dto/BookStoryRequestDTO.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 public class BookStoryRequestDTO {
 
     public enum BookStoryScope {
-        ALL, MY, FOLLOWING, CLUB
+        ALL, MY, FOLLOWING, CLUB, TARGET
     }
 
     @Getter

--- a/src/main/java/checkmo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/checkmo/domain/member/converter/MemberConverter.java
@@ -70,4 +70,14 @@ public class MemberConverter {
                 .build();
     }
 
+    /**
+     * BasicInfoDTO -> WithFollowStatusDTO 변환
+     */
+    public static MemberSharedDTO.WithFollowStatusDTO toWithFollowStatusDTO(MemberSharedDTO.BasicInfoDTO basicInfo, boolean isFollowing) {
+        return MemberSharedDTO.WithFollowStatusDTO.builder()
+                .nickname(basicInfo.getNickname())
+                .profileImageUrl(basicInfo.getProfileImageUrl())
+                .isFollowing(isFollowing)
+                .build();
+    }
 }

--- a/src/main/java/checkmo/domain/member/facade/MemberQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberQueryFacadeImpl.java
@@ -3,6 +3,7 @@ package checkmo.domain.member.facade;
 import checkmo.domain.member.converter.MemberConverter;
 import checkmo.domain.member.entity.Member;
 import checkmo.domain.member.repository.MemberRepository;
+import checkmo.domain.member.service.query.MemberFollowQueryService;
 import checkmo.domain.member.service.query.MemberQueryService;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
 import checkmo.global.dto.MemberSharedDTO;
@@ -17,6 +18,7 @@ public class MemberQueryFacadeImpl implements MemberQueryFacade {
 
     private final MemberRepository memberRepository; // 프록시용
     private final MemberQueryService memberQueryService;
+    private final MemberFollowQueryService memberFollowQueryService;
 
     @Override
     public boolean isNicknameDuplicated(String nickname) {
@@ -74,9 +76,19 @@ public class MemberQueryFacadeImpl implements MemberQueryFacade {
         return MemberConverter.toBasicInfoDTO(profile);
     }
 
+    /**
+     * 공유용 기본 회원 정보 + 팔로우 상태 조회 (외부용)
+     * @param targetMemberId 조회 대상 회원 ID
+     * @param currentMemberId 현재 로그인한 회원 ID
+     * @return MemberSharedDTO.WithFollowStatusDTO
+     */
     @Override
     public MemberSharedDTO.WithFollowStatusDTO getMemberWithFollowStatusForShare(String targetMemberId, String currentMemberId) {
-        return MemberSharedDTO.WithFollowStatusDTO.builder().build();
+        // 팔로우 상태를 조회
+        boolean isFollowing = memberFollowQueryService.isFollowing(currentMemberId, targetMemberId);
+
+        var basicInfoDTO = getMemberBasicInfoForShare(targetMemberId);
+        return MemberConverter.toWithFollowStatusDTO(basicInfoDTO, isFollowing);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/repository/FollowRepository.java
+++ b/src/main/java/checkmo/domain/member/repository/FollowRepository.java
@@ -4,4 +4,6 @@ import checkmo.domain.member.entity.Follow;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    boolean existsByFollowerIdAndFollowingId(String followerId, String followingId);
 }

--- a/src/main/java/checkmo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/checkmo/domain/member/repository/MemberRepository.java
@@ -1,8 +1,11 @@
 package checkmo.domain.member.repository;
 
 import checkmo.domain.member.entity.Member;
+
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
 
@@ -11,4 +14,7 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     boolean existsByEmail(String email);
 
     boolean existsByNickName(String nickName);
+
+    @Query("select m.id from Member m where m.nickName = :nickName")
+    Optional<String> findIdByNickName(@Param("nickName") String nickName);
 }

--- a/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryService.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryService.java
@@ -46,5 +46,5 @@ public interface MemberFollowQueryService {
     /**
      * 특정 회원의 팔로우 여부 확인
      */
-    boolean isFollowing(String memberId, String targetMemberNickname);
+    boolean isFollowing(String memberId, String targetMemberId);
 }

--- a/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
@@ -36,10 +36,10 @@ public class MemberFollowQueryServiceImpl implements MemberFollowQueryService {
     }
 
     @Override
-    public boolean isFollowing(String memberId, String targetMemberNickname) {
-        // 대상 회원의 ID를 조회
-        String targetMemberId = memberRepository.findIdByNickName(targetMemberNickname)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    public boolean isFollowing(String memberId, String targetMemberId) {
+        if (memberId == targetMemberId) {
+            return true; // 자기 자신을 팔로우하는 것은 항상 true
+        }
 
         // 팔로우 관계가 존재하는지 확인
         return followRepository.existsByFollowerIdAndFollowingId(memberId, targetMemberId);

--- a/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
@@ -1,0 +1,47 @@
+package checkmo.domain.member.service.query;
+
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.member.repository.FollowRepository;
+import checkmo.domain.member.repository.MemberRepository;
+import checkmo.domain.member.web.dto.MemberResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberFollowQueryServiceImpl implements MemberFollowQueryService {
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
+    @Override
+    public MemberResponseDTO.FollowerListResponseDTO getFollowers(String memberId, Long cursorId) {
+        return null;
+    }
+
+    @Override
+    public MemberResponseDTO.FollowingListResponseDTO getFollowing(String memberId, Long cursorId) {
+        return null;
+    }
+
+    @Override
+    public MemberResponseDTO.FollowerListResponseDTO getFollowers(Long memberId, int size) {
+        return null;
+    }
+
+    @Override
+    public MemberResponseDTO.FollowingListResponseDTO getFollowing(Long memberId, int size) {
+        return null;
+    }
+
+    @Override
+    public boolean isFollowing(String memberId, String targetMemberNickname) {
+        // 대상 회원의 ID를 조회
+        String targetMemberId = memberRepository.findIdByNickName(targetMemberNickname)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 팔로우 관계가 존재하는지 확인
+        return followRepository.existsByFollowerIdAndFollowingId(memberId, targetMemberId);
+    }
+}

--- a/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
@@ -37,7 +37,7 @@ public class MemberFollowQueryServiceImpl implements MemberFollowQueryService {
 
     @Override
     public boolean isFollowing(String memberId, String targetMemberId) {
-        if (memberId == targetMemberId) {
+        if (memberId.equals(targetMemberId)) {
             return true; // 자기 자신을 팔로우하는 것은 항상 true
         }
 

--- a/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
@@ -1,9 +1,6 @@
 package checkmo.domain.member.service.query;
 
-import checkmo.apiPayload.code.status.ErrorStatus;
-import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.member.repository.FollowRepository;
-import checkmo.domain.member.repository.MemberRepository;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,27 +9,26 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MemberFollowQueryServiceImpl implements MemberFollowQueryService {
 
-    private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
 
     @Override
     public MemberResponseDTO.FollowerListResponseDTO getFollowers(String memberId, Long cursorId) {
-        return null;
+        throw new UnsupportedOperationException("아직 개발 중~");
     }
 
     @Override
     public MemberResponseDTO.FollowingListResponseDTO getFollowing(String memberId, Long cursorId) {
-        return null;
+        throw new UnsupportedOperationException("아직 개발 중~");
     }
 
     @Override
     public MemberResponseDTO.FollowerListResponseDTO getFollowers(Long memberId, int size) {
-        return null;
+        throw new UnsupportedOperationException("아직 개발 중~");
     }
 
     @Override
     public MemberResponseDTO.FollowingListResponseDTO getFollowing(Long memberId, int size) {
-        return null;
+        throw new UnsupportedOperationException("아직 개발 중~");
     }
 
     @Override

--- a/src/main/java/checkmo/global/auth/CurrentMemberArgumentResolver.java
+++ b/src/main/java/checkmo/global/auth/CurrentMemberArgumentResolver.java
@@ -49,7 +49,7 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
         String memberId = null;
         if (authentication.getPrincipal() instanceof PrincipalDetails) {
             PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
-//            memberId = principalDetails.getUsername(); //‼️TODO: PrincipalDetails 완성하고 반드시 주석 해야함!!!!‼️
+            memberId = principalDetails.getUsername(); //‼️TODO: PrincipalDetails 완성하고 반드시 주석 해야함!!!!‼️
         }
 
         if (memberId == null) {


### PR DESCRIPTION
## 🚀 변경사항
- 책 이야기 전체 조회에서 특정 회원의 책이야기 조회도 무한 스크롤로 구현 후 추가
- MemberQueryService에서 특정 회원의 팔로잉 여부를 담은 DTO 반환하는 로직 추가

## 🔗 관련 이슈
- Closes #30

## ✅ 체크리스트
- [ ] 로컬에서 테스트 완료
- [ ] 코드 리뷰 준비 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving book stories of a specific member by nickname using a new "TARGET" scope.
  * Introduced the ability to check follow status between users when sharing member information.

* **Improvements**
  * Expanded book story listing options with additional scopes: "FOLLOWING" and "TARGET".
  * Controller endpoints now automatically inject the current member's ID for improved security and usability.
  * Standardized error handling with new error statuses for book story not found and unauthorized actions.

* **Bug Fixes**
  * Ensured proper assignment of member ID from authentication details in request handling.

* **API Changes**
  * Updated API parameters and documentation to reflect new scopes and required fields for book story retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->