### PR TITLE
Feat/38/logout

### DIFF
--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -65,6 +65,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER_407", "이미 존재하는 닉네임입니다."),
     MEMBER_PROFILE_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER_408", "프로필이 완성되지 않은 회원입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "MEMBER_409", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER_500", "서버 내부 오류입니다. 관리자에게 문의 바랍니다."),
 
     // 한줄평
     BOOK_REVIEW_FORBIDDEN(HttpStatus.FORBIDDEN, "BOOK_REVIEW403", "이 한줄평에 대한 수정/삭제 권한이 없습니다."),

--- a/src/main/java/checkmo/config/RedisConfig.java
+++ b/src/main/java/checkmo/config/RedisConfig.java
@@ -80,7 +80,7 @@ public class RedisConfig {
         Map<String, RedisCacheConfiguration> cacheConfigurations = Map.of(
                 "emailVerification", defaultConfig.entryTtl(Duration.ofMinutes(10)),
                 "refreshToken", defaultConfig.entryTtl(Duration.ofDays(14)),
-                "blacklist", defaultConfig.entryTtl(Duration.ofDays(7)), //TODO: 블랙리스트 TTL 설정기간은 Access Token과 동일하게 설정해주기!!
+                "blacklist", defaultConfig.entryTtl(Duration.ofHours(2)),
                 "notifications", defaultConfig.entryTtl(Duration.ofHours(6))  // 읽지 않은 알림 캐시
         );
 

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
@@ -2,6 +2,7 @@ package checkmo.domain.member.facade;
 
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
@@ -55,9 +56,9 @@ public interface MemberCommandFacade {
     /**
      * 로그아웃 처리 (내부용)
      *
-     * @param token 로그아웃할 JWT 토큰
+     * //@param token 로그아웃할 JWT 토큰
      */
-    void logout(String token);
+    void logout(HttpServletRequest request, HttpServletResponse response);
 
     /**
      * 회원 계정 복구 (내부용)

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
@@ -56,7 +56,8 @@ public interface MemberCommandFacade {
     /**
      * 로그아웃 처리 (내부용)
      *
-     * //@param token 로그아웃할 JWT 토큰
+     * @param request HttpServletRequest 객체
+     * @param response HttpServletResponse 객체
      */
     void logout(HttpServletRequest request, HttpServletResponse response);
 

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
@@ -4,6 +4,7 @@ import checkmo.domain.member.service.authenticate.MemberAuthenticationService;
 import checkmo.domain.member.service.command.MemberRegistrationCommandService;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,8 +44,8 @@ public class MemberCommandFacadeImpl implements MemberCommandFacade{
     }
 
     @Override
-    public void logout(String token) {
-        throw new UnsupportedOperationException("추후 구현 예정");
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
+        memberAuthenticationService.logout(request, response);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationService.java
+++ b/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationService.java
@@ -27,7 +27,8 @@ public interface MemberAuthenticationService {
      * 계정 복구를 원치 않는 경우에도 다시 사용하기
      * -> NO를 누름 -> AccessToken, RefreshToken 모두 삭제하고 탈퇴 상태 유지(아무것도 안해줘도 됨)
      *
-     * //@param token 로그아웃할 JWT 토큰 -> redis Blacklist에 저장하여 무효화
+     * @param request HttpServletRequest 객체
+     * @param response HttpServletResponse 객체
      */
     void logout(HttpServletRequest request, HttpServletResponse response);
 

--- a/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationService.java
+++ b/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationService.java
@@ -2,6 +2,7 @@ package checkmo.domain.member.service.authenticate;
 
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
@@ -26,9 +27,9 @@ public interface MemberAuthenticationService {
      * 계정 복구를 원치 않는 경우에도 다시 사용하기
      * -> NO를 누름 -> AccessToken, RefreshToken 모두 삭제하고 탈퇴 상태 유지(아무것도 안해줘도 됨)
      *
-     * @param token 로그아웃할 JWT 토큰 -> redis Blacklist에 저장하여 무효화
+     * //@param token 로그아웃할 JWT 토큰 -> redis Blacklist에 저장하여 무효화
      */
-    void logout(String token);
+    void logout(HttpServletRequest request, HttpServletResponse response);
 
     /**
      * 회원 계정 복구 (비활성화된 계정 재활성화)

--- a/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/authenticate/MemberAuthenticationServiceImpl.java
@@ -11,16 +11,21 @@ import checkmo.domain.member.service.security.jwt.JwtTokenProvider;
 import checkmo.domain.member.service.security.jwt.TokenCacheService;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MemberAuthenticationServiceImpl implements MemberAuthenticationService {
 
     private final AuthenticationManager authenticationManager;
@@ -56,9 +61,12 @@ public class MemberAuthenticationServiceImpl implements MemberAuthenticationServ
             String memberId = ((PrincipalDetails) authentication.getPrincipal()).getMember().getId();
             tokenCacheService.saveRefreshToken(memberId, jwtToken.getRefreshToken());
 
-        } catch (Exception e) {
+        } catch (AuthenticationException authEx) {
             // 인증 실패 시 예외 처리
             throw new GeneralException(ErrorStatus.INVALID_CREDENTIALS, "이메일 또는 비밀번호가 일치하지 않습니다");
+        } catch (Exception e) {
+            // 기타 예외 처리
+            throw new GeneralException(ErrorStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류: 로그인 처리 중 오류가 발생했습니다");
         }
 
         // 인증 성공 후 MemberResponseDTO 반환
@@ -67,8 +75,34 @@ public class MemberAuthenticationServiceImpl implements MemberAuthenticationServ
     }
 
     @Override
-    public void logout(String token) {
-        // TODO: 로그아웃 로직 구현
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
+
+        // 0. 쿠키에서 jwt 토큰 가져오기
+        String accessToken = jwtCookieUtil.resolveToken(request, "accessToken");
+        String refreshToken = jwtCookieUtil.resolveToken(request, "refreshToken");
+
+        // 1. jwt 토큰을 쿠키에서 삭제
+        jwtCookieUtil.deleteTokenFromCookie(response, "accessToken");
+        jwtCookieUtil.deleteTokenFromCookie(response, "refreshToken");
+
+        // 2. redis에 저장된 Access Token을 블랙리스트에 추가하여 무효화
+        if (StringUtils.hasText(accessToken)) {
+            try {
+                tokenCacheService.saveBlacklistToken(accessToken);
+            } catch (Exception e) {
+                log.error("[로그아웃] AccessToken 블랙리스트 저장 실패", e);
+            }
+        }
+
+        // 3. redis에 저장된 Refresh Token을 redis에서 삭제
+        if (StringUtils.hasText(refreshToken)) {
+            try{
+                String memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+                tokenCacheService.deleteRefreshToken(memberId);
+            } catch (Exception e) {
+                log.error("[로그아웃] RefreshToken 삭제 실패", e);
+            }
+        }
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtAuthenticationFilter.java
@@ -40,12 +40,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         throws ServletException, IOException {
 
         // 쿠키에서 Access Token 추출
-        String accessToken = resolveToken(request, "accessToken");
-        log.info("[JWT 필터] 요청 URI: {}, Access Token 존재 여부 확인: {}", request.getRequestURI(), accessToken != null);
+        String accessToken = jwtCookieUtil.resolveToken(request, "accessToken");
+        log.info("[JWT 필터] 요청 URI: {}, Access Token 존재 여부 확인: {}", request.getRequestURI(),
+            accessToken != null);
 
-        if (StringUtils.hasText(accessToken))  { // Access Token이 존재하는 경우
+        if (StringUtils.hasText(accessToken)) { // Access Token이 존재하는 경우
             try {
                 if (jwtTokenProvider.validateToken(accessToken)) { // Access Token 유효성 검사
+
+                    if (tokenCacheService.isAccessTokenBlacklisted(accessToken)) {
+                        log.warn("[JWT 필터] 블랙리스트에 등록된 Access Token 입니다. 요청 거부.");
+                        filterChain.doFilter(request, response); // 인증 없이 계속 진행
+                        return;
+                    }
 
                     // Access Token이 유효한 경우, 인증 정보 설정
                     Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
@@ -68,7 +75,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
 
         // 쿠키에서 Refresh Token 추출
-        String refreshToken = resolveToken(request, "refreshToken");
+        String refreshToken = jwtCookieUtil.resolveToken(request, "refreshToken");
         log.info("[재발급] Refresh Token 존재 여부 확인: {}", refreshToken != null);
 
         if (!StringUtils.hasText(refreshToken)) {
@@ -82,7 +89,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         String memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
-        if(!StringUtils.hasText(memberId)) {
+        if (!StringUtils.hasText(memberId)) {
             log.warn("재발급 실패: Refresh Token에서 memberId 추출 실패");
             return;
         }
@@ -106,23 +113,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String newAccessToken = newJwtToken.getAccessToken();
 
         int accessTokenMaxAge = (int) (jwtTokenProvider.getAccessTokenExpirationTime() / 1000L);
-        jwtCookieUtil.addTokenToCookie(response, "accessToken", newAccessToken, accessTokenMaxAge); // 2시간 유효
+        jwtCookieUtil.addTokenToCookie(response, "accessToken", newAccessToken,
+            accessTokenMaxAge); // 2시간 유효
 
         // SecurityContext에 새로운 인증 정보 설정
         SecurityContextHolder.getContext().setAuthentication(authentication);
         log.info("Access Token 재발급 성공: 새로운 Access Token 생성 (memberId={})", memberId);
     }
-
-    private String resolveToken(HttpServletRequest request, String cookieName) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (cookieName.equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
-            }
-        }
-        return null; // 쿠키에서 Access Token을 찾지 못한 경우
-    }
-
 }

--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtCookieUtil.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtCookieUtil.java
@@ -1,6 +1,7 @@
 package checkmo.domain.member.service.security.jwt;
 
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
 
@@ -15,5 +16,27 @@ public class JwtCookieUtil {
         cookie.setMaxAge(maxAge);
         response.addCookie(cookie);
         // TODO: 배포 시 cookie.setSecure(true); // HTTPS에서만 전송하도록 추가
+    }
+
+    public String resolveToken(HttpServletRequest request, String cookieName) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookieName.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null; // 쿠키에서 Access Token을 찾지 못한 경우
+    }
+
+    public void deleteTokenFromCookie(HttpServletResponse response, String cookieName) {
+        // 쿠키에서 토큰을 삭제
+        Cookie cookie = new Cookie(cookieName, null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setAttribute("SameSite", "Strict");
+        response.addCookie(cookie);
     }
 }

--- a/src/main/java/checkmo/domain/member/service/security/jwt/TokenCacheService.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/TokenCacheService.java
@@ -2,6 +2,7 @@ package checkmo.domain.member.service.security.jwt;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -23,5 +24,24 @@ public class TokenCacheService {
     public String getRefreshToken(String memberId) {
         log.info("리프레시 토큰 조회 - memberId={}", memberId);
         return (String) redisTemplate.opsForValue().get("refreshToken::" + memberId);
+    }
+
+    // Redis에서 리프레시 토큰 삭제
+    @CacheEvict(value = "refreshToken", key = "#memberId")
+    public void deleteRefreshToken(String memberId) {
+        log.info("리프레시 토큰 삭제 - memberId={}", memberId);
+    }
+
+    // 블랙리스트 토큰 저장
+    @CachePut(value = "blacklist", key = "#accessToken")
+    public String saveBlacklistToken(String accessToken) {
+        log.info("블랙리스트 토큰 저장");
+        return accessToken;
+    }
+
+    // 블랙리스트 토큰 조회
+    public boolean isAccessTokenBlacklisted(String accessToken) {
+        log.info("블랙리스트 토큰 조회");
+        return Boolean.TRUE.equals(redisTemplate.hasKey("blacklist::" + accessToken));
     }
 }

--- a/src/main/java/checkmo/domain/member/web/controller/AuthController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/AuthController.java
@@ -8,6 +8,7 @@ import checkmo.domain.member.web.dto.MemberResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
@@ -81,11 +82,15 @@ public class AuthController {
         return ApiResponse.onSuccess(memberCommandFacade.login(request, response));
     }
 
+    // 로그아웃
+    @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+        memberCommandFacade.logout(request, response);
+        return ApiResponse.onSuccess(null);
+    }
+
     // 소셜 로그인 관련
     // GET /api/auth/oauth2/google - 소셜 로그인 (구글)
     // GET /api/auth/oauth2/kakao - 소셜 로그인 (카카오)
-
-    // 일반 로그인/로그아웃 관련
-    // POST /api/auth/login - 이메일 로그인
-    // POST /api/auth/logout - 로그아웃
 }


### PR DESCRIPTION
## 🚀 변경사항
로그아웃 기능 구현
- 로그아웃 시 access token, refresh token 쿠키 삭제
- access token을 redis 블랙리스트에 등록
- redis에 저장된 refresh 토큰 삭제
- JWT 인증 필터에서 블랙리스트에 저장된 토큰인지 확인 후 저장되어 있으면 인증 차단

## 🔗 관련 이슈
- Closes #38 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a logout endpoint, allowing users to securely log out and invalidate their tokens.
  * Implemented full token invalidation and cookie cleanup during logout for enhanced security.
  * Introduced handling for internal server errors with a new error message.

* **Improvements**
  * Reduced the Redis "blacklist" cache expiration from 7 days to 2 hours for faster token invalidation.
  * Enhanced error handling during authentication and logout processes.
  * Improved detection and management of blacklisted access tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->