### PR TITLE
✨ [Feat] 독서 클럽 가입시 알림 생성 기능 개발

### DIFF
--- a/src/main/java/checkmo/domain/club/service/command/ClubMembershipCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMembershipCommandServiceImpl.java
@@ -14,8 +14,10 @@ import checkmo.domain.club.web.dto.club.ClubResponseDTO;
 import checkmo.domain.club.web.dto.club.ClubResponseDTO.ClubInfoDTO;
 import checkmo.domain.member.entity.Member;
 import checkmo.domain.member.facade.MemberQueryFacade;
+import checkmo.event.JoinClubEvent;
 import checkmo.global.dto.MemberSharedDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +31,8 @@ public class ClubMembershipCommandServiceImpl implements ClubMembershipCommandSe
     private final ClubQueryService clubQueryService;
     private final ClubMemberQueryService clubMemberQueryService;
     private final MemberQueryFacade memberQueryFacade;
+    
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 독서모임에 가입 신청을 합니다.
@@ -58,6 +62,12 @@ public class ClubMembershipCommandServiceImpl implements ClubMembershipCommandSe
                 ? ClubMember.ClubMemberStatus.MEMBER
                 : ClubMember.ClubMemberStatus.PENDING;
 
+        // 공개 클럽이면 즉시 가입 완료 이벤트 발행
+        if (club.isOpen()) {
+            JoinClubEvent joinClubEvent = new JoinClubEvent(memberId, String.valueOf(clubId), club.getName());
+            eventPublisher.publishEvent(joinClubEvent);
+        }
+
         // ClubMember 생성 및 연관관계 설정
         Member proxyMember = memberQueryFacade.findMemberReferenceById(memberId);
         ClubMember clubMember = ClubConverter.toClubMemberEntity(club, proxyMember, status, request.getJoinMessage());
@@ -81,7 +91,7 @@ public class ClubMembershipCommandServiceImpl implements ClubMembershipCommandSe
     public ClubResponseDTO.ClubMemberDTO updateClubMemberStatus(Long clubId, Long targetClubMemberId, String currentMemberId, String status) {
 
         // 1. 클럽 유효성 검증
-        clubQueryService.validateClub(clubId);
+        Club club = clubQueryService.validateClub(clubId);
         ClubMember requester = clubMemberQueryService.validateClubMember(clubId, currentMemberId);
         if (!requester.isStaff()) {
             throw new GeneralException(ErrorStatus.CLUB_STAFF_ONLY);
@@ -99,8 +109,15 @@ public class ClubMembershipCommandServiceImpl implements ClubMembershipCommandSe
             throw new GeneralException(ErrorStatus.CLUB_MEMBER_INVALID_STATUS);
         }
 
-        // 4. 상태 변경
+        // 4. 상태 변경 및 이벤트 발행
+        ClubMember.ClubMemberStatus oldStatus = targetMember.getClubMemberStatus();
         targetMember.updateStatus(newStatus);
+
+        // PENDING → MEMBER로 변경되면 가입 완료 이벤트 발행
+        if (oldStatus == ClubMember.ClubMemberStatus.PENDING && newStatus == ClubMember.ClubMemberStatus.MEMBER) {
+            JoinClubEvent joinClubEvent = new JoinClubEvent(targetMember.getMemberId(), String.valueOf(clubId), club.getName());
+            eventPublisher.publishEvent(joinClubEvent);
+        }
 
         // 5. DTO 반환
         MemberSharedDTO.BasicInfoDTO memberInfo = memberQueryFacade.getMemberBasicInfoForShare(targetMember.getMemberId());

--- a/src/main/java/checkmo/domain/club/service/command/ClubMembershipCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMembershipCommandServiceImpl.java
@@ -64,7 +64,7 @@ public class ClubMembershipCommandServiceImpl implements ClubMembershipCommandSe
 
         // 공개 클럽이면 즉시 가입 완료 이벤트 발행
         if (club.isOpen()) {
-            JoinClubEvent joinClubEvent = new JoinClubEvent(memberId, String.valueOf(clubId), club.getName());
+            JoinClubEvent joinClubEvent = new JoinClubEvent(memberId, clubId, club.getName());
             eventPublisher.publishEvent(joinClubEvent);
         }
 
@@ -115,7 +115,7 @@ public class ClubMembershipCommandServiceImpl implements ClubMembershipCommandSe
 
         // PENDING → MEMBER로 변경되면 가입 완료 이벤트 발행
         if (oldStatus == ClubMember.ClubMemberStatus.PENDING && newStatus == ClubMember.ClubMemberStatus.MEMBER) {
-            JoinClubEvent joinClubEvent = new JoinClubEvent(targetMember.getMemberId(), String.valueOf(clubId), club.getName());
+            JoinClubEvent joinClubEvent = new JoinClubEvent(targetMember.getMemberId(), clubId, club.getName());
             eventPublisher.publishEvent(joinClubEvent);
         }
 

--- a/src/main/java/checkmo/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/checkmo/domain/notification/converter/NotificationConverter.java
@@ -23,12 +23,14 @@ public class NotificationConverter {
     public static Notification fromEvent(
             Notification.NotificationType notificationType,
             String redirectPath,
+            String targetName,
             Member proxySender,
             Member proxyReceiver
     ) {
         return Notification.builder()
                 .notificationType(notificationType)
                 .redirectPath(redirectPath)
+                .targetName(targetName)
                 .sender(proxySender)
                 .receiver(proxyReceiver)
                 .build();
@@ -51,6 +53,13 @@ public class NotificationConverter {
         return null; // 지금은 FOLLOW 타입일 경우 무조건 Nickname을 사용하지만, 다른 타입이 추가될 경우를 대비하여 null 반환
     }
 
+    public static String getRedirectPathForClub(Notification.NotificationType notificationType, Long clubId) {
+        if (Notification.NotificationType.JOIN_CLUB == notificationType) {
+            return "/bookclub/" + clubId + "/home"; // 프론트엔드 경로
+        }
+        return null;
+    }
+
     // =====================================================
     // Notification → NotificationSharedDTO 변환
     // =====================================================
@@ -66,7 +75,7 @@ public class NotificationConverter {
         List<NotificationSharedDTO.NotificationPreview> previewList = notifications.stream()
                 .map(notification -> convertToPreviewDTO(
                         notification,
-                        senderNicknameMap.get(notification.getSenderId())
+                        notification.getSenderId() != null ? senderNicknameMap.get(notification.getSenderId()) : null
                 ))
                 .toList();
 
@@ -83,6 +92,7 @@ public class NotificationConverter {
                 .notificationId(notification.getId())
                 .notificationType(notification.getNotificationType())
                 .senderNickname(senderNickname)
+                .targetName(notification.getTargetName())
                 .read(notification.isRead())
                 .createdAt(notification.getCreatedAt())
                 .redirectPath(notification.getRedirectPath())
@@ -107,7 +117,7 @@ public class NotificationConverter {
         var notificationList = notifications.stream()
                 .map(notification -> convertToPreviewDTO(
                         notification, 
-                        senderNicknameMap.get(notification.getSenderId())
+                        notification.getSenderId() != null ? senderNicknameMap.get(notification.getSenderId()) : null
                 ))
                 .toList();
 

--- a/src/main/java/checkmo/domain/notification/entity/Notification.java
+++ b/src/main/java/checkmo/domain/notification/entity/Notification.java
@@ -13,7 +13,7 @@ import lombok.*;
 public class Notification extends BaseEntity {
 
     public enum NotificationType {
-        LIKE, FOLLOW
+        LIKE, FOLLOW, JOIN_CLUB
     }
 
     @Id
@@ -30,6 +30,9 @@ public class Notification extends BaseEntity {
 
     @Column(nullable = false)
     private String redirectPath; // 알림 클릭 시 이동할 페이지의 경로
+
+    @Column
+    private String targetName; // 대상 엔티티의 이름 (클럽명, 사용자명 등)
 
     @Column(name = "receiver_id", insertable = false, updatable = false)
     private String receiverId;

--- a/src/main/java/checkmo/domain/notification/handler/NotificationEventHandler.java
+++ b/src/main/java/checkmo/domain/notification/handler/NotificationEventHandler.java
@@ -2,6 +2,7 @@ package checkmo.domain.notification.handler;
 
 import checkmo.domain.notification.service.command.NotificationCommandService;
 import checkmo.event.FollowEvent;
+import checkmo.event.JoinClubEvent;
 import checkmo.event.LikeEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,16 @@ public class NotificationEventHandler {
             notificationCommandService.createNotification(event);
         } catch (Exception e) {
             log.error("팔로우 알림 생성 실패, FollowEvent: {}", event, e);
+        }
+    }
+
+    @Async("notificationExecutor")
+    @TransactionalEventListener
+    public void handleNotificationEvent(JoinClubEvent event) {
+        try {
+            notificationCommandService.createNotification(event);
+        } catch (Exception e) {
+            log.error("독서 클럽 가입 승인 알림 생성 실패, JoinClubEvent: {}", event, e);
         }
     }
 }

--- a/src/main/java/checkmo/domain/notification/service/command/NotificationCommandService.java
+++ b/src/main/java/checkmo/domain/notification/service/command/NotificationCommandService.java
@@ -1,6 +1,7 @@
 package checkmo.domain.notification.service.command;
 
 import checkmo.event.FollowEvent;
+import checkmo.event.JoinClubEvent;
 import checkmo.event.LikeEvent;
 
 /**
@@ -25,6 +26,13 @@ public interface NotificationCommandService {
      * @param event 팔로우 알림 정보 DTO
      */
      void createNotification(FollowEvent event);
+
+    /**
+     * 독서 클럽 가입 승인 알림 생성
+     *
+     * @param event 독서 클럽 가입 승인 알림 정보 DTO
+     */
+    void createNotification(JoinClubEvent event);
 
     /**
      * 알림 읽음 처리

--- a/src/main/java/checkmo/domain/notification/service/command/NotificationCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/notification/service/command/NotificationCommandServiceImpl.java
@@ -8,6 +8,7 @@ import checkmo.domain.notification.converter.NotificationConverter;
 import checkmo.domain.notification.entity.Notification;
 import checkmo.domain.notification.repository.NotificationRepository;
 import checkmo.event.FollowEvent;
+import checkmo.event.JoinClubEvent;
 import checkmo.event.LikeEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
@@ -33,8 +34,14 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
         // 리다이렉트 경로를 생성
         String redirectPath = NotificationConverter.getRedirectPath(Notification.NotificationType.LIKE, event.getBookStoryId());
 
-        // Notification 객체를 생성하고 저장
-        Notification notification = NotificationConverter.fromEvent(Notification.NotificationType.LIKE, redirectPath, proxySender, proxyReceiver);
+        // Notification 객체를 생성하고 저장 (targetName = null)
+        Notification notification = NotificationConverter.fromEvent(
+                Notification.NotificationType.LIKE, 
+                redirectPath, 
+                null, 
+                proxySender, 
+                proxyReceiver
+        );
         notificationRepository.save(notification);
     }
 
@@ -52,8 +59,35 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
         // 리다이렉트 경로를 생성
         String redirectPath = NotificationConverter.getRedirectPath(Notification.NotificationType.FOLLOW, FollowerNickname);
 
-        // Notification 객체를 생성하고 저장
-        Notification notification = NotificationConverter.fromEvent(Notification.NotificationType.FOLLOW, redirectPath, proxyFollower, proxyFollowing);
+        // Notification 객체를 생성하고 저장 (targetName = followerNickname)
+        Notification notification = NotificationConverter.fromEvent(
+                Notification.NotificationType.FOLLOW, 
+                redirectPath, 
+                FollowerNickname, 
+                proxyFollower, 
+                proxyFollowing
+        );
+        notificationRepository.save(notification);
+    }
+
+    @Override
+    @Transactional
+    @CacheEvict(value = "notifications", key = "#event.getMemberId()")
+    public void createNotification(JoinClubEvent event) {
+        // 독서 클럽 가입 승인 이벤트에서 멤버 정보를 가져옴 (프록시로)
+        Member proxyJoinedMember = memberQueryFacade.findMemberReferenceById(event.getMemberId()); // 클럽에 새로 가입된 사람
+
+        // 리다이렉트 경로를 생성
+        String redirectPath = NotificationConverter.getRedirectPathForClub(Notification.NotificationType.JOIN_CLUB, event.getClubId());
+
+        // Notification 객체를 생성하고 저장 (sender 없이, targetName 포함)
+        Notification notification = NotificationConverter.fromEvent(
+                Notification.NotificationType.JOIN_CLUB, 
+                redirectPath, 
+                event.getClubName(),
+                null, // 시스템 알림이므로 sender는 null
+                proxyJoinedMember
+        );
         notificationRepository.save(notification);
     }
 

--- a/src/main/java/checkmo/event/JoinClubEvent.java
+++ b/src/main/java/checkmo/event/JoinClubEvent.java
@@ -7,6 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JoinClubEvent {
     private final String memberId; // 클럽에 가입한 회원의 ID
-    private final String clubId;    // 가입한 클럽의 ID
+    private final Long clubId;    // 가입한 클럽의 ID
     private final String clubName;  // 가입한 클럽의 이름
 }

--- a/src/main/java/checkmo/event/JoinClubEvent.java
+++ b/src/main/java/checkmo/event/JoinClubEvent.java
@@ -1,0 +1,12 @@
+package checkmo.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class JoinClubEvent {
+    private final String memberId; // 클럽에 가입한 회원의 ID
+    private final String clubId;    // 가입한 클럽의 ID
+    private final String clubName;  // 가입한 클럽의 이름
+}

--- a/src/main/java/checkmo/global/dto/NotificationSharedDTO.java
+++ b/src/main/java/checkmo/global/dto/NotificationSharedDTO.java
@@ -42,6 +42,7 @@ public class NotificationSharedDTO {
         private Long notificationId;
         private Notification.NotificationType notificationType; // 알림 타입
         private String senderNickname;
+        private String targetName; // 대상 이름 (클럽명, 사용자명 등)
         private boolean read;
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")


### PR DESCRIPTION
## 🚀 변경사항
독서 클럽 가입 시 알림 기능 개발
- 이를 위해서 Notification 객체에 targetName이라는 필드 추가했습니다.
- 클럽 가입의 경우 Sender가 null인 (Sender는 Member 타입) Club의 이름을 담을 필드가 추가로 필요해서 추가하고 이에 맞게 기존의 LIKE, FOLLOW 타입의 알림 기능도 전부 수정했습니다.
- 클럽 가입 승인 알림은 클럽이 open인 경우 이벤트 즉시 발행, open이 아닌 경우 상태가 PENDING에서 MEMBER로 바뀔 때 이벤트 발행 합니다.

## 🔗 관련 이슈
- Closes #78

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Receive notifications when you join an open club or when your club join request is approved.
  - Notification previews now include the target name (e.g., club name or follower nickname).
  - Tapping a club join notification redirects you directly to the club’s home.

- Improvements
  - More reliable display of sender names in notifications when the sender is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->