### PR TITLE
Feat/32/email login

### DIFF
--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -30,7 +30,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CLUB_BOOK_RECOMMEND_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB_4014", "추천 책을 찾을 수 없습니다."),
     CLUB_BOOK_RECOMMEND_FORBIDDEN(HttpStatus.FORBIDDEN, "CLUB_4015", "해당 추천 책에 대한 권한이 없습니다."),
 
-    // 회원
+    // 이메일
     EMAIL_VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "EMAIL_401", "인증번호가 만료되었습니다."),
     EMAIL_VERIFICATION_CODE_INVALID(HttpStatus.BAD_REQUEST, "EMAIL_402", "잘못된 인증번호입니다."),
     EMAIL_VERIFICATION_CODE_ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "EMAIL_403", "이미 인증된 이메일입니다."),
@@ -43,12 +43,15 @@ public enum ErrorStatus implements BaseErrorCode {
     // 카테고리
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_4004", "카테고리를 찾을 수 없습니다."),
 
+    // 회원
     MEMBER_INACTIVE(HttpStatus.FORBIDDEN, "MEMBER_401", "비활성화된 회원입니다."),
     MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER402", "이미 존재하는 회원입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "해당 회원을 찾을 수 없습니다."),
     MEMBER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "MEMBER_403", "인증되지 않은 회원입니다."),
     MEMBER_PROFILE_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER_406", "이미 프로필이 완성된 회원입니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER_407", "이미 존재하는 닉네임입니다."),
+    MEMBER_PROFILE_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER_408", "프로필이 완성되지 않은 회원입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "MEMBER_409", "이메일 또는 비밀번호가 일치하지 않습니다."),
 
     // 한줄평
     BOOK_REVIEW_FORBIDDEN(HttpStatus.FORBIDDEN, "BOOK_REVIEW403", "이 한줄평에 대한 수정/삭제 권한이 없습니다."),

--- a/src/main/java/checkmo/config/SecurityConfig.java
+++ b/src/main/java/checkmo/config/SecurityConfig.java
@@ -22,10 +22,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ProfileCompletionAuthorizationFilter profileCompletionAuthorizationFilter;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http,
-                                           ProfileCompletionAuthorizationFilter profileCompletionAuthorizationFilter)
+    public SecurityFilterChain filterChain(HttpSecurity http)
         throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/checkmo/config/SecurityConfig.java
+++ b/src/main/java/checkmo/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package checkmo.config;
 
+import checkmo.domain.member.service.security.auth.ProfileCompletionAuthorizationFilter;
 import checkmo.domain.member.service.security.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -23,20 +24,26 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           ProfileCompletionAuthorizationFilter profileCompletionAuthorizationFilter)
+        throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
             .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용 안함
-                )
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용 안함
+            )
             .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**").permitAll() // Swagger UI 접근 허용
-                        .requestMatchers("/**").permitAll() // TODO: 로그인 구현 후 삭제 필수
-                    .requestMatchers("/api/auth/**").permitAll()
-                        .anyRequest().authenticated()
-                )
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class); // JWT 인증 필터 추가
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**")
+                .permitAll() // Swagger UI 접근 허용
+                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/api/auth/additional-info").authenticated()
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(jwtAuthenticationFilter,
+                UsernamePasswordAuthenticationFilter.class) // JWT 인증 필터 추가
+            .addFilterAfter(profileCompletionAuthorizationFilter,
+                JwtAuthenticationFilter.class); // 프로필 완료 필터 추가
 
         return http.build();
     }
@@ -47,7 +54,8 @@ public class SecurityConfig {
     }
 
     @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+    public AuthenticationManager authenticationManager(
+        AuthenticationConfiguration authenticationConfiguration) throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
     }
 }

--- a/src/main/java/checkmo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/checkmo/domain/member/converter/MemberConverter.java
@@ -50,6 +50,15 @@ public class MemberConverter {
     }
 
     /**
+     * Member 엔티티 → MemberLoginResponseDTO 변환
+     */
+    public static MemberResponseDTO.LoginResponseDTO fromMemberToLoginResponseDTO(Member member) {
+        return MemberResponseDTO.LoginResponseDTO.builder()
+                .nickname(member.getNickName())
+                .build();
+    }
+
+    /**
      * Member 엔티티 → MemberProfileResponseDTO 변환
      */
     public static MemberResponseDTO.MemberProfileResponseDTO toMemberProfileResponseDTO(Member member) {

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
@@ -31,6 +31,7 @@ public interface MemberCommandFacade {
      * 회원 가입 (내부용)
      *
      * @param request id,pw DTO
+     * @param response HttpServletResponse 객체
      * @return 회원 가입 응답 DTO
      */
     MemberResponseDTO.SignUpResponseDTO signUp(MemberRequestDTO.SignUpRequestDTO request, HttpServletResponse response);
@@ -46,10 +47,10 @@ public interface MemberCommandFacade {
     /**
      * 로그인 처리 (내부용)
      *
-     * @param email 사용자의 이메일
-     * @param password 사용자의 비밀번호
+     * @param request 로그인 요청 DTO
+     * @param response HttpServletResponse 객체
      */
-    void login(String email, String password, HttpServletResponse response);
+    void login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response);
 
     /**
      * 로그아웃 처리 (내부용)

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
@@ -50,7 +50,7 @@ public interface MemberCommandFacade {
      * @param request 로그인 요청 DTO
      * @param response HttpServletResponse 객체
      */
-    void login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response);
+    MemberResponseDTO.LoginResponseDTO login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response);
 
     /**
      * 로그아웃 처리 (내부용)

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
@@ -38,8 +38,8 @@ public class MemberCommandFacadeImpl implements MemberCommandFacade{
     }
 
     @Override
-    public void login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response) {
-        memberAuthenticationService.login(request, response);
+    public MemberResponseDTO.LoginResponseDTO login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response) {
+        return memberAuthenticationService.login(request, response);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
@@ -38,8 +38,8 @@ public class MemberCommandFacadeImpl implements MemberCommandFacade{
     }
 
     @Override
-    public void login(String email, String password, HttpServletResponse response) {
-        memberAuthenticationService.login(email, password, response);
+    public void login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response) {
+        memberAuthenticationService.login(request, response);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationService.java
+++ b/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationService.java
@@ -1,5 +1,6 @@
 package checkmo.domain.member.service.authenticate;
 
+import checkmo.domain.member.web.dto.MemberRequestDTO;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
@@ -14,10 +15,10 @@ public interface MemberAuthenticationService {
     /**
      * 로그인 처리
      *
-     * @param email 사용자의 이메일
-     * @param password 사용자의 비밀번호
+     * @param request 로그인 요청 DTO
+     * @param response HttpServletResponse 객체
      */
-    void login(String email, String password, HttpServletResponse response);
+    void login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response);
 
     /**
      * 로그아웃 처리 - JWT 토큰을 무효화하고 쿠키 삭제

--- a/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationService.java
+++ b/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationService.java
@@ -1,6 +1,7 @@
 package checkmo.domain.member.service.authenticate;
 
 import checkmo.domain.member.web.dto.MemberRequestDTO;
+import checkmo.domain.member.web.dto.MemberResponseDTO;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
@@ -18,7 +19,7 @@ public interface MemberAuthenticationService {
      * @param request 로그인 요청 DTO
      * @param response HttpServletResponse 객체
      */
-    void login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response);
+    MemberResponseDTO.LoginResponseDTO login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response);
 
     /**
      * 로그아웃 처리 - JWT 토큰을 무효화하고 쿠키 삭제

--- a/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationServiceImpl.java
@@ -2,12 +2,15 @@ package checkmo.domain.member.service.authenticate;
 
 import checkmo.apiPayload.code.status.ErrorStatus;
 import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.member.converter.MemberConverter;
+import checkmo.domain.member.entity.Member;
 import checkmo.domain.member.service.security.auth.PrincipalDetails;
 import checkmo.domain.member.service.security.jwt.JwtCookieUtil;
 import checkmo.domain.member.service.security.jwt.JwtToken;
 import checkmo.domain.member.service.security.jwt.JwtTokenProvider;
 import checkmo.domain.member.service.security.jwt.TokenCacheService;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
+import checkmo.domain.member.web.dto.MemberResponseDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -26,15 +29,16 @@ public class MemberAuthenticationServiceImpl implements MemberAuthenticationServ
     private final JwtCookieUtil jwtCookieUtil;
 
     @Override
-    public void login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response) {
+    public MemberResponseDTO.LoginResponseDTO login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response) {
 
         UsernamePasswordAuthenticationToken authenticationToken =
             new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
 
+        Authentication authentication;
+
         try {
             // 인증 요청
-            Authentication authentication =
-                authenticationManager.authenticate(authenticationToken);
+            authentication = authenticationManager.authenticate(authenticationToken);
 
             /// 인증 성공 후 SecurityContext에 인증 정보 저장
             SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -56,6 +60,10 @@ public class MemberAuthenticationServiceImpl implements MemberAuthenticationServ
             // 인증 실패 시 예외 처리
             throw new GeneralException(ErrorStatus.INVALID_CREDENTIALS, "이메일 또는 비밀번호가 일치하지 않습니다");
         }
+
+        // 인증 성공 후 MemberResponseDTO 반환
+        Member member = ((PrincipalDetails) authentication.getPrincipal()).getMember();
+        return MemberConverter.fromMemberToLoginResponseDTO(member);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationServiceImpl.java
@@ -1,7 +1,12 @@
 package checkmo.domain.member.service.authenticate;
 
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.member.service.security.auth.PrincipalDetails;
 import checkmo.domain.member.service.security.jwt.JwtToken;
 import checkmo.domain.member.service.security.jwt.JwtTokenProvider;
+import checkmo.domain.member.service.security.jwt.TokenCacheService;
+import checkmo.domain.member.web.dto.MemberRequestDTO;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,27 +22,36 @@ public class MemberAuthenticationServiceImpl implements MemberAuthenticationServ
 
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenCacheService tokenCacheService;
 
     @Override
-    public void login(String email, String password, HttpServletResponse response) {
+    public void login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response) {
 
         UsernamePasswordAuthenticationToken authenticationToken =
-            new UsernamePasswordAuthenticationToken(email, password);
+            new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword());
 
-        // 인증 요청
-        Authentication authentication =
-            authenticationManager.authenticate(authenticationToken);
+        try {
+            // 인증 요청
+            Authentication authentication =
+                authenticationManager.authenticate(authenticationToken);
 
-        /// 인증 성공 후 SecurityContext에 인증 정보 저장
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+            /// 인증 성공 후 SecurityContext에 인증 정보 저장
+            SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        // JWT 토큰 생성
-        JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
+            // JWT 토큰 생성
+            JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
 
-        addTokenToCookie(response, "accessToken", jwtToken.getAccessToken(), 2 * 60 * 60); // 2시간 유효
-        addTokenToCookie(response, "refreshToken", jwtToken.getRefreshToken(), 14 * 24 * 60 * 60); // 14일 유효
+            addTokenToCookie(response, "accessToken", jwtToken.getAccessToken(), 2 * 60 * 60); // 2시간 유효
+            addTokenToCookie(response, "refreshToken", jwtToken.getRefreshToken(), 14 * 24 * 60 * 60); // 14일 유효
 
-        // TODO: Redis에 리프레시 토큰 저장 로직 추가
+            // RefreshToken Redis에 저장
+            String memberId = ((PrincipalDetails) authentication.getPrincipal()).getMember().getId();
+            tokenCacheService.saveRefreshToken(memberId, jwtToken.getRefreshToken());
+
+        } catch (Exception e) {
+            // 인증 실패 시 예외 처리
+            throw new GeneralException(ErrorStatus.INVALID_CREDENTIALS, "이메일 또는 비밀번호가 일치하지 않습니다");
+        }
     }
 
     @Override
@@ -57,5 +71,6 @@ public class MemberAuthenticationServiceImpl implements MemberAuthenticationServ
         cookie.setPath("/"); // 모든 경로에서 접근 가능
         cookie.setMaxAge(maxAge);
         response.addCookie(cookie);
+        // TODO: 배포 시 cookie.setSecure(true); // HTTPS에서만 전송하도록 추가
     }
 }

--- a/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationServiceImpl.java
@@ -8,7 +8,6 @@ import checkmo.domain.member.service.security.jwt.JwtToken;
 import checkmo.domain.member.service.security.jwt.JwtTokenProvider;
 import checkmo.domain.member.service.security.jwt.TokenCacheService;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -43,8 +42,11 @@ public class MemberAuthenticationServiceImpl implements MemberAuthenticationServ
             // JWT 토큰 생성
             JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
 
-            jwtCookieUtil.addTokenToCookie(response, "accessToken", jwtToken.getAccessToken(), 2 * 60 * 60); // 2시간 유효
-            jwtCookieUtil.addTokenToCookie(response, "refreshToken", jwtToken.getRefreshToken(), 14 * 24 * 60 * 60); // 14일 유효
+            int accessTokenMaxAge = (int) (jwtTokenProvider.getAccessTokenExpirationTime() / 1000L); // ms → sec
+            int refreshTokenMaxAge = (int) (jwtTokenProvider.getRefreshTokenExpirationTime() / 1000L);
+
+            jwtCookieUtil.addTokenToCookie(response, "accessToken", jwtToken.getAccessToken(), accessTokenMaxAge);
+            jwtCookieUtil.addTokenToCookie(response, "refreshToken", jwtToken.getRefreshToken(), refreshTokenMaxAge);
 
             // RefreshToken Redis에 저장
             String memberId = ((PrincipalDetails) authentication.getPrincipal()).getMember().getId();

--- a/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationServiceImpl.java
@@ -3,6 +3,7 @@ package checkmo.domain.member.service.authenticate;
 import checkmo.apiPayload.code.status.ErrorStatus;
 import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.member.service.security.auth.PrincipalDetails;
+import checkmo.domain.member.service.security.jwt.JwtCookieUtil;
 import checkmo.domain.member.service.security.jwt.JwtToken;
 import checkmo.domain.member.service.security.jwt.JwtTokenProvider;
 import checkmo.domain.member.service.security.jwt.TokenCacheService;
@@ -23,6 +24,7 @@ public class MemberAuthenticationServiceImpl implements MemberAuthenticationServ
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenCacheService tokenCacheService;
+    private final JwtCookieUtil jwtCookieUtil;
 
     @Override
     public void login(MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response) {
@@ -41,8 +43,8 @@ public class MemberAuthenticationServiceImpl implements MemberAuthenticationServ
             // JWT 토큰 생성
             JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
 
-            addTokenToCookie(response, "accessToken", jwtToken.getAccessToken(), 2 * 60 * 60); // 2시간 유효
-            addTokenToCookie(response, "refreshToken", jwtToken.getRefreshToken(), 14 * 24 * 60 * 60); // 14일 유효
+            jwtCookieUtil.addTokenToCookie(response, "accessToken", jwtToken.getAccessToken(), 2 * 60 * 60); // 2시간 유효
+            jwtCookieUtil.addTokenToCookie(response, "refreshToken", jwtToken.getRefreshToken(), 14 * 24 * 60 * 60); // 14일 유효
 
             // RefreshToken Redis에 저장
             String memberId = ((PrincipalDetails) authentication.getPrincipal()).getMember().getId();
@@ -62,15 +64,5 @@ public class MemberAuthenticationServiceImpl implements MemberAuthenticationServ
     @Override
     public void reactivateMember() {
         // TODO: 계정 복구 로직 구현
-    }
-
-    private void addTokenToCookie(HttpServletResponse response, String cookieName, String token, int maxAge) {
-        Cookie cookie = new Cookie(cookieName, token);
-        cookie.setHttpOnly(true); // 클라이언트 스크립트에서 접근 불가
-        cookie.setAttribute("SameSite", "Strict"); // CSRF 공격 방지
-        cookie.setPath("/"); // 모든 경로에서 접근 가능
-        cookie.setMaxAge(maxAge);
-        response.addCookie(cookie);
-        // TODO: 배포 시 cookie.setSecure(true); // HTTPS에서만 전송하도록 추가
     }
 }

--- a/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandService.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandService.java
@@ -43,6 +43,7 @@ public interface MemberRegistrationCommandService {
      *  - 추가 정보 입력 안받으면 정식 회원 아님
      *
      * @param request id,pw DTO
+     * @param response HttpServletResponse 객체
      * @return 회원 가입 응답 DTO
      */
     MemberResponseDTO.SignUpResponseDTO signUp(

--- a/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberRegistrationCommandServiceImpl.java
@@ -11,6 +11,7 @@ import checkmo.domain.member.service.common.EmailSender;
 import checkmo.domain.member.service.query.MemberQueryService;
 import checkmo.domain.member.service.security.auth.PrincipalDetails;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
+import checkmo.domain.member.web.dto.MemberRequestDTO.LoginRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
 import checkmo.global.dto.CategorySharedDTO;
 import jakarta.servlet.http.HttpServletResponse;
@@ -128,7 +129,9 @@ public class MemberRegistrationCommandServiceImpl implements MemberRegistrationC
         memberRepository.save(newMember);
         redisTemplate.delete(redisKey); // 회원가입 후 인증 정보 삭제
 
-        memberAuthenticationService.login(request.getEmail(), request.getPassword(), response);
+        MemberRequestDTO.LoginRequestDTO loginRequest = new LoginRequestDTO(request.getEmail(), request.getPassword());
+
+        memberAuthenticationService.login(loginRequest, response);
 
         return MemberConverter.fromMember(newMember);
     }
@@ -145,8 +148,14 @@ public class MemberRegistrationCommandServiceImpl implements MemberRegistrationC
         }
 
         // 사용자 정보 추출
-        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
-        String memberId = principalDetails.getMember().getId();
+        Object principal = authentication.getPrincipal();
+
+        // PrincipalDetails 타입으로 캐스팅
+        if (!(principal instanceof PrincipalDetails)) {
+            throw new GeneralException(ErrorStatus.MEMBER_UNAUTHORIZED);
+        }
+
+        String memberId = ((PrincipalDetails) principal).getMember().getId();
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));

--- a/src/main/java/checkmo/domain/member/service/security/auth/ProfileCompletionAuthorizationFilter.java
+++ b/src/main/java/checkmo/domain/member/service/security/auth/ProfileCompletionAuthorizationFilter.java
@@ -1,0 +1,77 @@
+package checkmo.domain.member.service.security.auth;
+
+import checkmo.apiPayload.ApiResponse;
+import checkmo.apiPayload.code.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+public class ProfileCompletionAuthorizationFilter extends OncePerRequestFilter {
+
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    private final List<String> excludedPaths = List.of(
+        "/api/auth/logout",
+        "/api/auth/additional-info"
+    );
+
+    @Override
+    protected boolean shouldNotFilter(@Nonnull HttpServletRequest request) {
+        return excludedPaths.stream()
+                            .anyMatch(path -> pathMatcher.match(path, request.getRequestURI()));
+    }
+
+    @Override
+    protected void doFilterInternal(@Nonnull HttpServletRequest request,
+                                    @Nonnull HttpServletResponse response,
+                                    @Nonnull FilterChain filterChain)
+        throws ServletException, IOException {
+
+        // 현재 인증 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated()
+            && authentication.getPrincipal() instanceof PrincipalDetails principalDetails) {
+
+            //  프로필이 완료되지 않은 회원은 에러
+            if (!principalDetails.getMember().isProfileCompleted()) {
+                log.warn("프로필 미완료 회원 접근 차단: {}, 요청 URI: {}",
+                    principalDetails.getMember().getId(), request.getRequestURI());
+                sendErrorResponse(response);
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void sendErrorResponse(HttpServletResponse response) throws IOException {
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+
+        ApiResponse<Object> errorResponse = ApiResponse.onFailure(
+            ErrorStatus.MEMBER_PROFILE_NOT_COMPLETED.getCode(),
+            ErrorStatus.MEMBER_PROFILE_NOT_COMPLETED.getMessage(),
+            null
+        );
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtAuthenticationFilter.java
@@ -31,6 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final TokenCacheService tokenCacheService;
+    private final JwtCookieUtil jwtCookieUtil;
 
     @Override
     protected void doFilterInternal(@Nonnull HttpServletRequest request,
@@ -103,7 +104,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 이제 새로운 Access Token을 쿠키에 담기
         String newAccessToken = newJwtToken.getAccessToken();
-        addTokenToCookie(response, "accessToken", newAccessToken, 2 * 60 * 60); // 2시간 유효
+        jwtCookieUtil.addTokenToCookie(response, "accessToken", newAccessToken, 2 * 60 * 60); // 2시간 유효
 
         // SecurityContext에 새로운 인증 정보 설정
         SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -122,14 +123,4 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return null; // 쿠키에서 Access Token을 찾지 못한 경우
     }
 
-    // TODO: 공통 메서드 분리시키기
-    private void addTokenToCookie(HttpServletResponse response, String cookieName, String token,
-                                  int maxAge) {
-        Cookie cookie = new Cookie(cookieName, token);
-        cookie.setHttpOnly(true); // 클라이언트 스크립트에서 접근 불가
-        cookie.setAttribute("SameSite", "Strict"); // CSRF 공격 방지
-        cookie.setPath("/"); // 모든 경로에서 접근 가능
-        cookie.setMaxAge(maxAge);
-        response.addCookie(cookie);
-    }
 }

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtAuthenticationFilter.java
@@ -104,7 +104,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 이제 새로운 Access Token을 쿠키에 담기
         String newAccessToken = newJwtToken.getAccessToken();
-        jwtCookieUtil.addTokenToCookie(response, "accessToken", newAccessToken, 2 * 60 * 60); // 2시간 유효
+
+        int accessTokenMaxAge = (int) (jwtTokenProvider.getAccessTokenExpirationTime() / 1000L);
+        jwtCookieUtil.addTokenToCookie(response, "accessToken", newAccessToken, accessTokenMaxAge); // 2시간 유효
 
         // SecurityContext에 새로운 인증 정보 설정
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtAuthenticationFilter.java
@@ -42,58 +42,61 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String accessToken = resolveToken(request, "accessToken");
         log.info("[JWT 필터] 요청 URI: {}, Access Token 존재 여부 확인: {}", request.getRequestURI(), accessToken != null);
 
-        try {
-            if (StringUtils.hasText(accessToken) && jwtTokenProvider.validateToken(accessToken)) {
-                log.info("[JWT 필터] 유효한 Access Token 발견: {}", accessToken);
+        if (StringUtils.hasText(accessToken))  { // Access Token이 존재하는 경우
+            try {
+                if (jwtTokenProvider.validateToken(accessToken)) { // Access Token 유효성 검사
 
-                // 토큰이 유효한 경우 인증 정보 설정
-                Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            } else {
-                log.warn("[JWT 필터] 유효하지 않거나 만료된 Access Token");
+                    // Access Token이 유효한 경우, 인증 정보 설정
+                    Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                    log.info("[JWT 필터] Access Token 유효성 검사 통과");
+                }
+            } catch (ExpiredJwtException e) { // Access Token이 존재하지만 만료된 경우
+                log.warn("[JWT 필터] Access Token 만료됨: {}", e.getMessage());
+                reissueAccessToken(request, response); // Refresh Token을 사용해 Access Token 재발급 시도
             }
-        } catch (ExpiredJwtException e) { // Access Token 만료 되었으면 재발급
-            log.info("만료된 Access Token, Refresh Token으로 재발급 시도: {}", e.getMessage());
-            reissueAccessToken(request, response, accessToken, e);
+        } else { // Access Token이 존재하지 않는 경우
+            log.warn("[JWT 필터] Access Token이 존재하지 않음");
+            reissueAccessToken(request, response); // Refresh Token을 사용해 Access Token 재발급 시도
         }
 
-        filterChain.doFilter(request, response);
+        filterChain.doFilter(request, response); // 다음 필터로 요청 전달
     }
 
-    private void reissueAccessToken(HttpServletRequest request, HttpServletResponse response,
-                                    String expiredAccessToken,
-                                    ExpiredJwtException e) {
-
-        // 사용자 식별 정보 추출
-        String memberId = e.getClaims().getSubject();
-        log.info("[재발급] memberId 추출: {}", memberId);
+    // Access Token이 만료된 경우, Refresh Token을 사용해 재발급
+    private void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
 
         // 쿠키에서 Refresh Token 추출
         String refreshToken = resolveToken(request, "refreshToken");
         log.info("[재발급] Refresh Token 존재 여부 확인: {}", refreshToken != null);
 
         if (!StringUtils.hasText(refreshToken)) {
-            log.warn("재발급 실패: Refresh Token 쿠키 없음 (memberId={})", memberId);
+            log.warn("재발급 실패: Refresh Token 쿠키 없음");
+            return;
+        }
+
+        if (!jwtTokenProvider.isRefreshTokenValid(refreshToken)) {
+            log.warn("재발급 실패: 유효하지 않은 Refresh Token");
+            return;
+        }
+
+        String memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+        if(!StringUtils.hasText(memberId)) {
+            log.warn("재발급 실패: Refresh Token에서 memberId 추출 실패");
             return;
         }
 
         // Redis에 저장된 Refresh Token과 비교
         String storedRefreshToken = tokenCacheService.getRefreshToken(memberId);
-        log.info("[재발급] Redis에 저장된 Refresh Token: {}", storedRefreshToken);
+        log.info("[재발급] Redis에 저장된 Refresh Token과 비교");
 
         if (!refreshToken.equals(storedRefreshToken)) {
             log.warn("재발급 실패: 저장된 Refresh Token과 일치하지 않음 (memberId={})", memberId);
             return;
         }
 
-        // Refresh Token 유효성 검사 (만료 되었는지)
-        if (!jwtTokenProvider.isRefreshTokenValid(refreshToken)) {
-            log.warn("재발급 실패: Refresh Token 만료됨 (memberId={})", memberId);
-            return;
-        }
-
-        // 만료된 Access Token으로 인증 객체 생성
-        Authentication authentication = jwtTokenProvider.getAuthentication(expiredAccessToken);
+        // Refresh Token이 유효한 경우, 해당 memberId로 인증 정보 가져오기
+        Authentication authentication = jwtTokenProvider.getAuthenticationFromMemberId(memberId);
 
         // 그리고 새로운 Access Token 생성
         JwtToken newJwtToken = jwtTokenProvider.generateToken(authentication);

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package checkmo.domain.member.service.security.jwt;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.annotation.Nonnull;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -8,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -17,18 +19,18 @@ import org.springframework.web.filter.OncePerRequestFilter;
 /**
  * JWT 토큰 기반 인증 필터
  *
- * 모든 HTTP 요청에 대해 쿠키에서 JWT 토큰을 추출하고 토큰 검증
- * 액세스 토큰 만료시 리프레시 토큰으로 자동 갱신
- * 토큰 검증 성공시 SecurityContext에 인증 정보 설정
- * JwtTokenProvider 사용해서 토큰 검증 로직 처리
- * -> JwtAuthenticationFilter에서는 토큰을 직접 검증하지 않음. JwtTokenProvider에서 토큰 검증 로직 구현
+ * 모든 HTTP 요청에 대해 쿠키에서 JWT 토큰을 추출하고 토큰 검증 액세스 토큰 만료시 리프레시 토큰으로 자동 갱신 토큰 검증 성공시 SecurityContext에 인증
+ * 정보 설정 JwtTokenProvider 사용해서 토큰 검증 로직 처리 -> JwtAuthenticationFilter에서는 토큰을 직접 검증하지 않음.
+ * JwtTokenProvider에서 토큰 검증 로직 구현
  */
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenCacheService tokenCacheService;
 
     @Override
     protected void doFilterInternal(@Nonnull HttpServletRequest request,
@@ -36,24 +38,95 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     @Nonnull FilterChain filterChain)
         throws ServletException, IOException {
 
-        String token = resolveToken(request);
-        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-            // 토큰이 유효한 경우 인증 정보 설정
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        // 쿠키에서 Access Token 추출
+        String accessToken = resolveToken(request, "accessToken");
+        log.info("[JWT 필터] 요청 URI: {}, Access Token 존재 여부 확인: {}", request.getRequestURI(), accessToken != null);
+
+        try {
+            if (StringUtils.hasText(accessToken) && jwtTokenProvider.validateToken(accessToken)) {
+                log.info("[JWT 필터] 유효한 Access Token 발견: {}", accessToken);
+
+                // 토큰이 유효한 경우 인증 정보 설정
+                Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } else {
+                log.warn("[JWT 필터] 유효하지 않거나 만료된 Access Token");
+            }
+        } catch (ExpiredJwtException e) { // Access Token 만료 되었으면 재발급
+            log.info("만료된 Access Token, Refresh Token으로 재발급 시도: {}", e.getMessage());
+            reissueAccessToken(request, response, accessToken, e);
         }
+
         filterChain.doFilter(request, response);
     }
 
-    private String resolveToken(HttpServletRequest request) {
+    private void reissueAccessToken(HttpServletRequest request, HttpServletResponse response,
+                                    String expiredAccessToken,
+                                    ExpiredJwtException e) {
+
+        // 사용자 식별 정보 추출
+        String memberId = e.getClaims().getSubject();
+        log.info("[재발급] memberId 추출: {}", memberId);
+
+        // 쿠키에서 Refresh Token 추출
+        String refreshToken = resolveToken(request, "refreshToken");
+        log.info("[재발급] Refresh Token 존재 여부 확인: {}", refreshToken != null);
+
+        if (!StringUtils.hasText(refreshToken)) {
+            log.warn("재발급 실패: Refresh Token 쿠키 없음 (memberId={})", memberId);
+            return;
+        }
+
+        // Redis에 저장된 Refresh Token과 비교
+        String storedRefreshToken = tokenCacheService.getRefreshToken(memberId);
+        log.info("[재발급] Redis에 저장된 Refresh Token: {}", storedRefreshToken);
+
+        if (!refreshToken.equals(storedRefreshToken)) {
+            log.warn("재발급 실패: 저장된 Refresh Token과 일치하지 않음 (memberId={})", memberId);
+            return;
+        }
+
+        // Refresh Token 유효성 검사 (만료 되었는지)
+        if (!jwtTokenProvider.isRefreshTokenValid(refreshToken)) {
+            log.warn("재발급 실패: Refresh Token 만료됨 (memberId={})", memberId);
+            return;
+        }
+
+        // 만료된 Access Token으로 인증 객체 생성
+        Authentication authentication = jwtTokenProvider.getAuthentication(expiredAccessToken);
+
+        // 그리고 새로운 Access Token 생성
+        JwtToken newJwtToken = jwtTokenProvider.generateToken(authentication);
+
+        // 이제 새로운 Access Token을 쿠키에 담기
+        String newAccessToken = newJwtToken.getAccessToken();
+        addTokenToCookie(response, "accessToken", newAccessToken, 2 * 60 * 60); // 2시간 유효
+
+        // SecurityContext에 새로운 인증 정보 설정
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.info("Access Token 재발급 성공: 새로운 Access Token 생성 (memberId={})", memberId);
+    }
+
+    private String resolveToken(HttpServletRequest request, String cookieName) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                if ("accessToken".equals(cookie.getName())) {
+                if (cookieName.equals(cookie.getName())) {
                     return cookie.getValue();
                 }
             }
         }
-        return null; // 쿠키에서 accessToken을 찾지 못한 경우
+        return null; // 쿠키에서 Access Token을 찾지 못한 경우
+    }
+
+    // TODO: 공통 메서드 분리시키기
+    private void addTokenToCookie(HttpServletResponse response, String cookieName, String token,
+                                  int maxAge) {
+        Cookie cookie = new Cookie(cookieName, token);
+        cookie.setHttpOnly(true); // 클라이언트 스크립트에서 접근 불가
+        cookie.setAttribute("SameSite", "Strict"); // CSRF 공격 방지
+        cookie.setPath("/"); // 모든 경로에서 접근 가능
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
     }
 }

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtCookieUtil.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtCookieUtil.java
@@ -1,0 +1,19 @@
+package checkmo.domain.member.service.security.jwt;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtCookieUtil {
+
+    public void addTokenToCookie(HttpServletResponse response, String cookieName, String token, int maxAge) {
+        Cookie cookie = new Cookie(cookieName, token);
+        cookie.setHttpOnly(true); // 클라이언트 스크립트에서 접근 불가
+        cookie.setAttribute("SameSite", "Strict"); // CSRF 공격 방지
+        cookie.setPath("/"); // 모든 경로에서 접근 가능
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+        // TODO: 배포 시 cookie.setSecure(true); // HTTPS에서만 전송하도록 추가
+    }
+}

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtToken.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtToken.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class JwtToken {
-    private String grantType; // Bearer
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProvider.java
@@ -16,4 +16,5 @@ public interface JwtTokenProvider {
     boolean validateToken(String token);
     String getUserIdFromToken(String token);
     boolean isRefreshTokenValid(String refreshToken);
+    Authentication getAuthenticationFromMemberId(String memberId);
 }

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProvider.java
@@ -15,4 +15,5 @@ public interface JwtTokenProvider {
     Authentication getAuthentication(String accessToken);
     boolean validateToken(String token);
     String getUserIdFromToken(String token);
+    boolean isRefreshTokenValid(String refreshToken);
 }

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProvider.java
@@ -17,4 +17,6 @@ public interface JwtTokenProvider {
     String getUserIdFromToken(String token);
     boolean isRefreshTokenValid(String refreshToken);
     Authentication getAuthenticationFromMemberId(String memberId);
+    long getAccessTokenExpirationTime();
+    long getRefreshTokenExpirationTime();
 }

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProviderImpl.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProviderImpl.java
@@ -1,6 +1,7 @@
 package checkmo.domain.member.service.security.jwt;
 
 import checkmo.config.properties.JwtProperties;
+import checkmo.config.properties.MailProperties.Auth;
 import checkmo.domain.member.service.security.auth.CustomUserDetailsService;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -18,6 +19,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Component
@@ -60,6 +62,7 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
 
         // 리프레시 토큰 생성
         String refreshToken = Jwts.builder()
+                                  .subject(authentication.getName())
                                   .expiration(new Date(now + refreshTokenValidity))
                                   .signWith(key)
                                   .compact();
@@ -81,6 +84,12 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
 
     @Override
     public boolean validateToken(String token) {
+
+        if (!StringUtils.hasText(token)) {
+            log.warn("JWT 토큰이 null 입니다.");
+            return false;
+        }
+
         try {
             // TODO: 로그아웃 시 토큰 블랙리스트 검증 로직 추가
             Jwts.parser()
@@ -127,5 +136,14 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
         } catch (ExpiredJwtException e) {
             return e.getClaims().getSubject();
         }
+    }
+
+    @Override
+    public Authentication getAuthenticationFromMemberId(String memberId) {
+        UserDetails userDetails = customUserDetailsService.loadUserById(memberId);
+
+        return new UsernamePasswordAuthenticationToken(
+            userDetails, null, userDetails.getAuthorities()
+        );
     }
 }

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProviderImpl.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProviderImpl.java
@@ -47,8 +47,8 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
         long now = (new Date()).getTime();
 
         // 액세스 토큰과 리프레시 토큰 유효 시간 가져오기
-        long accessTokenValidity = jwtProperties.getTokenValidity().getAccessToken() * 1000;
-        long refreshTokenValidity = jwtProperties.getTokenValidity().getRefreshToken() * 1000;
+        long accessTokenValidity = jwtProperties.getTokenValidity().getAccessToken();
+        long refreshTokenValidity = jwtProperties.getTokenValidity().getRefreshToken();
 
         // 액세스 토큰 생성
         String accessToken = Jwts.builder()
@@ -65,7 +65,6 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
                                   .compact();
 
         return JwtToken.builder()
-                       .grantType("Bearer")
                        .accessToken(accessToken)
                        .refreshToken(refreshToken)
                        .build();
@@ -89,16 +88,31 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
                 .build()
                 .parseSignedClaims(token);
             return true;
-        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.warn("잘못된 JWT 서명입니다.", e);
         } catch (ExpiredJwtException e) {
-            log.warn("만료된 JWT 서명입니다", e);
+            throw e; // 토큰이 만료된 경우 재발급하도록 던지기
+        }
+        catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.warn("잘못된 JWT 서명입니다.", e);
         } catch (UnsupportedJwtException e) {
             log.warn("지원하지 않는 JWT 토큰입니다", e);
         } catch (IllegalArgumentException e) {
             log.warn("JWT 토큰이 잘못되었습니다", e);
         }
         return false;
+    }
+
+    @Override
+    public boolean isRefreshTokenValid(String refreshToken) {
+        try {
+            Jwts.parser()
+                .verifyWith((SecretKey) key)
+                .build()
+                .parseSignedClaims(refreshToken);
+            return true;
+        } catch (Exception e) {
+            log.warn("유효하지 않은 Refresh Token 입니다: {}", e.getMessage());
+            return false;
+        }
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProviderImpl.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtTokenProviderImpl.java
@@ -146,4 +146,14 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
             userDetails, null, userDetails.getAuthorities()
         );
     }
+
+    @Override
+    public long getAccessTokenExpirationTime() {
+        return jwtProperties.getTokenValidity().getAccessToken();
+    }
+
+    @Override
+    public long getRefreshTokenExpirationTime() {
+        return jwtProperties.getTokenValidity().getRefreshToken();
+    }
 }

--- a/src/main/java/checkmo/domain/member/service/security/jwt/TokenCacheService.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/TokenCacheService.java
@@ -15,7 +15,7 @@ public class TokenCacheService {
 
     @CachePut(value = "refreshToken", key = "#memberId")
     public String saveRefreshToken(String memberId, String refreshToken) {
-        log.info("리프레시 토큰 저장 - memberId={}, refreshToken={}", memberId, refreshToken);
+        log.info("리프레시 토큰 저장 - memberId={}", memberId);
         return refreshToken;
     }
 

--- a/src/main/java/checkmo/domain/member/service/security/jwt/TokenCacheService.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/TokenCacheService.java
@@ -1,0 +1,27 @@
+package checkmo.domain.member.service.security.jwt;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @CachePut(value = "refreshToken", key = "#memberId")
+    public String saveRefreshToken(String memberId, String refreshToken) {
+        log.info("리프레시 토큰 저장 - memberId={}, refreshToken={}", memberId, refreshToken);
+        return refreshToken;
+    }
+
+    // 이건 Redis에서 직접 조회하는 메서드로, @Cacheable을 사용하지 않고 RedisTemplate을 통해 조회
+    public String getRefreshToken(String memberId) {
+        log.info("리프레시 토큰 조회 - memberId={}", memberId);
+        return (String) redisTemplate.opsForValue().get("refreshToken::" + memberId);
+    }
+}

--- a/src/main/java/checkmo/domain/member/web/controller/AuthController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/AuthController.java
@@ -77,9 +77,8 @@ public class AuthController {
     // 이메일 로그인
     @Operation(summary = "이메일 로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @PostMapping("/login")
-    public ApiResponse<Void> login(@Valid @RequestBody MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response) {
-        memberCommandFacade.login(request, response);
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<MemberResponseDTO.LoginResponseDTO> login(@Valid @RequestBody MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response) {
+        return ApiResponse.onSuccess(memberCommandFacade.login(request, response));
     }
 
     // 소셜 로그인 관련

--- a/src/main/java/checkmo/domain/member/web/controller/AuthController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/AuthController.java
@@ -64,8 +64,6 @@ public class AuthController {
         return ApiResponse.onSuccess(null);
     }
 
-    // 회원가입 관련
-
     // 닉네임 중복 확인
     @Operation(summary = "닉네임 중복 확인", description = "회원가입 시 닉네임 중복을 확인합니다.")
     @PostMapping("/check-nickname")
@@ -76,8 +74,13 @@ public class AuthController {
         return ApiResponse.onSuccess(isDuplicated);
     }
 
-
-    // POST /api/auth/additional-info - 회원 추가 정보 입력
+    // 이메일 로그인
+    @Operation(summary = "이메일 로그인", description = "이메일과 비밀번호로 로그인합니다.")
+    @PostMapping("/login")
+    public ApiResponse<Void> login(@Valid @RequestBody MemberRequestDTO.LoginRequestDTO request, HttpServletResponse response) {
+        memberCommandFacade.login(request, response);
+        return ApiResponse.onSuccess(null);
+    }
 
     // 소셜 로그인 관련
     // GET /api/auth/oauth2/google - 소셜 로그인 (구글)

--- a/src/main/java/checkmo/domain/member/web/dto/MemberRequestDTO.java
+++ b/src/main/java/checkmo/domain/member/web/dto/MemberRequestDTO.java
@@ -2,6 +2,7 @@ package checkmo.domain.member.web.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -75,5 +76,19 @@ public class MemberRequestDTO {
 
         @NotEmpty(message = "관심 카테고리는 최소 1개 이상 선택해야 합니다")
         private List<Long> categoryIds;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LoginRequestDTO {
+        @NotBlank(message = "이메일은 필수입니다")
+        @Email(message = "유효한 이메일 형식이 아닙니다")
+        private String email;
+
+        @NotBlank(message = "비밀번호는 필수입니다")
+        @Size(min = 6, max = 10, message = "비밀번호는 6-10자여야 합니다")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^&*]).*$", message = "비밀번호는 영어 및 특수문자를 포함해야 합니다")
+        private String password;
     }
 }

--- a/src/main/java/checkmo/domain/member/web/dto/MemberResponseDTO.java
+++ b/src/main/java/checkmo/domain/member/web/dto/MemberResponseDTO.java
@@ -91,4 +91,12 @@ public class MemberResponseDTO {
         private LocalDateTime createdAt;
         private boolean isLiked; // 조회하는 사람의 좋아요 여부
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class LoginResponseDTO {
+        private String nickname;
+    }
 }

--- a/src/main/java/checkmo/global/auth/CurrentMemberArgumentResolver.java
+++ b/src/main/java/checkmo/global/auth/CurrentMemberArgumentResolver.java
@@ -49,7 +49,7 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
         String memberId = null;
         if (authentication.getPrincipal() instanceof PrincipalDetails) {
             PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
-//            memberId = principalDetails.getUsername(); //‼️TODO: PrincipalDetails 완성하고 반드시 주석 해야함!!!!‼️
+            memberId = principalDetails.getUsername(); //‼️TODO: PrincipalDetails 완성하고 반드시 주석 해야함!!!!‼️
         }
 
         if (memberId == null) {
@@ -66,7 +66,7 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
         // @CurrentUser인 경우 User 객체 반환
         if (parameter.getParameterAnnotation(CurrentMember.class) != null) {
             Member currentUser = memberRepository.findById(memberId)
-                    .orElse(null);
+                                                 .orElse(null);
 
             if (currentUser != null) {
                 log.info("User 객체 주입: {}", currentUser.getId());


### PR DESCRIPTION
## 🚀 변경사항
JWT 기반 이메일 로그인 기능 구현
- 로그인 성공 시 Access Token, Refresh Token 발급 후 쿠키 저장
- Redis에 Refresh Token 저장
- Access Token 만료/누락 시 Refresh Token으로 자동 재발급
- 프로필 추가 정보 미입력한 회원 차단 필터 추가

## 🔗 관련 이슈
- Closes #32 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added login via email and password with a new API endpoint.
  * Introduced automatic access token renewal using refresh tokens for seamless authentication.
  * Added enforcement: users must complete their profile before accessing most endpoints.
  * Implemented secure handling and storage of JWT tokens in cookies and Redis.

* **Bug Fixes**
  * Improved error categorization and messages for email and member-related authentication issues.

* **Refactor**
  * Unified login request handling using a dedicated data transfer object (DTO).
  * Enhanced security configuration and token management for better reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->