### PR TITLE
✨ [FEAT] 발제 등록순 -> 최신순 정렬 기능 변경

### DIFF
--- a/src/main/java/checkmo/domain/club/repository/meeting/TeamTopicRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TeamTopicRepository.java
@@ -18,8 +18,9 @@ public interface TeamTopicRepository extends JpaRepository<TeamTopic, Long> {
             "FROM TeamTopic tt " +
             "JOIN FETCH tt.topic t " +
             "JOIN FETCH t.clubMember cm " +
-            "WHERE tt.teamId = :teamId")
-    List<TeamTopic> findTeamTopicsWithTopicAndClubMemberByTeamId(Long teamId);
+            "WHERE tt.teamId = :teamId " +
+            "ORDER BY t.id DESC ")
+    List<TeamTopic> findTeamTopicsWithTopicAndClubMemberByTeamIdOrderByDesc(Long teamId);
 
     Optional<TeamTopic> findByTeamIdAndTopicId(Long teamId, Long topicId);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TopicRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TopicRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface TopicRepository extends JpaRepository<Topic, Long>, TopicRepositoryCustom {
     Optional<Topic> findByIdAndMeetingId(Long topicId, Long meetingId);
 
-    List<Topic> findTopicsByMeetingIdOrderByIdAsc(Long meetingId);
+    List<Topic> findTopicsByMeetingIdOrderByIdDesc(Long meetingId);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustom.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustom.java
@@ -5,5 +5,5 @@ import checkmo.domain.club.entity.meeting.Topic;
 import java.util.List;
 
 public interface TopicRepositoryCustom {
-    List<Topic> findTopicsByCursorOrderByIdAsc(Long meetingId, Long cursorId, Integer size);
+    List<Topic> findTopicsByCursorOrderByIdDesc(Long meetingId, Long cursorId, Integer size);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustomImpl.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustomImpl.java
@@ -16,19 +16,19 @@ public class TopicRepositoryCustomImpl implements TopicRepositoryCustom {
     private final QTopic topic = QTopic.topic;
 
     @Override
-    public List<Topic> findTopicsByCursorOrderByIdAsc(Long meetingId, Long cursorId, Integer size) {
+    public List<Topic> findTopicsByCursorOrderByIdDesc(Long meetingId, Long cursorId, Integer size) {
         BooleanBuilder predicate = new BooleanBuilder();
         predicate.and(topic.meeting.id.eq(meetingId));
 
         if (cursorId != null) {
-            predicate.and(topic.id.gt(cursorId));
+            predicate.and(topic.id.lt(cursorId));
         }
         return queryFactory
                 .selectFrom(topic)
                 .distinct()
                 .where(predicate)
                 .join(topic.clubMember).fetchJoin()
-                .orderBy(topic.id.asc())
+                .orderBy(topic.id.desc())
                 .limit(size)
                 .fetch();
     }

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
@@ -42,9 +42,9 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
     @Override
     public List<Topic> findTopicsByMeeting(Long meetingId, Long cursorId, Integer size) {
         if (size == null) { // size가 null인 경우 전체 토픽 조회
-            return topicRepository.findTopicsByMeetingIdOrderByIdAsc(meetingId);
+            return topicRepository.findTopicsByMeetingIdOrderByIdDesc(meetingId);
         }
-        return topicRepository.findTopicsByCursorOrderByIdAsc(meetingId, cursorId, size + 1);
+        return topicRepository.findTopicsByCursorOrderByIdDesc(meetingId, cursorId, size + 1);
     }
 
     @Override
@@ -63,7 +63,7 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
 
     @Override
     public List<TeamTopic> findTeamTopicsByTeam(Long teamId) {
-        return teamTopicRepository.findTeamTopicsWithTopicAndClubMemberByTeamId(teamId);
+        return teamTopicRepository.findTeamTopicsWithTopicAndClubMemberByTeamIdOrderByDesc(teamId);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/club/web/controller/ClubBookshelfController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubBookshelfController.java
@@ -225,7 +225,7 @@ public class ClubBookshelfController {
         return ApiResponse.onSuccess(null);
     }
 
-    @Operation(summary = "미팅에 대한 발제 조회 API", description = "[책장] 페이지 - 발제를 등록순으로 조회합니다.")
+    @Operation(summary = "미팅에 대한 발제 조회 API", description = "[책장] 페이지 - 발제를 최신순으로 조회합니다.")
     @Parameters({
             @Parameter(name = "meetingId", description = "발제를 조회할 정기 독서모임 ID", required = true, example = "1"),
             @Parameter(name = "cursorId", description = "마지막으로 조회한 발제 ID (무한 스크롤용)", required = false, example = "10"),

--- a/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
@@ -121,7 +121,7 @@ public class ClubMeetingController {
     // POST /api/meetings/{meetingId}/teams - 토론조 생성
     // GET api/meetings/{meetingId}?teamNumber=1 - Team에 속한 인원 전체보기
 
-    @Operation(summary = "독서모임 발제 + 선택한 팀 정보 전체 조회 API", description = "[모임] 페이지 - 독서모임의 발제와 선택한 팀 정보를 등록순으로 전체 조회합니다.")
+    @Operation(summary = "독서모임 발제 + 선택한 팀 정보 전체 조회 API", description = "[모임] 페이지 - 독서모임의 발제와 선택한 팀 정보를 최신순으로 전체 조회합니다.")
     @Parameters({
             @Parameter(name = "meetingId", description = "독서모임 ID", required = true, example = "1"),
     })


### PR DESCRIPTION
## 🚀 변경사항
<!-- 뭘 구현했는지/수정했는지 간단히 -->
발제 등록순를 등록순으로 조회하면 UX 상 불편할 것으로 판단되어, 관련 팀원들과 협의 후 최신순 정렬로 수정하기로 했다.

1. 책장 상세 조회 API
2. 책장 - 발제 상세 조회 API
3. 모임 - 발제 상세 조회 API
4. 모임 - 팀별 발제 상세 조회 API


## 🔗 관련 이슈
- Closes #71 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Topics and team topics are now shown in latest-first order, making recent items appear at the top.
  - Cursor-based pagination now follows latest-first ordering for a more intuitive browsing experience.
- Documentation
  - API descriptions updated to state that topic and team-topic lists are returned in latest order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->