### PR TITLE
♻️refactor: 소셜 로그인 성공 시 리다이렉트 URI를 프론트쪽으로 변경

### DIFF
--- a/src/main/java/checkmo/domain/member/service/security/jwt/JwtCookieUtil.java
+++ b/src/main/java/checkmo/domain/member/service/security/jwt/JwtCookieUtil.java
@@ -11,7 +11,7 @@ public class JwtCookieUtil {
     public void addTokenToCookie(HttpServletResponse response, String cookieName, String token, int maxAge) {
         Cookie cookie = new Cookie(cookieName, token);
         cookie.setHttpOnly(true); // 클라이언트 스크립트에서 접근 불가
-        cookie.setAttribute("SameSite", "Lax");
+        cookie.setAttribute("SameSite", "None");
         cookie.setPath("/"); // 모든 경로에서 접근 가능
         cookie.setMaxAge(maxAge);
         cookie.setSecure(true); // HTTPS에서만 전송하도록 추가
@@ -36,7 +36,7 @@ public class JwtCookieUtil {
         cookie.setMaxAge(0);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
-        cookie.setAttribute("SameSite", "Lax");
+        cookie.setAttribute("SameSite", "None");
         response.addCookie(cookie);
     }
 }

--- a/src/main/java/checkmo/domain/member/service/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/checkmo/domain/member/service/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -42,10 +42,11 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         // 기본 리다이렉트 URI
         String targetUrl = UriComponentsBuilder.fromUriString(baseUri)
-                                               .path(path)
+                                               .pathSegment(path)
                                                .build().toUriString();
 
         // 성공 후 리다이렉트 URL 설정
+        clearAuthenticationAttributes(request);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/checkmo/domain/member/service/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/checkmo/domain/member/service/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -1,13 +1,17 @@
 package checkmo.domain.member.service.security.oauth2;
 
+import checkmo.domain.member.entity.Member;
+import checkmo.domain.member.service.security.auth.PrincipalDetails;
 import checkmo.domain.member.service.security.jwt.JwtLoginProcessor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * 소셜 로그인 성공 후의 성공 처리 핸들러
@@ -22,16 +26,26 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     private final JwtLoginProcessor jwtLoginProcessor;
 
+    @Value("${app.oauth2.redirect.base-uri}")
+    private String baseUri;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
 
         // JWT 토큰 생성 및 쿠키 설정
         jwtLoginProcessor.processLogin(response, authentication);
 
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        Member member = principalDetails.getMember();
+
+        String path = member.isProfileCompleted() ? "/home" : "/profile";
+
         // 기본 리다이렉트 URI
-        String redirectUri = "/api/auth/redirect/oauth2";
+        String targetUrl = UriComponentsBuilder.fromUriString(baseUri)
+                                               .path(path)
+                                               .build().toUriString();
 
         // 성공 후 리다이렉트 URL 설정
-        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/checkmo/domain/member/service/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/checkmo/domain/member/service/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -38,7 +38,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
         Member member = principalDetails.getMember();
 
-        String path = member.isProfileCompleted() ? "/home" : "/profile";
+        String path = member.isProfileCompleted() ? "home" : "profile";
 
         // 기본 리다이렉트 URI
         String targetUrl = UriComponentsBuilder.fromUriString(baseUri)

--- a/src/main/java/checkmo/domain/member/web/controller/AuthController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/AuthController.java
@@ -100,30 +100,4 @@ public class AuthController {
         memberCommandFacade.logout(request, response);
         return ApiResponse.onSuccess(null);
     }
-
-    // 소셜 로그인 관련
-    @Operation(summary = "소셜 로그인 성공 후 리다이렉트 (임시 컨트롤러)", description = """
-        소셜 로그인 성공 후, 리다이렉트 되는 중간 경로입니다.
-
-        - 실제 로그인 진입 경로는 `/oauth2/authorization/{provider}` (예: /oauth2/authorization/google) 이며,
-        이 엔드포인트는 로그인 성공 후 JWT 토큰이 발급된 상태에서 호출됩니다.
-
-        - 최초 로그인(회원가입)의 경우: `isProfileCompleted: false` 가 응답되고, 프로필이 이미 완료된 유저의 경우: `nickname` 이 응답됩니다. 
-
-        - 이 API는 프론트가 직접 호출하는 것이 아니라, 로그인 성공 후 자동으로 리다이렉트되는 경로입니다.
-        """)
-    @GetMapping(value = "/redirect/oauth2", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ApiResponse<Map<String, Object>> handleSocialLoginRedirect(@CurrentMember Member member) {
-
-        boolean isProfileCompleted = member.isProfileCompleted();
-        if (isProfileCompleted) {
-            return ApiResponse.onSuccess(
-                Map.of("nickname", member.getNickName()));
-        } else {
-            return ApiResponse.onSuccess(
-                Map.of("email", member.getEmail(), "isProfileCompleted",
-                    false)
-            );
-        }
-    }
 }

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -1,3 +1,8 @@
+app:
+  oauth2:
+    redirect:
+      base-uri: ${FRONTEND_BASE_URI}
+
 spring:
   security:
     oauth2:


### PR DESCRIPTION
## 🚀 변경사항
프론트쪽으로 리다이렉트하도록 변경
- 회원가입 (프로필 미완료) 시 `/profile`(프로필 추가 정보 입력 페이지)로 이동
- 로그인 (프로필 완료) 시 `/home`(홈화면 페이지)로 이동

## 🔗 관련 이슈
- Closes #73 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth2 login now redirects users dynamically based on their profile completion status, sending them to either the home page or profile setup page.
  * The redirect base URI is now configurable via application settings.

* **Bug Fixes**
  * Updated cookie settings to improve cross-site compatibility by setting the SameSite attribute to "None".

* **Chores**
  * Removed deprecated social login redirect endpoint and its related API documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->