### PR TITLE
Feat/56/member follow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Docker 이미지 생성 및 ECR에 푸시
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: checkmo-server
+          ECR_REPOSITORY: checkmo-ecr
           IMAGE_TAG: latest
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
@@ -48,7 +48,7 @@ jobs:
       # 7. S3에 배포 파일 업로드
       - name: S3에 배포 파일 업로드
         run: |
-          aws s3 cp deployment.zip s3://${{ secrets.S3_BUCKET_NAME }}/codedeploy/checkmo-server/${{ github.sha }}.zip
+          aws s3 cp deployment.zip s3://${{ secrets.S3_BUCKET_NAME }}/codedeploy/checkmo-ecr/${{ github.sha }}.zip
 
       # 8. CodeDeploy 배포 생성
       - name: CodeDeploy 배포 생성
@@ -56,4 +56,4 @@ jobs:
           aws deploy create-deployment \
             --application-name ${{ secrets.CODEDEPLOY_APPLICATION_NAME }} \
             --deployment-group-name ${{ secrets.CODEDEPLOY_DEPLOYMENT_GROUP_NAME }} \
-            --s3-location bucket=${{ secrets.S3_BUCKET_NAME }},bundleType=zip,key=codedeploy/checkmo-server/${{ github.sha }}.zip
+            --s3-location bucket=${{ secrets.S3_BUCKET_NAME }},bundleType=zip,key=codedeploy/checkmo-ecr/${{ github.sha }}.zip

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: 268456953414.dkr.ecr.ap-northeast-2.amazonaws.com/checkmo-server
+    image: 667183278509.dkr.ecr.ap-northeast-2.amazonaws.com/checkmo-ecr
     container_name: checkmo-app
     env_file:
       - .env
@@ -9,8 +9,6 @@ services:
     restart: unless-stopped
     networks:
       - app-network
-    depends_on:
-      - redis # redis가 먼저 시작되어야지 우리 서비스에 redis 의존성 주입 가능
 
   nginx:
     image: nginx:alpine
@@ -28,26 +26,6 @@ services:
     depends_on:
       - app # 우리 서비스가 먼저 시작되어야지 nginx가 우리 서비스에 대한 프록시 설정을 할 수 있음
 
-  redis:
-    image: 'redis:7.2-alpine'
-    container_name: redis-cache
-    ports:
-      - "6379:6379"
-    command: redis-server --appendonly yes --requirepass checkmo123
-    volumes:
-      - redis_data:/data
-    networks:
-      - app-network
-    healthcheck:
-      test: ["CMD", "redis-cli", "-a", "checkmo123", "ping"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-
-
 networks:
   app-network:
     driver: bridge
-
-volumes:
-  redis_data:

--- a/scripts/codedeploy/after_install.sh
+++ b/scripts/codedeploy/after_install.sh
@@ -8,7 +8,7 @@ chmod +x ./scripts/codedeploy/*.sh
 
 # 2. AWS ECR 로그인
 echo "AWS ECR에 로그인"
-aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 268456953414.dkr.ecr.ap-northeast-2.amazonaws.com
+aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 667183278509.dkr.ecr.ap-northeast-2.amazonaws.com
 
 # 3. 최신 Docker 이미지 다운로드 (pull)
 echo "최신 Docker 이미지를 다운로드"

--- a/scripts/codedeploy/stop.sh
+++ b/scripts/codedeploy/stop.sh
@@ -7,5 +7,5 @@ if [ -f compose.yml ]; then
     docker compose -f compose.yml down --remove-orphans
     echo "기존 컨테이너가 중지 및 삭제"
 else
-    echo "compose.yml 파일이 없어서 중지할 것 컨테이너가 없는 상태.
+    echo "compose.yml 파일이 없어서 중지할 것 컨테이너가 없는 상태."
 fi

--- a/src/main/java/checkmo/HealthCheckController.java
+++ b/src/main/java/checkmo/HealthCheckController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/")
+@RequestMapping("/health")
 @Slf4j
 @Tag(name = "헬스체크용", description = "헬스체크용 테스트용 사용 X")
 public class HealthCheckController {

--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -65,6 +65,7 @@ public enum ErrorStatus implements BaseErrorCode {
     NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER_407", "이미 존재하는 닉네임입니다."),
     MEMBER_PROFILE_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER_408", "프로필이 완성되지 않은 회원입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "MEMBER_409", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    MEMBER_ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "MEMBER_410", "이미 팔로잉 중인 회원입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER_500", "서버 내부 오류입니다. 관리자에게 문의 바랍니다."),
 
     // 발제

--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -65,9 +65,10 @@ public enum ErrorStatus implements BaseErrorCode {
     NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER_407", "이미 존재하는 닉네임입니다."),
     MEMBER_PROFILE_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER_408", "프로필이 완성되지 않은 회원입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "MEMBER_409", "이메일 또는 비밀번호가 일치하지 않습니다."),
-    MEMBER_ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "MEMBER_410", "이미 팔로잉 중인 회원입니다."),
-    MEMBER_NOT_FOLLOWING(HttpStatus.BAD_REQUEST, "MEMBER_411", "팔로우 중이지 않은 회원입니다."),
-    MEMBER_NOT_FOLLOWER(HttpStatus.BAD_REQUEST, "MEMBER_412", "팔로워가 아닌 회원입니다."),
+    MEMBER_CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST, "MEMBER_410", "자기 자신을 팔로잉할 수 없습니다."),
+    MEMBER_ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "MEMBER_411", "이미 팔로잉 중인 회원입니다."),
+    MEMBER_NOT_FOLLOWING(HttpStatus.BAD_REQUEST, "MEMBER_412", "팔로우 중이지 않은 회원입니다."),
+    MEMBER_NOT_FOLLOWER(HttpStatus.BAD_REQUEST, "MEMBER_413", "팔로워가 아닌 회원입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER_500", "서버 내부 오류입니다. 관리자에게 문의 바랍니다."),
 
     // 발제

--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -66,6 +66,8 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_PROFILE_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER_408", "프로필이 완성되지 않은 회원입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "MEMBER_409", "이메일 또는 비밀번호가 일치하지 않습니다."),
     MEMBER_ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "MEMBER_410", "이미 팔로잉 중인 회원입니다."),
+    MEMBER_NOT_FOLLOWING(HttpStatus.BAD_REQUEST, "MEMBER_411", "팔로우 중이지 않은 회원입니다."),
+    MEMBER_NOT_FOLLOWER(HttpStatus.BAD_REQUEST, "MEMBER_412", "팔로워가 아닌 회원입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER_500", "서버 내부 오류입니다. 관리자에게 문의 바랍니다."),
 
     // 발제

--- a/src/main/java/checkmo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/checkmo/domain/member/converter/MemberConverter.java
@@ -4,6 +4,8 @@ import checkmo.domain.member.entity.Follow;
 import checkmo.domain.member.entity.Member;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
+
+import java.util.List;
 import java.util.UUID;
 import checkmo.global.dto.MemberSharedDTO;
 import lombok.AccessLevel;
@@ -94,12 +96,31 @@ public class MemberConverter {
     // =====================================================
 
     /**
-     * followerId, FollowingId → Follow 엔티티 변환
+     * follower, Following → Follow 엔티티 변환
      */
-    public static Follow toFollow(String followerId, String followingId) {
+    public static Follow toFollow(Member follower, Member following) {
         return Follow.builder()
-                .followerId(followerId)
-                .followingId(followingId)
+                .follower(follower)
+                .following(following)
+                .build();
+    }
+
+    // =====================================================
+    // DTO ↔ DTO 변환
+    // =====================================================
+
+    /**
+     * follower -> MemberResponseDTO.FollowerList 변환
+     */
+    public static MemberResponseDTO.FollowList toFollowList(
+            List<MemberResponseDTO.FollowResponse> followerList,
+            boolean hasNext,
+            Long nextCursor
+    ) {
+        return MemberResponseDTO.FollowList.builder()
+                .followList(followerList)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
                 .build();
     }
 }

--- a/src/main/java/checkmo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/checkmo/domain/member/converter/MemberConverter.java
@@ -1,5 +1,6 @@
 package checkmo.domain.member.converter;
 
+import checkmo.domain.member.entity.Follow;
 import checkmo.domain.member.entity.Member;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
@@ -85,6 +86,20 @@ public class MemberConverter {
                 .nickname(basicInfo.getNickname())
                 .profileImageUrl(basicInfo.getProfileImageUrl())
                 .isFollowing(isFollowing)
+                .build();
+    }
+
+    // =====================================================
+    // DTO ↔ Entity 변환
+    // =====================================================
+
+    /**
+     * followerId, FollowingId → Follow 엔티티 변환
+     */
+    public static Follow toFollow(String followerId, String followingId) {
+        return Follow.builder()
+                .followerId(followerId)
+                .followingId(followingId)
                 .build();
     }
 }

--- a/src/main/java/checkmo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/checkmo/domain/member/converter/MemberConverter.java
@@ -110,17 +110,28 @@ public class MemberConverter {
     // =====================================================
 
     /**
-     * follower -> MemberResponseDTO.FollowerList 변환
+     * follow -> MemberResponseDTO.FollowList 변환
      */
     public static MemberResponseDTO.FollowList toFollowList(
-            List<MemberResponseDTO.FollowResponse> followerList,
+            List<MemberResponseDTO.FollowResponse> followList,
             boolean hasNext,
             Long nextCursor
     ) {
         return MemberResponseDTO.FollowList.builder()
-                .followList(followerList)
+                .followList(followList)
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
+                .build();
+    }
+
+    /**
+     * follow -> MemberResponseDTO.FollowPreviewList 변환
+     */
+    public static MemberResponseDTO.FollowPreviewList toFollowPreviewList(
+            List<MemberResponseDTO.FollowResponse> followList
+    ) {
+        return MemberResponseDTO.FollowPreviewList.builder()
+                .followList(followList)
                 .build();
     }
 }

--- a/src/main/java/checkmo/domain/member/entity/Follow.java
+++ b/src/main/java/checkmo/domain/member/entity/Follow.java
@@ -9,6 +9,9 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Table(uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"follower_id", "following_id"})
+})
 public class Follow extends BaseEntity {
 
     @Id

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
@@ -107,23 +107,23 @@ public interface MemberCommandFacade {
      * 특정 회원을 팔로우 (내부용/외부용) - Notification 도메인에서 사용
      *
      * @param memberId 팔로우할 회원의 ID
-     * @param targetNickname 팔로우 대상 회원의 nickname
+     * @param followingNickname 팔로우 대상 회원의 nickname
      */
-    void followMember(String memberId, String targetNickname);
-
-    /**
-     * 특정 회원의 팔로우를 취소 (언팔로우) (내부용)
-     *
-     * @param memberId 언팔로우할 회원의 ID
-     * @param targetNickname 팔로우 대상 회원의 nickname
-     */
-    void unfollowMember(String memberId, String targetNickname);
+    void followingMember(String memberId, String followingNickname);
 
     /**
      * 특정 회원의 팔로잉를 취소 (언팔로잉) (내부용)
      *
      * @param memberId 언팔로우할 회원의 ID
-     * @param targetNickname 팔로우 대상 회원의 nickname
+     * @param followingNickname 팔로우 대상 회원의 nickname
      */
-    void unfollowingMember(String memberId, String targetNickname);
+    void unfollowingMember(String memberId, String followingNickname);
+
+    /**
+     * 특정 회원의 팔로우를 취소 (언팔로우) (내부용)
+     *
+     * @param memberId 언팔로우할 회원의 ID
+     * @param followerNickname 팔로우 대상 회원의 nickname
+     */
+    void deleteFollower(String memberId, String followerNickname);
 }

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
@@ -106,24 +106,24 @@ public interface MemberCommandFacade {
     /**
      * 특정 회원을 팔로우 (내부용/외부용) - Notification 도메인에서 사용
      *
-     * @param memberId 팔로우할 회원의 ID
-     * @param followingNickname 팔로우 대상 회원의 nickname
+     * @param memberId 회원의 ID
+     * @param followingNickname 팔로잉 대상 회원의 nickname
      */
     void followingMember(String memberId, String followingNickname);
 
     /**
-     * 특정 회원의 팔로잉를 취소 (언팔로잉) (내부용)
+     * 특정 회원을 언팔로잉 (언팔로잉) (내부용)
      *
-     * @param memberId 언팔로우할 회원의 ID
-     * @param followingNickname 팔로우 대상 회원의 nickname
+     * @param memberId 회원의 ID
+     * @param followingNickname 언팔로잉 대상 회원의 nickname
      */
     void unfollowingMember(String memberId, String followingNickname);
 
     /**
-     * 특정 회원의 팔로우를 취소 (언팔로우) (내부용)
+     * 특정 회원의 팔로워를 삭제 (언팔로우) (내부용)
      *
-     * @param memberId 언팔로우할 회원의 ID
-     * @param followerNickname 팔로우 대상 회원의 nickname
+     * @param memberId 회원의 ID
+     * @param followerNickname 팔로워 중 삭제할 회원의 nickname
      */
     void deleteFollower(String memberId, String followerNickname);
 }

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
@@ -76,17 +76,17 @@ public class MemberCommandFacadeImpl implements MemberCommandFacade{
     }
 
     @Override
-    public void followMember(String memberId, String targetNickname) {
-        memberFollowCommandService.followingMember(memberId, targetNickname);
+    public void followingMember(String memberId, String followingNickname) {
+        memberFollowCommandService.followingMember(memberId, followingNickname);
     }
 
     @Override
-    public void unfollowMember(String memberId, String targetNickname) {
-        throw new UnsupportedOperationException("추후 구현 예정");
+    public void unfollowingMember(String memberId, String followingNickname) {
+        memberFollowCommandService.unfollowingMember(memberId, followingNickname);
     }
 
     @Override
-    public void unfollowingMember(String memberId, String targetNickname) {
-        throw new UnsupportedOperationException("추후 구현 예정");
+    public void deleteFollower(String memberId, String followerNickname) {
+        memberFollowCommandService.deleteFollower(memberId, followerNickname);
     }
 }

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
@@ -1,6 +1,7 @@
 package checkmo.domain.member.facade;
 
 import checkmo.domain.member.service.authenticate.MemberAuthenticationService;
+import checkmo.domain.member.service.command.MemberFollowCommandService;
 import checkmo.domain.member.service.command.MemberRegistrationCommandService;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
@@ -17,6 +18,7 @@ public class MemberCommandFacadeImpl implements MemberCommandFacade{
 
     private final MemberRegistrationCommandService memberRegistrationCommandService;
     private final MemberAuthenticationService memberAuthenticationService;
+    private final MemberFollowCommandService memberFollowCommandService;
 
     @Override
     public void sendEmailVerification(String email) {
@@ -75,7 +77,7 @@ public class MemberCommandFacadeImpl implements MemberCommandFacade{
 
     @Override
     public void followMember(String memberId, String targetNickname) {
-        throw new UnsupportedOperationException("추후 구현 예정");
+        memberFollowCommandService.followingMember(memberId, targetNickname);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/facade/MemberQueryFacade.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberQueryFacade.java
@@ -49,7 +49,7 @@ public interface MemberQueryFacade {
      * @param cursorId 커서 ID
      * @return 팔로워 목록
      */
-    MemberResponseDTO.FollowerListResponseDTO getFollowers(String memberId, Long cursorId);
+    MemberResponseDTO.FollowList getFollowerList(String memberId, Long cursorId);
 
     /**
      * 특정 회원의 팔로잉 목록 전체 조회 (내부용)
@@ -58,7 +58,7 @@ public interface MemberQueryFacade {
      * @param cursorId 커서 ID
      * @return 팔로잉 목록
      */
-    MemberResponseDTO.FollowingListResponseDTO getFollowing(String memberId, Long cursorId);
+    MemberResponseDTO.FollowList getFollowingList(String memberId, Long cursorId);
 
     /**
      * 특정 회원의 팔로워 목록 size 개수만큼 조회 (내부용)
@@ -67,7 +67,7 @@ public interface MemberQueryFacade {
      * @param size     조회할 개수
      * @return 팔로워 목록
      */
-    MemberResponseDTO.FollowerListResponseDTO getFollowers(Long memberId, int size);
+    MemberResponseDTO.FollowList getFollowers(Long memberId, int size);
 
     /**
      * 특정 회원의 팔로잉 목록 size 개수만큼 조회 (내부용)
@@ -76,7 +76,7 @@ public interface MemberQueryFacade {
      * @param size     조회할 개수
      * @return 팔로잉 목록
      */
-    MemberResponseDTO.FollowingListResponseDTO getFollowing(Long memberId, int size);
+    MemberResponseDTO.FollowList getFollowings(Long memberId, int size);
 
     /**
      * 닉네임으로 회원 ID 조회 (외부용)

--- a/src/main/java/checkmo/domain/member/facade/MemberQueryFacade.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberQueryFacade.java
@@ -63,20 +63,24 @@ public interface MemberQueryFacade {
     /**
      * 특정 회원의 팔로워 목록 size 개수만큼 조회 (내부용)
      *
+     * ‼️ 마이페이지 구성할 때 사용하세요~~
+     *
      * @param memberId 조회할 회원의 ID
      * @param size     조회할 개수
      * @return 팔로워 목록
      */
-    MemberResponseDTO.FollowList getFollowers(Long memberId, int size);
+    MemberResponseDTO.FollowPreviewList getFollowers(String memberId, int size);
 
     /**
      * 특정 회원의 팔로잉 목록 size 개수만큼 조회 (내부용)
+     *
+     * ‼️ 마이페이지 구성할 때 사용하세요~~
      *
      * @param memberId 조회할 회원의 ID
      * @param size     조회할 개수
      * @return 팔로잉 목록
      */
-    MemberResponseDTO.FollowList getFollowings(Long memberId, int size);
+    MemberResponseDTO.FollowPreviewList getFollowings(String memberId, int size);
 
     /**
      * 닉네임으로 회원 ID 조회 (외부용)

--- a/src/main/java/checkmo/domain/member/facade/MemberQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberQueryFacadeImpl.java
@@ -97,13 +97,41 @@ public class MemberQueryFacadeImpl implements MemberQueryFacade {
     }
 
     @Override
-    public MemberResponseDTO.FollowList getFollowers(Long memberId, int size) {
-        return null;
+    public MemberResponseDTO.FollowPreviewList getFollowers(String memberId, int size) {
+        // 1. 팔로워 목록 size 개수만큼 조회
+        List<Follow> followerList = memberFollowQueryService.getFollowers(memberId, size);
+
+        // 2. 팔로워 목록의 닉네임, 프로필 이미지 배치 조회
+        List<String> followerIdList = followerList.stream()
+                .map(Follow::getFollowerId)
+                .distinct()
+                .toList();
+
+        var followerMap = memberQueryService.getMemberNicknamesAndProfileImagesByMemberIds(memberId, followerIdList);
+
+        List<MemberResponseDTO.FollowResponse> followerDTOList = new ArrayList<>(followerMap.values());
+
+        // 3. DTO 변환
+        return MemberConverter.toFollowPreviewList(followerDTOList);
     }
 
     @Override
-    public MemberResponseDTO.FollowList getFollowings(Long memberId, int size) {
-        return null;
+    public MemberResponseDTO.FollowPreviewList getFollowings(String memberId, int size) {
+        // 1. 팔로잉 목록 size 개수만큼 조회
+        List<Follow> followingList = memberFollowQueryService.getFollowings(memberId, size);
+
+        // 2. 팔로잉 목록의 닉네임, 프로필 이미지 배치 조회
+        List<String> followingIdList = followingList.stream()
+                .map(Follow::getFollowingId)
+                .distinct()
+                .toList();
+
+        var followingMap = memberQueryService.getMemberNicknamesAndProfileImagesByMemberIds(memberId, followingIdList);
+
+        List<MemberResponseDTO.FollowResponse> followingDTOList = new ArrayList<>(followingMap.values());
+
+        // 3. DTO 변환
+        return MemberConverter.toFollowPreviewList(followingDTOList);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/facade/MemberQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberQueryFacadeImpl.java
@@ -1,6 +1,7 @@
 package checkmo.domain.member.facade;
 
 import checkmo.domain.member.converter.MemberConverter;
+import checkmo.domain.member.entity.Follow;
 import checkmo.domain.member.entity.Member;
 import checkmo.domain.member.repository.MemberRepository;
 import checkmo.domain.member.service.query.MemberFollowQueryService;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -18,6 +20,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberQueryFacadeImpl implements MemberQueryFacade {
+
+    public static final int DEFAULT_PAGE_SIZE = 20;
 
     private final MemberRepository memberRepository; // 프록시용
     private final MemberQueryService memberQueryService;
@@ -39,22 +43,66 @@ public class MemberQueryFacadeImpl implements MemberQueryFacade {
     }
 
     @Override
-    public MemberResponseDTO.FollowerListResponseDTO getFollowers(String memberId, Long cursorId) {
+    public MemberResponseDTO.FollowList getFollowerList(String memberId, Long cursorId) {
+        // 1. 팔로워 목록 조회
+        List<Follow> followerList = memberFollowQueryService.getFollowerList(memberId, cursorId, DEFAULT_PAGE_SIZE + 1);
+
+        // 2. 커서 기반 페이징 처리
+        boolean hasNext = followerList.size() > DEFAULT_PAGE_SIZE;
+        Long nextCursor = null;
+        if (hasNext) {
+            followerList.removeLast();
+            nextCursor = followerList.getLast().getId();
+        }
+
+        // 3. 팔로워 목록의 닉네임, 프로필 이미지 배치 조회
+        List<String> followerIdList = followerList.stream()
+                .map(Follow::getFollowerId)
+                .distinct()
+                .toList();
+
+        var followerMap = memberQueryService.getMemberNicknamesAndProfileImagesByMemberIds(memberId, followerIdList);
+
+        List<MemberResponseDTO.FollowResponse> followerDTOList = new ArrayList<>(followerMap.values());
+
+        // 4. DTO 변환
+        return MemberConverter.toFollowList(followerDTOList, hasNext, nextCursor);
+    }
+
+    @Override
+    public MemberResponseDTO.FollowList getFollowingList(String memberId, Long cursorId) {
+        // 1. 팔로잉 목록 조회
+        List<Follow> followingList = memberFollowQueryService.getFollowingList(memberId, cursorId, DEFAULT_PAGE_SIZE + 1);
+
+        // 2. 커서 기반 페이징 처리
+        boolean hasNext = followingList.size() > DEFAULT_PAGE_SIZE;
+        Long nextCursor = null;
+        if (hasNext) {
+            followingList.removeLast();
+            nextCursor = followingList.getLast().getId();
+        }
+
+        // 3. 팔로잉 목록의 닉네임, 프로필 이미지 배치 조회
+        List<String> followingIdList = followingList.stream()
+                .map(Follow::getFollowingId)
+                .distinct()
+                .toList();
+
+        var followingMap = memberQueryService.getMemberNicknamesAndProfileImagesByMemberIds(memberId, followingIdList);
+
+        List<MemberResponseDTO.FollowResponse> followingDTOList = new ArrayList<>(followingMap.values());
+
+        // 4. DTO 변환
+        return MemberConverter.toFollowList(followingDTOList, hasNext, nextCursor);
+    }
+
+    @Override
+    public MemberResponseDTO.FollowList getFollowers(Long memberId, int size) {
         return null;
     }
 
     @Override
-    public MemberResponseDTO.FollowingListResponseDTO getFollowing(String memberId, Long cursorId) {
-        return null;
-    }
-
-    @Override
-    public MemberResponseDTO.FollowerListResponseDTO getFollowers(Long memberId, int size) {
-        return null;
-    }
-
-    @Override
-    public MemberResponseDTO.FollowingListResponseDTO getFollowing(Long memberId, int size) {
+    public MemberResponseDTO.FollowList getFollowings(Long memberId, int size) {
         return null;
     }
 

--- a/src/main/java/checkmo/domain/member/repository/FollowRepository.java
+++ b/src/main/java/checkmo/domain/member/repository/FollowRepository.java
@@ -4,8 +4,11 @@ import checkmo.domain.member.entity.Follow;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Set;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
@@ -22,5 +25,12 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     List<Follow> findByFollowerIdAndIdLessThanOrderByIdDesc(String memberId, Long cursorId, Pageable pageable);
 
-
+    /**
+     * 배치로 팔로우 관계 확인 - N+1 문제 해결용
+     * @param followerId 팔로우하는 사람 ID
+     * @param memberIds 확인할 대상 회원 ID 목록
+     * @return followerId가 팔로우하고 있는 회원 ID 집합
+     */
+    @Query("SELECT f.followingId FROM Follow f WHERE f.followerId = :followerId AND f.followingId IN :memberIds")
+    Set<String> findFollowingIdsByFollowerId(@Param("followerId") String followerId, @Param("memberIds") List<String> memberIds);
 }

--- a/src/main/java/checkmo/domain/member/repository/FollowRepository.java
+++ b/src/main/java/checkmo/domain/member/repository/FollowRepository.java
@@ -2,8 +2,12 @@ package checkmo.domain.member.repository;
 
 import checkmo.domain.member.entity.Follow;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     boolean existsByFollowerIdAndFollowingId(String followerId, String followingId);
+
+    @Modifying
+    void deleteByFollowerIdAndFollowingId(String followerId, String followingId);
 }

--- a/src/main/java/checkmo/domain/member/repository/FollowRepository.java
+++ b/src/main/java/checkmo/domain/member/repository/FollowRepository.java
@@ -1,8 +1,11 @@
 package checkmo.domain.member.repository;
 
 import checkmo.domain.member.entity.Follow;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
+
+import java.util.List;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
@@ -10,4 +13,14 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     @Modifying
     void deleteByFollowerIdAndFollowingId(String followerId, String followingId);
+
+    List<Follow> findByFollowingIdOrderByIdDesc(String memberId, Pageable pageable);
+
+    List<Follow> findByFollowerIdOrderByIdDesc(String memberId, Pageable pageable);
+
+    List<Follow> findByFollowingIdAndIdLessThanOrderByIdDesc(String memberId, Long cursorId, Pageable pageable);
+
+    List<Follow> findByFollowerIdAndIdLessThanOrderByIdDesc(String memberId, Long cursorId, Pageable pageable);
+
+
 }

--- a/src/main/java/checkmo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/checkmo/domain/member/repository/MemberRepository.java
@@ -24,4 +24,7 @@ public interface MemberRepository extends JpaRepository<Member, String> {
 
     @Query("select m.id, m.nickName from Member m where m.id in :memberIds")
     List<Object[]> findIdAndNicknameByIdIn(@Param("memberIds") List<String> memberIds);
+
+    @Query("select m.id, m.nickName, m.imgUrl from Member m where m.id in :memberIds")
+    List<Object[]> findIdNicknameAndImgUrlByIdIn(@Param("memberIds") List<String> memberIds);
 }

--- a/src/main/java/checkmo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/checkmo/domain/member/repository/MemberRepository.java
@@ -16,6 +16,8 @@ public interface MemberRepository extends JpaRepository<Member, String> {
 
     boolean existsByNickName(String nickName);
 
+    Optional<Member> findByNickName(String nickname);
+
     @Query("select m.id from Member m where m.nickName = :nickName")
     Optional<String> findIdByNickName(@Param("nickName") String nickName);
 

--- a/src/main/java/checkmo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/checkmo/domain/member/repository/MemberRepository.java
@@ -16,7 +16,7 @@ public interface MemberRepository extends JpaRepository<Member, String> {
 
     boolean existsByNickName(String nickName);
 
-    Optional<Member> findByNickName(String nickname);
+    Optional<Member> findByNickName(String nickName);
 
     @Query("select m.id from Member m where m.nickName = :nickName")
     Optional<String> findIdByNickName(@Param("nickName") String nickName);

--- a/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandService.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandService.java
@@ -12,23 +12,23 @@ public interface MemberFollowCommandService {
      * 특정 회원을 팔로우
      *
      * @param memberId 팔로우할 회원의 ID
-     * @param targetNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로우 처리
+     * @param followingNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로우 처리
      */
-    void followMember(String memberId, String targetNickname);
+    void followingMember(String memberId, String followingNickname);
 
     /**
      * 특정 회원의 팔로우를 취소 (언팔로우)
      *
      * @param memberId 언팔로우할 회원의 ID
-     * @param targetNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로우 처리
+     * @param followingNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로우 처리
      */
-    void unfollowMember(String memberId, String targetNickname);
+    void unfollowMember(String memberId, String followingNickname);
 
     /**
      * 특정 회원의 팔로잉를 취소 (언팔로잉)
      *
      * @param memberId 언팔로우할 회원의 ID
-     * @param targetNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로우 처리
+     * @param followingNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로우 처리
      */
-    void unfollowingMember(String memberId, String targetNickname);
+    void unfollowingMember(String memberId, String followingNickname);
 }

--- a/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandService.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandService.java
@@ -28,7 +28,7 @@ public interface MemberFollowCommandService {
      * 내 팔로워 중 특정 회원 삭제
      *
      * @param memberId 제거할 회원 ID
-     * @param followingNickname 팔로워의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로워 삭제 처리
+     * @param followerNickname 팔로워의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로워 삭제 처리
      */
-    void deleteFollower(String memberId, String followingNickname);
+    void deleteFollower(String memberId, String followerNickname);
 }

--- a/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandService.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandService.java
@@ -1,34 +1,34 @@
 package checkmo.domain.member.service.command;
 
 /**
- * 팔로우/팔로잉 처리하는 서비스
+ * 팔로잉 처리하는 서비스
  *
- * 팔로우/언팔로우 기능을 담당
- * 팔로우/팔로잉 시 NotificationCommandService를 통해 알림 처리
+ * 팔로잉/언팔로우 기능을 담당
+ * 팔로잉 NotificationCommandService를 통해 알림 처리
  */
 public interface MemberFollowCommandService {
 
     /**
-     * 특정 회원을 팔로우
+     * 특정 회원을 팔로잉
      *
      * @param memberId 팔로우할 회원의 ID
-     * @param followingNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로우 처리
+     * @param followingNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로잉 처리
      */
     void followingMember(String memberId, String followingNickname);
 
     /**
-     * 특정 회원의 팔로우를 취소 (언팔로우)
-     *
-     * @param memberId 언팔로우할 회원의 ID
-     * @param followingNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로우 처리
-     */
-    void unfollowMember(String memberId, String followingNickname);
-
-    /**
      * 특정 회원의 팔로잉를 취소 (언팔로잉)
      *
-     * @param memberId 언팔로우할 회원의 ID
-     * @param followingNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로우 처리
+     * @param memberId 언팔로잉할 회원의 ID
+     * @param followingNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 언팔로잉 처리
      */
     void unfollowingMember(String memberId, String followingNickname);
+
+    /**
+     * 내 팔로워 중 특정 회원 삭제
+     *
+     * @param memberId 제거할 회원 ID
+     * @param followingNickname 팔로워의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로워 삭제 처리
+     */
+    void deleteFollower(String memberId, String followingNickname);
 }

--- a/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandServiceImpl.java
@@ -1,0 +1,54 @@
+package checkmo.domain.member.service.command;
+
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.member.converter.MemberConverter;
+import checkmo.domain.member.repository.FollowRepository;
+import checkmo.domain.member.repository.MemberRepository;
+import checkmo.event.FollowEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberFollowCommandServiceImpl implements MemberFollowCommandService {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
+    @Override
+    public void followingMember(String memberId, String followingNickname) {
+
+        // 닉네임으로 팔로잉 대상의 Id 조회
+        String followingId = memberRepository.findIdByNickName(followingNickname)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        
+        // 이미 팔로우 중인지 확인
+        if (followRepository.existsByFollowerIdAndFollowingId(memberId, followingId)) {
+            throw new GeneralException(ErrorStatus.MEMBER_ALREADY_FOLLOWING);
+        }
+
+        // 팔로잉 관계 생성
+        followRepository.save(MemberConverter.toFollow(memberId, followingId));
+        
+        // 팔로우 이벤트 발행
+        eventPublisher.publishEvent(new FollowEvent(memberId, followingId));
+    }
+
+    @Override
+    public void unfollowMember(String memberId, String followingNickname) {
+
+    }
+
+    @Override
+    public void unfollowingMember(String memberId, String followingNickname) {
+
+    }
+}

--- a/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandServiceImpl.java
@@ -30,7 +30,7 @@ public class MemberFollowCommandServiceImpl implements MemberFollowCommandServic
         String followingId = memberRepository.findIdByNickName(followingNickname)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
         
-        // 이미 팔로우 중인지 확인
+        // 이미 팔로잉 중인지 확인
         if (followRepository.existsByFollowerIdAndFollowingId(memberId, followingId)) {
             throw new GeneralException(ErrorStatus.MEMBER_ALREADY_FOLLOWING);
         }
@@ -38,17 +38,39 @@ public class MemberFollowCommandServiceImpl implements MemberFollowCommandServic
         // 팔로잉 관계 생성
         followRepository.save(MemberConverter.toFollow(memberId, followingId));
         
-        // 팔로우 이벤트 발행
+        // 팔로잉 이벤트 발행
         eventPublisher.publishEvent(new FollowEvent(memberId, followingId));
-    }
-
-    @Override
-    public void unfollowMember(String memberId, String followingNickname) {
-
     }
 
     @Override
     public void unfollowingMember(String memberId, String followingNickname) {
 
+        // 닉네임으로 팔로잉 대상의 Id 조회
+        String followingId = memberRepository.findIdByNickName(followingNickname)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 팔로잉 하고 있는지 여부 확인
+        if (!followRepository.existsByFollowerIdAndFollowingId(memberId, followingId)) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOLLOWING);
+        }
+
+        // 팔로잉 관계 삭제
+        followRepository.deleteByFollowerIdAndFollowingId(memberId, followingId);
+    }
+
+    @Override
+    public void deleteFollower(String memberId, String followingNickname) {
+
+        // 닉네임으로 팔로워의 Id 조회
+        String followerId = memberRepository.findIdByNickName(followingNickname)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 팔로워가 존재하는지 확인
+        if (!followRepository.existsByFollowerIdAndFollowingId(followerId, memberId)) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOLLOWER);
+        }
+
+        // 팔로워 관계 삭제
+        followRepository.deleteByFollowerIdAndFollowingId(followerId, memberId);
     }
 }

--- a/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandServiceImpl.java
@@ -27,17 +27,17 @@ public class MemberFollowCommandServiceImpl implements MemberFollowCommandServic
     @Override
     public void followingMember(String memberId, String followingNickname) {
 
-        // 닉네임으로 팔로잉 대상의 Id 조회
-        String followingId = memberRepository.findIdByNickName(followingNickname)
+        // 닉네임으로 팔로잉 대상 조회
+        Member following = memberRepository.findByNickName(followingNickname)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         // 자기 자신을 팔로우할 수 없음
-        if (memberId.equals(followingId)) {
+        if (memberId.equals(following.getId())) {
             throw new GeneralException(ErrorStatus.MEMBER_CANNOT_FOLLOW_SELF);
         }
         
         // 이미 팔로잉 중인지 확인
-        if (followRepository.existsByFollowerIdAndFollowingId(memberId, followingId)) {
+        if (followRepository.existsByFollowerIdAndFollowingId(memberId, following.getId())) {
             throw new GeneralException(ErrorStatus.MEMBER_ALREADY_FOLLOWING);
         }
 
@@ -45,14 +45,11 @@ public class MemberFollowCommandServiceImpl implements MemberFollowCommandServic
         Member follower = memberRepository.findById(memberId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
-        Member following = memberRepository.findById(followingId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-
         // 팔로잉 관계 생성
         followRepository.save(MemberConverter.toFollow(follower, following));
         
         // 팔로잉 이벤트 발행
-        eventPublisher.publishEvent(new FollowEvent(memberId, followingId));
+        eventPublisher.publishEvent(new FollowEvent(memberId, following.getId()));
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandServiceImpl.java
@@ -72,10 +72,10 @@ public class MemberFollowCommandServiceImpl implements MemberFollowCommandServic
     }
 
     @Override
-    public void deleteFollower(String memberId, String followingNickname) {
+    public void deleteFollower(String memberId, String followerNickname) {
 
         // 닉네임으로 팔로워의 Id 조회
-        String followerId = memberRepository.findIdByNickName(followingNickname)
+        String followerId = memberRepository.findIdByNickName(followerNickname)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         // 팔로워가 존재하는지 확인

--- a/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberFollowCommandServiceImpl.java
@@ -3,6 +3,7 @@ package checkmo.domain.member.service.command;
 import checkmo.apiPayload.code.status.ErrorStatus;
 import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.member.converter.MemberConverter;
+import checkmo.domain.member.entity.Member;
 import checkmo.domain.member.repository.FollowRepository;
 import checkmo.domain.member.repository.MemberRepository;
 import checkmo.event.FollowEvent;
@@ -29,14 +30,26 @@ public class MemberFollowCommandServiceImpl implements MemberFollowCommandServic
         // 닉네임으로 팔로잉 대상의 Id 조회
         String followingId = memberRepository.findIdByNickName(followingNickname)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 자기 자신을 팔로우할 수 없음
+        if (memberId.equals(followingId)) {
+            throw new GeneralException(ErrorStatus.MEMBER_CANNOT_FOLLOW_SELF);
+        }
         
         // 이미 팔로잉 중인지 확인
         if (followRepository.existsByFollowerIdAndFollowingId(memberId, followingId)) {
             throw new GeneralException(ErrorStatus.MEMBER_ALREADY_FOLLOWING);
         }
 
+        // 회원 조회
+        Member follower = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Member following = memberRepository.findById(followingId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
         // 팔로잉 관계 생성
-        followRepository.save(MemberConverter.toFollow(memberId, followingId));
+        followRepository.save(MemberConverter.toFollow(follower, following));
         
         // 팔로잉 이벤트 발행
         eventPublisher.publishEvent(new FollowEvent(memberId, followingId));

--- a/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryService.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryService.java
@@ -1,6 +1,9 @@
 package checkmo.domain.member.service.query;
 
+import checkmo.domain.member.entity.Follow;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
+
+import java.util.List;
 
 /**
  * 팔로우/팔로잉 조회 서비스
@@ -16,7 +19,7 @@ public interface MemberFollowQueryService {
      * @param cursorId 커서 ID (페이징을 위한) => 커서로 사용되는 ID는 Follow 엔티티 자체의 ID 값으로 사용하기!!
      * @return 팔로워 목록
      */
-     MemberResponseDTO.FollowerListResponseDTO getFollowers(String memberId, Long cursorId);
+    List<Follow> getFollowerList(String memberId, Long cursorId, int pageSize);
 
     /**
      * 특정 회원의 팔로잉 목록 전체 조회
@@ -25,7 +28,7 @@ public interface MemberFollowQueryService {
      * @param cursorId 커서 ID (페이징을 위한) => 커서로 사용되는 ID는 Follow 엔티티 자체의 ID 값으로 사용하기!!
      * @return 팔로잉 목록
      */
-    MemberResponseDTO.FollowingListResponseDTO getFollowing(String memberId, Long cursorId);
+    List<Follow> getFollowingList(String memberId, Long cursorId, int pageSize);
 
     /**
      * 특정 회원의 팔로우 목록 size 개수만큼 조회
@@ -33,7 +36,7 @@ public interface MemberFollowQueryService {
      * @param memberId 조회할 회원의 ID
      * @return 팔로워 목록
      */
-    MemberResponseDTO.FollowerListResponseDTO getFollowers(Long memberId, int size);
+    MemberResponseDTO.FollowList getFollowers(Long memberId, int size);
 
     /**
      * 특정 회원의 팔로잉 목록 size 개수만큼 조회
@@ -41,7 +44,7 @@ public interface MemberFollowQueryService {
      * @param memberId 조회할 회원의 ID
      * @return 팔로잉 목록
      */
-    MemberResponseDTO.FollowingListResponseDTO getFollowing(Long memberId, int size);
+    MemberResponseDTO.FollowList getFollowings(Long memberId, int size);
 
     /**
      * 특정 회원의 팔로우 여부 확인

--- a/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryService.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryService.java
@@ -1,7 +1,6 @@
 package checkmo.domain.member.service.query;
 
 import checkmo.domain.member.entity.Follow;
-import checkmo.domain.member.web.dto.MemberResponseDTO;
 
 import java.util.List;
 

--- a/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryService.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryService.java
@@ -36,7 +36,7 @@ public interface MemberFollowQueryService {
      * @param memberId 조회할 회원의 ID
      * @return 팔로워 목록
      */
-    MemberResponseDTO.FollowList getFollowers(Long memberId, int size);
+    List<Follow> getFollowers(String memberId, int size);
 
     /**
      * 특정 회원의 팔로잉 목록 size 개수만큼 조회
@@ -44,7 +44,7 @@ public interface MemberFollowQueryService {
      * @param memberId 조회할 회원의 ID
      * @return 팔로잉 목록
      */
-    MemberResponseDTO.FollowList getFollowings(Long memberId, int size);
+    List<Follow> getFollowings(String memberId, int size);
 
     /**
      * 특정 회원의 팔로우 여부 확인

--- a/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
@@ -1,9 +1,13 @@
 package checkmo.domain.member.service.query;
 
+import checkmo.domain.member.entity.Follow;
 import checkmo.domain.member.repository.FollowRepository;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -12,22 +16,36 @@ public class MemberFollowQueryServiceImpl implements MemberFollowQueryService {
     private final FollowRepository followRepository;
 
     @Override
-    public MemberResponseDTO.FollowerListResponseDTO getFollowers(String memberId, Long cursorId) {
+    public List<Follow> getFollowerList(String memberId, Long cursorId, int pageSize) {
+
+        // cursorId가 null인 경우, 가장 최근 팔로워부터 조회, 여기서 memberId = 팔로잉 당하는 사람의 ID
+        if (cursorId == null) {
+            return followRepository.findByFollowingIdOrderByIdDesc(memberId, PageRequest.of(0, pageSize));
+        } else {
+            // cursorId보다 작은 ID의 팔로워를 조회
+            return followRepository.findByFollowingIdAndIdLessThanOrderByIdDesc(memberId, cursorId, PageRequest.of(0, pageSize));
+        }
+    }
+
+    @Override
+    public List<Follow> getFollowingList(String memberId, Long cursorId, int pageSize) {
+
+        // cursorId가 null인 경우, 가장 최근 팔로잉부터 조회, 여기서 memberId = 팔로우 하는 사람의 ID
+        if (cursorId == null) {
+            return followRepository.findByFollowerIdOrderByIdDesc(memberId, PageRequest.of(0, pageSize));
+        } else {
+            // cursorId보다 작은 ID의 팔로잉을 조회
+            return followRepository.findByFollowerIdAndIdLessThanOrderByIdDesc(memberId, cursorId, PageRequest.of(0, pageSize));
+        }
+    }
+
+    @Override
+    public MemberResponseDTO.FollowList getFollowers(Long memberId, int size) {
         throw new UnsupportedOperationException("아직 개발 중~");
     }
 
     @Override
-    public MemberResponseDTO.FollowingListResponseDTO getFollowing(String memberId, Long cursorId) {
-        throw new UnsupportedOperationException("아직 개발 중~");
-    }
-
-    @Override
-    public MemberResponseDTO.FollowerListResponseDTO getFollowers(Long memberId, int size) {
-        throw new UnsupportedOperationException("아직 개발 중~");
-    }
-
-    @Override
-    public MemberResponseDTO.FollowingListResponseDTO getFollowing(Long memberId, int size) {
+    public MemberResponseDTO.FollowList getFollowings(Long memberId, int size) {
         throw new UnsupportedOperationException("아직 개발 중~");
     }
 

--- a/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberFollowQueryServiceImpl.java
@@ -2,7 +2,6 @@ package checkmo.domain.member.service.query;
 
 import checkmo.domain.member.entity.Follow;
 import checkmo.domain.member.repository.FollowRepository;
-import checkmo.domain.member.web.dto.MemberResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -40,13 +39,13 @@ public class MemberFollowQueryServiceImpl implements MemberFollowQueryService {
     }
 
     @Override
-    public MemberResponseDTO.FollowList getFollowers(Long memberId, int size) {
-        throw new UnsupportedOperationException("아직 개발 중~");
+    public List<Follow> getFollowers(String memberId, int size) {
+        return followRepository.findByFollowingIdOrderByIdDesc(memberId, PageRequest.of(0, size));
     }
 
     @Override
-    public MemberResponseDTO.FollowList getFollowings(Long memberId, int size) {
-        throw new UnsupportedOperationException("아직 개발 중~");
+    public List<Follow> getFollowings(String memberId, int size) {
+        return followRepository.findByFollowerIdOrderByIdDesc(memberId, PageRequest.of(0, size));
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/service/query/MemberQueryService.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberQueryService.java
@@ -60,4 +60,13 @@ public interface MemberQueryService {
      * @return 회원 ID와 닉네임의 매핑 정보
      */
     Map<String, String> getMemberNicknamesByMemberIds(List<String> memberIds);
+
+    /**
+     * 회원 ID 목록으로 회원 닉네임과 프로필 이미지 배치 조회
+     *
+     * @param memberId 조회하는 회원 ID (팔로우 여부 확인용)
+     * @param memberIds 회원 ID 목록
+     * @return 회원 ID와 닉네임, 프로필 이미지 정보의 매핑
+     */
+    Map<String, MemberResponseDTO.FollowResponse> getMemberNicknamesAndProfileImagesByMemberIds(String memberId, List<String> memberIds);
 }

--- a/src/main/java/checkmo/domain/member/service/query/MemberQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberQueryServiceImpl.java
@@ -4,6 +4,7 @@ import checkmo.apiPayload.exception.GeneralException;
 import checkmo.apiPayload.code.status.ErrorStatus;
 import checkmo.domain.member.converter.MemberConverter;
 import checkmo.domain.member.entity.Member;
+import checkmo.domain.member.repository.FollowRepository;
 import checkmo.domain.member.repository.MemberRepository;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -18,7 +20,7 @@ import java.util.stream.Collectors;
 public class MemberQueryServiceImpl implements MemberQueryService {
 
     private final MemberRepository memberRepository;
-    private final MemberFollowQueryService memberFollowQueryService;
+    private final FollowRepository followRepository;
 
     @Override
     public boolean isNicknameDuplicated(String nickname) {
@@ -68,17 +70,23 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
     @Override
     public Map<String, MemberResponseDTO.FollowResponse> getMemberNicknamesAndProfileImagesByMemberIds(String memberId, List<String> memberIds) {
+        // 1. 배치로 회원 기본 정보 조회 (1번의 쿼리)
         var results = memberRepository.findIdNicknameAndImgUrlByIdIn(memberIds);
+        
+        // 2. 배치처리로 팔로잉 중인 회원의 id 목록 전부 조회 (2번의 쿼리)
+        Set<String> followingIds = followRepository.findFollowingIdsByFollowerId(memberId, memberIds);
+        
+        // 3. DTO 생성
         return results.stream()
                 .collect(Collectors.toMap(
                         row -> (String) row[0], // targetMemberId
                         row -> {
                             String targetMemberId = (String) row[0];
-                            boolean isFollowing = memberFollowQueryService.isFollowing(memberId, targetMemberId);
+                            boolean isFollowing = followingIds.contains(targetMemberId); // 팔로잉 여부 확인
                             return MemberResponseDTO.FollowResponse.builder()
                                     .nickname((String) row[1])     // nickname
                                     .profileImageUrl((String) row[2]) // imgUrl
-                                    .following(isFollowing) // 실제 팔로우 여부 조회
+                                    .following(isFollowing)
                                     .build();
                         }
                 ));

--- a/src/main/java/checkmo/domain/member/service/query/MemberQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberQueryServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 public class MemberQueryServiceImpl implements MemberQueryService {
 
     private final MemberRepository memberRepository;
+    private final MemberFollowQueryService memberFollowQueryService;
 
     @Override
     public boolean isNicknameDuplicated(String nickname) {
@@ -62,6 +63,24 @@ public class MemberQueryServiceImpl implements MemberQueryService {
                 .collect(Collectors.toMap(
                         row -> (String) row[0], // memberId
                         row -> (String) row[1]  // nickname
+                ));
+    }
+
+    @Override
+    public Map<String, MemberResponseDTO.FollowResponse> getMemberNicknamesAndProfileImagesByMemberIds(String memberId, List<String> memberIds) {
+        var results = memberRepository.findIdNicknameAndImgUrlByIdIn(memberIds);
+        return results.stream()
+                .collect(Collectors.toMap(
+                        row -> (String) row[0], // targetMemberId
+                        row -> {
+                            String targetMemberId = (String) row[0];
+                            boolean isFollowing = memberFollowQueryService.isFollowing(memberId, targetMemberId);
+                            return MemberResponseDTO.FollowResponse.builder()
+                                    .nickname((String) row[1])     // nickname
+                                    .profileImageUrl((String) row[2]) // imgUrl
+                                    .following(isFollowing) // 실제 팔로우 여부 조회
+                                    .build();
+                        }
                 ));
     }
 }

--- a/src/main/java/checkmo/domain/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/MemberController.java
@@ -73,7 +73,7 @@ public class MemberController {
     @Operation(summary = "팔로잉 중 특정 회원 삭제 API",
             description = "나를 팔로잉하고 있는 특정 회원을 삭제합니다.\n"+
             "팔로워 삭제는 팔로워 목록에서만 가능합니다. 팔로잉 목록에서는 팔로워를 삭제할 수 없습니다.\n"+
-            "팔로워를 삭제하면 해당 회운의 팔로잉 목록에서도 제거됩니다.")
+            "팔로워를 삭제하면 해당 회원의 팔로잉 목록에서도 제거됩니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),

--- a/src/main/java/checkmo/domain/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/MemberController.java
@@ -3,8 +3,10 @@ package checkmo.domain.member.web.controller;
 import checkmo.apiPayload.ApiResponse;
 import checkmo.domain.member.facade.MemberCommandFacade;
 import checkmo.domain.member.facade.MemberQueryFacade;
+import checkmo.domain.member.web.dto.MemberResponseDTO;
 import checkmo.global.auth.CurrentId;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -28,9 +30,13 @@ public class MemberController {
     // GET /api/members/me/clubs?status=all - 모임관리 페이지
     // DELETE /api/clubs/{clubId}/members/me - 모임 탈퇴
 
+    // 알림 설정 관련
+    // PATCH /api/members/me/notification-settings - 알림 설정
+
+    // 다른 사람 프로필 관련
+    // GET /api/members/{memberNickname} - 다른 사람 프로필 조회
+
     // 팔로우 관련
-    // GET /api/members/me/follow - 내 팔로우 조회
-    // GET /api/members/me/following - 내 팔로잉 조회
     @Operation(summary = "회원 팔로잉 API", description = "특정 회원을 팔로잉합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
@@ -82,9 +88,36 @@ public class MemberController {
         return ApiResponse.onSuccess(memberNickname + "님을 팔로워 목록에서 제거하였습니다.");
     }
 
-    // 알림 설정 관련
-    // PATCH /api/members/me/notification-settings - 알림 설정
+    @Operation(summary = "팔로잉 목록 조회 API", description = "특정 회원의 팔로잉 목록을 조회합니다.")
+    @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "10")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @GetMapping("/me/following")
+    public ApiResponse<MemberResponseDTO.FollowList> getFollowingList(
+            @CurrentId String memberId,
+            @RequestParam(required = false) Long cursorId
+    ) {
+        var followingList = memberQueryFacade.getFollowingList(memberId, cursorId);
+        return ApiResponse.onSuccess(followingList);
+    }
 
-    // 다른 사람 프로필 관련
-    // GET /api/members/{memberNickname} - 다른 사람 프로필 조회
+    @Operation(summary = "팔로워 목록 조회 API", description = "특정 회원의 팔로워 목록을 조회합니다.")
+    @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "10")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @GetMapping("/me/follower")
+    public ApiResponse<MemberResponseDTO.FollowList> getFollowerList(
+            @CurrentId String memberId,
+            @RequestParam(required = false) Long cursorId
+    ) {
+        var followerList = memberQueryFacade.getFollowerList(memberId, cursorId);
+        return ApiResponse.onSuccess(followerList);
+    }
+
 }

--- a/src/main/java/checkmo/domain/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/MemberController.java
@@ -29,7 +29,6 @@ public class MemberController {
     // DELETE /api/clubs/{clubId}/members/me - 모임 탈퇴
 
     // 팔로우 관련
-    // DELETE /api/members/{memberNickname}/follow - 팔로우 삭제
     // GET /api/members/me/follow - 내 팔로우 조회
     // GET /api/members/me/following - 내 팔로잉 조회
     @Operation(summary = "회원 팔로잉 API", description = "특정 회원을 팔로잉합니다.")
@@ -39,12 +38,48 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
     })
     @PostMapping("/{memberNickname}/following")
-    public ApiResponse<String> toggleFollow(
+    public ApiResponse<String> following(
             @CurrentId String memberId,
             @PathVariable String memberNickname
     ) {
-        memberCommandFacade.followMember(memberId, memberNickname);
+        memberCommandFacade.followingMember(memberId, memberNickname);
         return ApiResponse.onSuccess(memberNickname + "님 팔로잉에 성공했습니다.");
+    }
+
+    @Operation(summary = "회원 언팔로잉 API",
+            description = "팔로잉 목록에서 특정 회원을 언팔로잉 합니다.\n"+
+            "언팔로잉은 팔로잉 목록에서만 가능합니다. 팔로워 목록에서는 언팔로잉할 수 없습니다.\n"+
+            "언팔로잉을 하면 해당 회원의 팔로워 목록에서도 제거됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @DeleteMapping("/{memberNickname}/following")
+    public ApiResponse<String> unfollowing(
+            @CurrentId String memberId,
+            @PathVariable String memberNickname
+    ) {
+        memberCommandFacade.unfollowingMember(memberId, memberNickname);
+        return ApiResponse.onSuccess(memberNickname + "님을 언팔로잉 하였습니다.");
+    }
+
+    @Operation(summary = "팔로잉 중 특정 회원 삭제 API",
+            description = "나를 팔로잉하고 있는 특정 회원을 삭제합니다.\n"+
+            "팔로워 삭제는 팔로워 목록에서만 가능합니다. 팔로잉 목록에서는 팔로워를 삭제할 수 없습니다.\n"+
+            "팔로워를 삭제하면 해당 회운의 팔로잉 목록에서도 제거됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @DeleteMapping("/{memberNickname}/follower")
+    public ApiResponse<String> deleteFollower(
+            @CurrentId String memberId,
+            @PathVariable String memberNickname
+    ) {
+        memberCommandFacade.deleteFollower(memberId, memberNickname);
+        return ApiResponse.onSuccess(memberNickname + "님을 팔로워 목록에서 제거하였습니다.");
     }
 
     // 알림 설정 관련

--- a/src/main/java/checkmo/domain/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/MemberController.java
@@ -1,15 +1,23 @@
 package checkmo.domain.member.web.controller;
 
+import checkmo.apiPayload.ApiResponse;
+import checkmo.domain.member.facade.MemberCommandFacade;
+import checkmo.domain.member.facade.MemberQueryFacade;
+import checkmo.global.auth.CurrentId;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping()
+@RequestMapping("/api/members")
 @RequiredArgsConstructor
 @Tag(name = "회원", description = "마이페이지, 프로필 관리, 팔로우, 모임 관리, 알림 설정 관련 API")
 public class MemberController {
+
+    private final MemberCommandFacade memberCommandFacade;
+    private final MemberQueryFacade memberQueryFacade;
 
     // 마이페이지 관련
     // GET /api/members/me - 마이페이지 조회
@@ -21,10 +29,23 @@ public class MemberController {
     // DELETE /api/clubs/{clubId}/members/me - 모임 탈퇴
 
     // 팔로우 관련
-    // POST /api/members/{memberNickname}/follow - 팔로우 누르기
     // DELETE /api/members/{memberNickname}/follow - 팔로우 삭제
     // GET /api/members/me/follow - 내 팔로우 조회
     // GET /api/members/me/following - 내 팔로잉 조회
+    @Operation(summary = "회원 팔로잉 API", description = "특정 회원을 팔로잉합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @PostMapping("/{memberNickname}/following")
+    public ApiResponse<String> toggleFollow(
+            @CurrentId String memberId,
+            @PathVariable String memberNickname
+    ) {
+        memberCommandFacade.followMember(memberId, memberNickname);
+        return ApiResponse.onSuccess(memberNickname + "님 팔로잉에 성공했습니다.");
+    }
 
     // 알림 설정 관련
     // PATCH /api/members/me/notification-settings - 알림 설정

--- a/src/main/java/checkmo/domain/member/web/dto/MemberResponseDTO.java
+++ b/src/main/java/checkmo/domain/member/web/dto/MemberResponseDTO.java
@@ -18,21 +18,8 @@ public class MemberResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class FollowingListResponseDTO {
-        private List<FollowResponseDTO> followingList; // 팔로잉 목록
-        private boolean hasNext;        // 다음 페이지 존재 여부
-        private Long nextCursor;        // 다음 페이지 커서 (마지막 항목의 ID)
-    }
-
-    /**
-     * 팔로우 목록 조회 응답 DTO
-     */
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class FollowerListResponseDTO {
-        private List<FollowResponseDTO> followerList; // 팔로우 목록
+    public static class FollowList {
+        private List<FollowResponse> followList; // 팔로잉 목록
         private boolean hasNext;        // 다음 페이지 존재 여부
         private Long nextCursor;        // 다음 페이지 커서 (마지막 항목의 ID)
     }
@@ -41,10 +28,10 @@ public class MemberResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class FollowResponseDTO {
-        private Long followId;   // 팔로우 ID (Follow 엔티티의 ID)
+    public static class FollowResponse {
         private String nickname; // 회원 닉네임
         private String profileImageUrl; // 프로필 이미지 URL
+        private boolean following; // 조회하는 사람의 팔로우 여부
     }
 
 

--- a/src/main/java/checkmo/domain/member/web/dto/MemberResponseDTO.java
+++ b/src/main/java/checkmo/domain/member/web/dto/MemberResponseDTO.java
@@ -19,9 +19,17 @@ public class MemberResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class FollowList {
-        private List<FollowResponse> followList; // 팔로잉 목록
+        private List<FollowResponse> followList; // 팔로워/팔로잉 목록
         private boolean hasNext;        // 다음 페이지 존재 여부
         private Long nextCursor;        // 다음 페이지 커서 (마지막 항목의 ID)
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class FollowPreviewList {
+        private List<FollowResponse> followList; // 팔로워/팔로잉 목록
     }
 
     @Getter
@@ -31,7 +39,7 @@ public class MemberResponseDTO {
     public static class FollowResponse {
         private String nickname; // 회원 닉네임
         private String profileImageUrl; // 프로필 이미지 URL
-        private boolean following; // 조회하는 사람의 팔로우 여부
+        private boolean following; // 조회하는 사람의 팔로잉 여부
     }
 
 

--- a/src/main/java/checkmo/domain/notification/entity/Notification.java
+++ b/src/main/java/checkmo/domain/notification/entity/Notification.java
@@ -24,6 +24,7 @@ public class Notification extends BaseEntity {
     @Column(nullable = false)
     private NotificationType notificationType;
 
+    @Builder.Default
     @Column(nullable = false)
     private boolean isRead = false;
 

--- a/src/main/java/checkmo/domain/notification/service/command/NotificationCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/notification/service/command/NotificationCommandServiceImpl.java
@@ -40,11 +40,11 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
 
     @Override
     @Transactional
-    @CacheEvict(value = "notifications", key = "#event.getFollowedId()")
+    @CacheEvict(value = "notifications", key = "#event.getFollowingId()")
     public void createNotification(FollowEvent event) {
         // 팔로우 이벤트에서 팔로우 누른 사람과 팔로우 당하는 사람의 정보를 가져옴 (프록시로)
         Member proxyFollower = memberQueryFacade.findMemberReferenceById(event.getFollowerId()); // 팔로우 누른 사람
-        Member proxyFollowed = memberQueryFacade.findMemberReferenceById(event.getFollowedId()); // 팔로우 당하는 사람
+        Member proxyFollowing = memberQueryFacade.findMemberReferenceById(event.getFollowingId()); // 팔로우 당하는 사람
 
         // 팔로우 누른 사람의 닉네임을 가져옴
         String FollowerNickname = memberQueryFacade.getMemberNicknameById(event.getFollowerId());
@@ -53,7 +53,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
         String redirectPath = NotificationConverter.getRedirectPath(Notification.NotificationType.FOLLOW, FollowerNickname);
 
         // Notification 객체를 생성하고 저장
-        Notification notification = NotificationConverter.fromEvent(Notification.NotificationType.FOLLOW, redirectPath, proxyFollower, proxyFollowed);
+        Notification notification = NotificationConverter.fromEvent(Notification.NotificationType.FOLLOW, redirectPath, proxyFollower, proxyFollowing);
         notificationRepository.save(notification);
     }
 

--- a/src/main/java/checkmo/event/FollowEvent.java
+++ b/src/main/java/checkmo/event/FollowEvent.java
@@ -7,5 +7,5 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FollowEvent {
     private final String followerId; // 팔로우를 한 회원의 ID
-    private final String followedId;  // 팔로우를 당한 회원의 ID
+    private final String followingId;  // 팔로우를 당한 회원의 ID
 }

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -1,9 +1,8 @@
 spring:
   data:
     redis:
-      host: redis
+      host: ${REDIS_ENDPOINT}
       port: 6379
-      password: checkmo123
       database: 0
       timeout: 2000ms
       lettuce:


### PR DESCRIPTION
## 🚀 변경사항
팔로잉 하기, 팔로잉 취소, 팔로우 삭제
내 팔로잉 목록 조회, 내 팔로워 목록 조회 구현
- 처음에는 팔로잉/언팔로잉 을 전부 같은 API로 가능하게 설계하려 했으나, 책이야기 좋아요와 같이 단순 토글로 처리하기에는 복잡도가 있어 팔로잉은 POST로 언팔로잉은 DELETE로 분리

## 🔗 관련 이슈
- Closes #56 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive member follow functionality with APIs to follow/unfollow members, remove followers, and retrieve follower/following lists with cursor-based pagination.
  * Added endpoints for managing and viewing your followers and followings.

* **Improvements**
  * Enhanced follow/follower list responses to include member nicknames, profile images, and following status.
  * Enforced unique follow relationships to prevent duplicate follows.
  * Improved error messaging for follow actions with detailed status codes.

* **Bug Fixes**
  * Corrected default values and cache logic for notifications related to follow events.

* **Refactor**
  * Standardized naming conventions for follow-related methods and data fields for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->