### PR TITLE
Feat/64/update profile

### DIFF
--- a/src/main/java/checkmo/domain/category/facade/CategoryCommandFacade.java
+++ b/src/main/java/checkmo/domain/category/facade/CategoryCommandFacade.java
@@ -2,6 +2,7 @@ package checkmo.domain.category.facade;
 
 import checkmo.domain.category.web.dto.CategoryRequestDTO;
 import checkmo.global.dto.CategorySharedDTO;
+import java.util.List;
 
 /**
  * Category Domain Command Facade
@@ -18,7 +19,7 @@ public interface CategoryCommandFacade {
      * @param request  수정할 카테고리 ID 목록 DTO
      * @return 수정된 카테고리 정보가 담긴 **공유 DTO**
      */
-    CategorySharedDTO.CategoryInfoList modifyMemberCategories(String memberId, CategorySharedDTO.CategoryIdListDTO request);
+    void modifyMemberCategories(String memberId, CategorySharedDTO.CategoryIdListDTO request);
 
     /**
      * 특정 모임의 카테고리 목록을 수정합니다.

--- a/src/main/java/checkmo/domain/category/facade/CategoryCommandFacade.java
+++ b/src/main/java/checkmo/domain/category/facade/CategoryCommandFacade.java
@@ -2,7 +2,6 @@ package checkmo.domain.category.facade;
 
 import checkmo.domain.category.web.dto.CategoryRequestDTO;
 import checkmo.global.dto.CategorySharedDTO;
-import java.util.List;
 
 /**
  * Category Domain Command Facade
@@ -17,7 +16,6 @@ public interface CategoryCommandFacade {
      *
      * @param memberId 회원 ID
      * @param request  수정할 카테고리 ID 목록 DTO
-     * @return 수정된 카테고리 정보가 담긴 **공유 DTO**
      */
     void modifyMemberCategories(String memberId, CategorySharedDTO.CategoryIdListDTO request);
 

--- a/src/main/java/checkmo/domain/category/facade/CategoryCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/category/facade/CategoryCommandFacadeImpl.java
@@ -5,6 +5,7 @@ import checkmo.domain.category.service.command.CategoryAssignmentCommandService;
 import checkmo.domain.category.web.dto.CategoryRequestDTO;
 import checkmo.domain.category.web.dto.CategoryResponseDTO;
 import checkmo.global.dto.CategorySharedDTO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,9 +18,8 @@ public class CategoryCommandFacadeImpl implements CategoryCommandFacade {
     private final CategoryAssignmentCommandService categoryAssignmentCommandService;
 
     @Override
-    public CategorySharedDTO.CategoryInfoList modifyMemberCategories(String memberId, CategorySharedDTO.CategoryIdListDTO request) {
-        CategoryResponseDTO.CategoryListResponseDTO response = categoryAssignmentCommandService.modifyMemberCategories(memberId, request);
-        return CategoryConverter.toCategoryInfoListDTO(response);
+    public void modifyMemberCategories(String memberId, CategorySharedDTO.CategoryIdListDTO request) {
+        categoryAssignmentCommandService.modifyMemberCategories(memberId, request);
     }
 
     /**

--- a/src/main/java/checkmo/domain/category/facade/CategoryCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/category/facade/CategoryCommandFacadeImpl.java
@@ -5,7 +5,6 @@ import checkmo.domain.category.service.command.CategoryAssignmentCommandService;
 import checkmo.domain.category.web.dto.CategoryRequestDTO;
 import checkmo.domain.category.web.dto.CategoryResponseDTO;
 import checkmo.global.dto.CategorySharedDTO;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/checkmo/domain/category/facade/CategoryQueryFacade.java
+++ b/src/main/java/checkmo/domain/category/facade/CategoryQueryFacade.java
@@ -2,7 +2,6 @@ package checkmo.domain.category.facade;
 
 import checkmo.domain.category.entity.Category;
 import checkmo.global.dto.CategorySharedDTO;
-import java.util.List;
 
 /**
  * Category Domain Query Facade

--- a/src/main/java/checkmo/domain/category/facade/CategoryQueryFacade.java
+++ b/src/main/java/checkmo/domain/category/facade/CategoryQueryFacade.java
@@ -2,6 +2,7 @@ package checkmo.domain.category.facade;
 
 import checkmo.domain.category.entity.Category;
 import checkmo.global.dto.CategorySharedDTO;
+import java.util.List;
 
 /**
  * Category Domain Query Facade
@@ -25,7 +26,7 @@ public interface CategoryQueryFacade {
      * @param memberId 회원 ID
      * @return 해당 회원의 카테고리 정보가 담긴 공유 DTO
      */
-    CategorySharedDTO.CategoryInfoList getCategoriesByMemberForShare(Long memberId);
+    CategorySharedDTO.CategoryInfoList getCategoriesByMemberForShare(String memberId);
 
     /**
      * 특정 모임에 설정된 카테고리 목록을 조회합니다. (외부용)

--- a/src/main/java/checkmo/domain/category/facade/CategoryQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/category/facade/CategoryQueryFacadeImpl.java
@@ -8,6 +8,7 @@ import checkmo.domain.category.web.dto.CategoryResponseDTO;
 import checkmo.global.dto.CategorySharedDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,8 +23,9 @@ public class CategoryQueryFacadeImpl implements CategoryQueryFacade {
     }
 
     @Override
-    public CategorySharedDTO.CategoryInfoList getCategoriesByMemberForShare(Long memberId) {
-        return null;
+    public CategorySharedDTO.CategoryInfoList getCategoriesByMemberForShare(String memberId) {
+        CategoryResponseDTO.CategoryListResponseDTO responseDTO = categoryQueryService.findCategoriesByMember(memberId);
+        return CategoryConverter.toCategoryInfoListDTO(responseDTO);
     }
 
     /**

--- a/src/main/java/checkmo/domain/category/service/command/CategoryAssignmentCommandService.java
+++ b/src/main/java/checkmo/domain/category/service/command/CategoryAssignmentCommandService.java
@@ -15,7 +15,7 @@ public interface CategoryAssignmentCommandService {
      * @param request  추가할 카테고리 ID 목록
      * @return 추가된 카테고리 정보가 담긴 DTO
      */
-    CategoryResponseDTO.CategoryListResponseDTO modifyMemberCategories(String memberId, CategorySharedDTO.CategoryIdListDTO request);
+    void modifyMemberCategories(String memberId, CategorySharedDTO.CategoryIdListDTO request);
 
     /**
      * Club의 관심 카테고리 수정 - 이미 추가되어있는 관심 카테고리는 서비스 로직 구현 시 제외하고 새로운 카테고리만 추가 or 제거

--- a/src/main/java/checkmo/domain/category/service/command/CategoryAssignmentCommandService.java
+++ b/src/main/java/checkmo/domain/category/service/command/CategoryAssignmentCommandService.java
@@ -13,7 +13,6 @@ public interface CategoryAssignmentCommandService {
      *
      * @param memberId     회원 ID
      * @param request  추가할 카테고리 ID 목록
-     * @return 추가된 카테고리 정보가 담긴 DTO
      */
     void modifyMemberCategories(String memberId, CategorySharedDTO.CategoryIdListDTO request);
 

--- a/src/main/java/checkmo/domain/category/service/command/CategoryAssignmentCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/category/service/command/CategoryAssignmentCommandServiceImpl.java
@@ -34,7 +34,7 @@ public class CategoryAssignmentCommandServiceImpl implements CategoryAssignmentC
     private final MemberQueryFacade memberQueryFacade;
 
     @Override
-    public CategoryResponseDTO.CategoryListResponseDTO modifyMemberCategories(String memberId, CategorySharedDTO.CategoryIdListDTO request) {
+    public void modifyMemberCategories(String memberId, CategorySharedDTO.CategoryIdListDTO request) {
 
         // 1. 기존 카테고리 ID 리스트
         List<MemberCategory> existingMemberCategories = memberCategoryRepository.findByMemberId(memberId);
@@ -80,9 +80,6 @@ public class CategoryAssignmentCommandServiceImpl implements CategoryAssignmentC
 
         // 8. 최종 카테고리 목록
         List<MemberCategory> updatedMemberCategories = memberCategoryRepository.findByMemberId(memberId);
-
-        // 9. DTO 변환 후 반환
-        return CategoryConverter.toMemberCategoryListResponseDTO(updatedMemberCategories);
     }
 
     /**

--- a/src/main/java/checkmo/domain/category/service/query/CategoryQueryService.java
+++ b/src/main/java/checkmo/domain/category/service/query/CategoryQueryService.java
@@ -20,7 +20,7 @@ public interface CategoryQueryService {
      * @param memberId 회원 ID
      * @return 회원의 카테고리 정보가 담긴 List
      */
-    CategoryResponseDTO.CategoryListResponseDTO findCategoriesByMember(Long memberId);
+    CategoryResponseDTO.CategoryListResponseDTO findCategoriesByMember(String memberId);
 
     /**
      * 모임의 모든 카테고리 조회

--- a/src/main/java/checkmo/domain/category/service/query/CategoryQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/category/service/query/CategoryQueryServiceImpl.java
@@ -6,7 +6,6 @@ import checkmo.domain.category.entity.MemberCategory;
 import checkmo.domain.category.repository.ClubCategoryRepository;
 import checkmo.domain.category.repository.MemberCategoryRepository;
 import checkmo.domain.category.web.dto.CategoryResponseDTO;
-import checkmo.domain.member.web.dto.MemberResponseDTO.MemberProfileResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/checkmo/domain/category/service/query/CategoryQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/category/service/query/CategoryQueryServiceImpl.java
@@ -2,8 +2,11 @@ package checkmo.domain.category.service.query;
 
 import checkmo.domain.category.converter.CategoryConverter;
 import checkmo.domain.category.entity.ClubCategory;
+import checkmo.domain.category.entity.MemberCategory;
 import checkmo.domain.category.repository.ClubCategoryRepository;
+import checkmo.domain.category.repository.MemberCategoryRepository;
 import checkmo.domain.category.web.dto.CategoryResponseDTO;
+import checkmo.domain.member.web.dto.MemberResponseDTO.MemberProfileResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,6 +17,7 @@ import java.util.List;
 public class CategoryQueryServiceImpl implements CategoryQueryService {
 
     private final ClubCategoryRepository clubCategoryRepository;
+    private final MemberCategoryRepository memberCategoryRepository;
 
     @Override
     public CategoryResponseDTO.CategoryListResponseDTO findAllCategories() {
@@ -21,8 +25,10 @@ public class CategoryQueryServiceImpl implements CategoryQueryService {
     }
 
     @Override
-    public CategoryResponseDTO.CategoryListResponseDTO findCategoriesByMember(Long memberId) {
-        return null;
+    public CategoryResponseDTO.CategoryListResponseDTO findCategoriesByMember(String memberId) {
+        List<MemberCategory> memberCategories = memberCategoryRepository.findByMemberId(memberId);
+
+        return CategoryConverter.toMemberCategoryListResponseDTO(memberCategories);
     }
 
     /**

--- a/src/main/java/checkmo/domain/member/converter/MemberConverter.java
+++ b/src/main/java/checkmo/domain/member/converter/MemberConverter.java
@@ -5,10 +5,10 @@ import checkmo.domain.member.entity.Member;
 import checkmo.domain.member.service.security.oauth2.OAuth2Attributes;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
-
+import checkmo.global.dto.CategorySharedDTO;
+import checkmo.global.dto.MemberSharedDTO;
 import java.util.List;
 import java.util.UUID;
-import checkmo.global.dto.MemberSharedDTO;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -90,6 +90,17 @@ public class MemberConverter {
                 .build();
     }
 
+    /**
+     * Member 엔티티 → MemberResponseDTO.FollowResponse 변환
+     */
+    public static MemberResponseDTO.MemberProfileWithCategoryResponseDTO toMemberProfileWithCategoryResponseDTO(Member member, List<CategorySharedDTO.CategoryInfo> categories) {
+        return MemberResponseDTO.MemberProfileWithCategoryResponseDTO.builder()
+                .nickname(member.getNickName())
+                .description(member.getDescription())
+                .profileImageUrl(member.getImgUrl())
+                .categories(categories)
+                .build();
+    }
     /**
      * MemberProfileResponseDTO → BasicInfoDTO 변환
      */

--- a/src/main/java/checkmo/domain/member/entity/Member.java
+++ b/src/main/java/checkmo/domain/member/entity/Member.java
@@ -101,4 +101,10 @@ public class Member extends BaseEntity {
     public void completeProfile() {
         this.isProfileCompleted = true;
     }
+
+    // 프로필 수정
+    public void updateProfile(String description, String imgUrl) {
+        this.description = description != null ? description : "";
+        this.imgUrl = imgUrl != null ? imgUrl : "";
+    }
 }

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacade.java
@@ -76,7 +76,7 @@ public interface MemberCommandFacade {
      * @param request 수정할 프로필 정보 DTO
      * @return 수정된 회원 프로필 정보 DTO
      */
-    MemberResponseDTO.MemberProfileResponseDTO updateMemberProfile(String memberId, MemberRequestDTO.MemberProfileUpdateRequestDTO request);
+    MemberResponseDTO.MemberProfileWithCategoryResponseDTO updateMemberProfile(String memberId, MemberRequestDTO.MemberProfileUpdateRequestDTO request);
 
     /**
      * 회원 비밀번호 변경 (내부용)

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
@@ -2,6 +2,7 @@ package checkmo.domain.member.facade;
 
 import checkmo.domain.member.service.authenticate.MemberAuthenticationService;
 import checkmo.domain.member.service.command.MemberFollowCommandService;
+import checkmo.domain.member.service.command.MemberProfileCommandService;
 import checkmo.domain.member.service.command.MemberRegistrationCommandService;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
@@ -19,6 +20,7 @@ public class MemberCommandFacadeImpl implements MemberCommandFacade{
     private final MemberRegistrationCommandService memberRegistrationCommandService;
     private final MemberAuthenticationService memberAuthenticationService;
     private final MemberFollowCommandService memberFollowCommandService;
+    private final MemberProfileCommandService memberProfileCommandService;
 
     @Override
     public void sendEmailVerification(String email) {
@@ -57,7 +59,7 @@ public class MemberCommandFacadeImpl implements MemberCommandFacade{
 
     @Override
     public MemberResponseDTO.MemberProfileResponseDTO updateMemberProfile(String memberId, MemberRequestDTO.MemberProfileUpdateRequestDTO request) {
-        throw new UnsupportedOperationException("추후 구현 예정");
+        return memberProfileCommandService.updateMemberProfile(memberId, request);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberCommandFacadeImpl.java
@@ -58,7 +58,7 @@ public class MemberCommandFacadeImpl implements MemberCommandFacade{
     }
 
     @Override
-    public MemberResponseDTO.MemberProfileResponseDTO updateMemberProfile(String memberId, MemberRequestDTO.MemberProfileUpdateRequestDTO request) {
+    public MemberResponseDTO.MemberProfileWithCategoryResponseDTO updateMemberProfile(String memberId, MemberRequestDTO.MemberProfileUpdateRequestDTO request) {
         return memberProfileCommandService.updateMemberProfile(memberId, request);
     }
 

--- a/src/main/java/checkmo/domain/member/facade/MemberQueryFacade.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberQueryFacade.java
@@ -32,6 +32,14 @@ public interface MemberQueryFacade {
     MemberResponseDTO.MemberProfileResponseDTO getMemberBasicInfo(String memberId);
 
     /**
+     * 회원 프로필 정보 (카테고리 포함) 조회 (내부용)
+     *
+     * @param memberId 회원 ID
+     * @return 회원 프로필 정보 DTO
+     */
+    MemberResponseDTO.MemberProfileWithCategoryResponseDTO getMemberProfile(String memberId);
+
+    /**
      * 다른 사람 프로필 조회 (내부용)
      *
      * @param targetMemberNickname 조회 대상 회원 닉네임

--- a/src/main/java/checkmo/domain/member/facade/MemberQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberQueryFacadeImpl.java
@@ -34,7 +34,12 @@ public class MemberQueryFacadeImpl implements MemberQueryFacade {
 
     @Override
     public MemberResponseDTO.MemberProfileResponseDTO getMemberBasicInfo(String memberId) {
-        return null;
+        return memberQueryService.getMemberBasicInfo(memberId);
+    }
+
+    @Override
+    public MemberResponseDTO.MemberProfileWithCategoryResponseDTO getMemberProfile(String memberId) {
+        return memberQueryService.getMemberProfile(memberId);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/service/command/MemberProfileCommandService.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberProfileCommandService.java
@@ -18,7 +18,7 @@ public interface MemberProfileCommandService {
      * @param request 수정할 프로필 정보 DTO - 프로필 이미지, 간단 소개, 관심 카테고리 (닉네임은 변경 불가!!)
      * @return 수정된 회원 프로필 정보 DTO - 이때는 관심 카테고리 정보 DTO에 포함 X , -> 반드시 CategoryQueryFacade를 통해 조회해야 함
      */
-    MemberResponseDTO.MemberProfileResponseDTO updateMemberProfile(
+    MemberResponseDTO.MemberProfileWithCategoryResponseDTO updateMemberProfile(
             String memberId, MemberRequestDTO.MemberProfileUpdateRequestDTO request
     );
 

--- a/src/main/java/checkmo/domain/member/service/command/MemberProfileCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberProfileCommandServiceImpl.java
@@ -1,0 +1,63 @@
+package checkmo.domain.member.service.command;
+
+import checkmo.apiPayload.code.status.ErrorStatus;
+import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.category.facade.CategoryCommandFacade;
+import checkmo.domain.member.converter.MemberConverter;
+import checkmo.domain.member.entity.Member;
+import checkmo.domain.member.repository.MemberRepository;
+import checkmo.domain.member.web.dto.MemberRequestDTO;
+import checkmo.domain.member.web.dto.MemberResponseDTO;
+import checkmo.global.dto.CategorySharedDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberProfileCommandServiceImpl implements MemberProfileCommandService {
+
+    private final MemberRepository memberRepository;
+    private final CategoryCommandFacade categoryCommandFacade;
+
+    @Override
+    public MemberResponseDTO.MemberProfileResponseDTO updateMemberProfile(
+        String memberId, MemberRequestDTO.MemberProfileUpdateRequestDTO request
+    ) {
+        // 회원 조회
+        Member member = memberRepository.findById(memberId)
+                                        .orElseThrow(() -> new GeneralException(
+                                            ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 프로필 정보 업데이트 (소개, 이미지)
+        member.updateProfile(request.getDescription(), request.getImgUrl());
+
+        // 관심 카테고리 수정
+        if (request.getCategoryIds() != null) {
+            categoryCommandFacade.modifyMemberCategories(memberId,
+                CategorySharedDTO.CategoryIdListDTO.builder()
+                                                   .categoryIdList(request.getCategoryIds())
+                                                   .build());
+        }
+
+        return MemberConverter.toMemberProfileResponseDTO(member);
+    }
+
+    @Override
+    public void updatePassword(
+        String memberId, MemberRequestDTO.PasswordUpdateRequestDTO request
+    ) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void deactivateMember(String memberId) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+
+    @Override
+    public void deleteMember(String memberId) {
+        throw new UnsupportedOperationException("추후 구현 예정");
+    }
+}

--- a/src/main/java/checkmo/domain/member/service/command/MemberProfileCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/command/MemberProfileCommandServiceImpl.java
@@ -3,12 +3,14 @@ package checkmo.domain.member.service.command;
 import checkmo.apiPayload.code.status.ErrorStatus;
 import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.category.facade.CategoryCommandFacade;
+import checkmo.domain.category.facade.CategoryQueryFacade;
 import checkmo.domain.member.converter.MemberConverter;
 import checkmo.domain.member.entity.Member;
 import checkmo.domain.member.repository.MemberRepository;
 import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
 import checkmo.global.dto.CategorySharedDTO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,9 +22,10 @@ public class MemberProfileCommandServiceImpl implements MemberProfileCommandServ
 
     private final MemberRepository memberRepository;
     private final CategoryCommandFacade categoryCommandFacade;
+    private final CategoryQueryFacade categoryQueryFacade;
 
     @Override
-    public MemberResponseDTO.MemberProfileResponseDTO updateMemberProfile(
+    public MemberResponseDTO.MemberProfileWithCategoryResponseDTO updateMemberProfile(
         String memberId, MemberRequestDTO.MemberProfileUpdateRequestDTO request
     ) {
         // 회원 조회
@@ -41,7 +44,9 @@ public class MemberProfileCommandServiceImpl implements MemberProfileCommandServ
                                                    .build());
         }
 
-        return MemberConverter.toMemberProfileResponseDTO(member);
+        List<CategorySharedDTO.CategoryInfo> categories = categoryQueryFacade.getCategoriesByMemberForShare(memberId).getCategoryList();
+
+        return MemberConverter.toMemberProfileWithCategoryResponseDTO(member, categories);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/service/query/MemberQueryService.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberQueryService.java
@@ -30,6 +30,14 @@ public interface MemberQueryService {
     MemberResponseDTO.MemberProfileResponseDTO getMemberBasicInfo(String memberId);
 
     /**
+     * 회원 프로필 정보 (카테고리 포함) 조회
+     *
+     * @param memberId 회원 ID
+     * @return 회원 프로필 정보 DTO
+     */
+    MemberResponseDTO.MemberProfileWithCategoryResponseDTO getMemberProfile(String memberId);
+
+    /**
      * 회원 ID 목록으로 회원 기본 정보 배치 조회
      *
      * @param memberIds 회원 ID 목록

--- a/src/main/java/checkmo/domain/member/service/query/MemberQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberQueryServiceImpl.java
@@ -2,11 +2,13 @@ package checkmo.domain.member.service.query;
 
 import checkmo.apiPayload.code.status.ErrorStatus;
 import checkmo.apiPayload.exception.GeneralException;
+import checkmo.domain.category.facade.CategoryQueryFacade;
 import checkmo.domain.member.converter.MemberConverter;
 import checkmo.domain.member.entity.Member;
 import checkmo.domain.member.repository.FollowRepository;
 import checkmo.domain.member.repository.MemberRepository;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
+import checkmo.global.dto.CategorySharedDTO;
 import checkmo.global.dto.MemberSharedDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
+    private final CategoryQueryFacade categoryQueryFacade;
 
     @Override
     public boolean isNicknameDuplicated(String nickname) {
@@ -40,6 +43,16 @@ public class MemberQueryServiceImpl implements MemberQueryService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         return MemberConverter.toMemberProfileResponseDTO(member);
+    }
+
+    @Override
+    public MemberResponseDTO.MemberProfileWithCategoryResponseDTO getMemberProfile(String memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        List<CategorySharedDTO.CategoryInfo> categories = categoryQueryFacade.getCategoriesByMemberForShare(memberId).getCategoryList();
+
+        return MemberConverter.toMemberProfileWithCategoryResponseDTO(member, categories);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/MemberController.java
@@ -131,7 +131,7 @@ public class MemberController {
     }
 
     @Operation(summary = "내 프로필 조회 API", description = "내 프로필 정보(관심 카테고리 정보 포함)를 조회합니다.")
-    @GetMapping("/profile")
+    @GetMapping("/me")
     public ApiResponse<MemberResponseDTO.MemberProfileWithCategoryResponseDTO> getMemberProfile(
             @CurrentId String memberId
     ) {

--- a/src/main/java/checkmo/domain/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/MemberController.java
@@ -123,7 +123,7 @@ public class MemberController {
 
     @Operation(summary = "내 프로필 편집 API", description = "내 프로필을 편집합니다. 프로필 이미지, 소개, 관심 카테고리를 수정할 수 있습니다.")
     @PatchMapping("/me")
-    public ApiResponse<MemberResponseDTO.MemberProfileResponseDTO> updateMemberProfile(
+    public ApiResponse<MemberResponseDTO.MemberProfileWithCategoryResponseDTO> updateMemberProfile(
             @CurrentId String memberId,
             @RequestBody MemberRequestDTO.MemberProfileUpdateRequestDTO request
     ) {

--- a/src/main/java/checkmo/domain/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/MemberController.java
@@ -129,4 +129,12 @@ public class MemberController {
     ) {
         return ApiResponse.onSuccess(memberCommandFacade.updateMemberProfile(memberId, request));
     }
+
+    @Operation(summary = "내 프로필 조회 API", description = "내 프로필 정보(관심 카테고리 정보 포함)를 조회합니다.")
+    @GetMapping("/profile")
+    public ApiResponse<MemberResponseDTO.MemberProfileWithCategoryResponseDTO> getMemberProfile(
+            @CurrentId String memberId
+    ) {
+        return ApiResponse.onSuccess(memberQueryFacade.getMemberProfile(memberId));
+    }
 }

--- a/src/main/java/checkmo/domain/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/MemberController.java
@@ -3,6 +3,7 @@ package checkmo.domain.member.web.controller;
 import checkmo.apiPayload.ApiResponse;
 import checkmo.domain.member.facade.MemberCommandFacade;
 import checkmo.domain.member.facade.MemberQueryFacade;
+import checkmo.domain.member.web.dto.MemberRequestDTO;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
 import checkmo.global.auth.CurrentId;
 import io.swagger.v3.oas.annotations.Operation;
@@ -120,4 +121,12 @@ public class MemberController {
         return ApiResponse.onSuccess(followerList);
     }
 
+    @Operation(summary = "내 프로필 편집 API", description = "내 프로필을 편집합니다. 프로필 이미지, 소개, 관심 카테고리를 수정할 수 있습니다.")
+    @PatchMapping("/me")
+    public ApiResponse<MemberResponseDTO.MemberProfileResponseDTO> updateMemberProfile(
+            @CurrentId String memberId,
+            @RequestBody MemberRequestDTO.MemberProfileUpdateRequestDTO request
+    ) {
+        return ApiResponse.onSuccess(memberCommandFacade.updateMemberProfile(memberId, request));
+    }
 }

--- a/src/main/java/checkmo/domain/member/web/dto/MemberResponseDTO.java
+++ b/src/main/java/checkmo/domain/member/web/dto/MemberResponseDTO.java
@@ -1,13 +1,13 @@
 package checkmo.domain.member.web.dto;
 
 import checkmo.global.dto.BookSharedDTO;
+import checkmo.global.dto.CategorySharedDTO;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 public class MemberResponseDTO {
 
@@ -51,6 +51,17 @@ public class MemberResponseDTO {
         private String nickname;
         private String description;
         private String profileImageUrl;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MemberProfileWithCategoryResponseDTO {
+        private String nickname;
+        private String description;
+        private String profileImageUrl;
+        private List<CategorySharedDTO.CategoryInfo> categories; // 카테고리 정보 리스트
     }
 
     @Getter


### PR DESCRIPTION
## 🚀 변경사항
- 프로필 편집(소개, 프로필 이미지, 관심 카테고리) api 추가
- 프로필 조회 (닉네임, 소개, 프로필 이미지, 관심 카테고리) api 추가

## 🔗 관련 이슈
- Closes #64 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoints for updating and retrieving a user's profile, now including profile image, introduction, and interest categories.
  * Introduced a new response format for member profiles that includes associated categories.
  * Added support for managing member categories and profiles with string-based member IDs.
  * Added a new method to update member profiles with selective fields (description and image).
  * Implemented member profile update service handling profile and category changes.

* **Improvements**
  * Member profile update and retrieval operations now return enhanced information, including interest categories.
  * Member profile update logic now integrates category assignments seamlessly.
  * Category and member query services updated to use string-based member IDs for consistency.

* **Bug Fixes**
  * Fixed missing implementations for member profile update and retrieval.

* **Documentation**
  * API documentation updated for new and enhanced profile endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->