### PR TITLE
✨feat: 홈화면 - 회원이 가입한 모든 클럽의 공지 3종 조회하기 API 구현 완료

### DIFF
--- a/src/main/java/checkmo/domain/club/converter/ClubConverter.java
+++ b/src/main/java/checkmo/domain/club/converter/ClubConverter.java
@@ -215,6 +215,26 @@ public class ClubConverter {
     }
 
     /**
+     * ClubResponseDTO.ClubNoticeListDTO 변환
+     */
+    public static ClubResponseDTO.ClubNoticeListDTO toClubNoticeListDTO(
+            List<ClubResponseDTO.NoticeItem> noticeItems,
+            boolean hasNext,
+            Long nextCursor
+    ) {
+        List<ClubResponseDTO.NoticeItem> safeList =
+                (noticeItems == null) ? List.of() : List.copyOf(noticeItems);
+
+        return ClubResponseDTO.ClubNoticeListDTO.builder()
+                .noticeList(safeList)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
+                .pageSize(safeList.size())
+                .build();
+
+    }
+
+    /**
      * CreateBookRecommendDTO -> BookRecommend 엔티티
      */
     public static BookRecommend fromCreateBookRecommendDTOToEntity(

--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacade.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacade.java
@@ -93,14 +93,14 @@ public interface ClubQueryFacade {
     ClubResponseDTO.ClubNoticeListDTO getLatestNotices(Long clubId, String memberId, Long cursorId, boolean onlyImportant, Integer size);
 
     /**
-     * 특정 회원이 가입한 모든 클럽의 최신 소식을 조회합니다. (외부용)
+     * 특정 회원이 가입한 모든 클럽의 최신 소식을 조회합니다.
      * 홈 화면 피드를 구성할 때 사용됩니다.
      *
      * @param memberId 조회할 회원의 ID
      * @param size 조회할 개수
      * @return 모든 클럽의 최신 소식이 통합된 미리보기 DTO
      */
-    ClubSharedDTO.ClubUpdatePreviewListDTO getNoticeForHome(String memberId, int size);
+    ClubResponseDTO.ClubNoticeListDTO getNoticeForHome(String memberId, Long cursorId, boolean onlyImportant, Integer size);
 
     /**
      * ClubQueryService

--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
@@ -218,8 +218,28 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
     }
 
     @Override
-    public ClubSharedDTO.ClubUpdatePreviewListDTO getNoticeForHome(String memberId, int size) {
-        return null;
+    public ClubResponseDTO.ClubNoticeListDTO getNoticeForHome(String memberId, Long cursorId, boolean onlyImportant, Integer size) {
+
+        // 1. 커서 초기화
+        Long cursor = (cursorId == null || cursorId == 0L) ? Long.MAX_VALUE : cursorId;
+
+        // 2. 페이지 크기 결정 (size가 null 또는 0 이하이면 기본값 사용)
+        int pageSize = (size == null || size <= 0) ? DEFAULT_PAGE_SIZE : size;
+        Pageable pageable = PageRequest.of(0, pageSize + 1);
+
+        // 3. 공지(일반, 모임) + 투표 조회 및 변환
+        List<ClubResponseDTO.NoticeItem> noticeItems = clubCommunicationQueryService.getMemberNoticesAndVotes(memberId, onlyImportant, cursor, pageable);
+
+        // 4. 페이징
+        boolean hasNext = noticeItems.size() > pageSize;
+        if (hasNext) {
+            noticeItems = noticeItems.subList(0, pageSize);  // pageSize 만큼만 남기기
+        }
+        Long nextCursor = hasNext && noticeItems.size() >= pageSize
+                ? noticeItems.get(pageSize - 1).getId()
+                : null;
+
+        return ClubConverter.toClubNoticeListDTO(noticeItems, hasNext, nextCursor);
     }
 
     /**

--- a/src/main/java/checkmo/domain/club/repository/announcement/NoticeRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/announcement/NoticeRepository.java
@@ -24,4 +24,19 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
             Pageable pageable
     );
 
+    @Query("""
+        SELECT n FROM Notice n 
+        WHERE n.club.id IN :clubIds
+          AND (:onlyImportant = false OR n.important = true)
+          AND (:cursorId IS NULL OR n.id < :cursorId)
+        ORDER BY n.createdAt DESC
+        """)
+    List<Notice> findByClubIdsAndCursorPaging(
+            @Param("clubIds") List<Long> clubIds,
+            @Param("onlyImportant") boolean onlyImportant,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable
+    );
+
+
 }

--- a/src/main/java/checkmo/domain/club/repository/announcement/VoteRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/announcement/VoteRepository.java
@@ -23,4 +23,19 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
             @Param("cursorId") Long cursorId,
             Pageable pageable
     );
+
+    @Query("""
+        SELECT v FROM Vote v 
+        WHERE v.club.id IN :clubIds
+          AND (:onlyImportant = false OR v.important = true)
+          AND (:cursorId IS NULL OR v.id < :cursorId)
+        ORDER BY v.createdAt DESC
+        """)
+    List<Vote> findByClubIdsAndCursorPaging(
+            @Param("clubIds") List<Long> clubIds,
+            @Param("onlyImportant") boolean onlyImportant,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryService.java
@@ -27,4 +27,13 @@ public interface ClubCommunicationQueryService {
      */
     List<ClubResponseDTO.NoticeItem> getAllNoticesAndVotes(Long clubId, boolean onlyImportant, Long cursorId, Pageable pageable);
 
+    /**
+     * 회원이 가입한 클럽의 모든 공지와 투표를 조회합니다.
+     *
+     * @param onlyImportant 중요 공지/투표만 조회할지 여부
+     * @param cursorId 커서 ID (페이징을 위한 커서, 처음에는 null 또는 0)
+     * @return 공지와 투표 목록 DTO
+     */
+    List<ClubResponseDTO.NoticeItem> getMemberNoticesAndVotes(String memberId, boolean onlyImportant, Long cursorId, Pageable pageable);
+
 }

--- a/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryServiceImpl.java
@@ -14,12 +14,14 @@ import checkmo.domain.club.repository.announcement.VoteRepository;
 import checkmo.domain.club.web.dto.club.ClubResponseDTO;
 import checkmo.domain.member.facade.MemberQueryFacade;
 import checkmo.global.dto.BookSharedDTO;
+import checkmo.global.dto.ClubSharedDTO;
 import checkmo.global.dto.MemberSharedDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.time.LocalDateTime;
 
@@ -159,9 +161,54 @@ public class ClubCommunicationQueryServiceImpl implements ClubCommunicationQuery
         // 2. 투표 리스트 조회
         List<Vote> votes = voteRepository.findByClubIdAndCursorPaging(clubId, onlyImportant, cursorId, Pageable.ofSize(pageSize + 1));
 
+        // 3. 생성 시간 순서대로 합치기
+        return mergeNoticesAndVotes(notices, votes, pageSize);
+    }
+
+    /**
+     * 회원이 가입한 클럽의 모든 공지와 투표를 조회합니다.
+     *
+     * @param onlyImportant 중요 공지/투표만 조회할지 여부
+     * @param cursorId 커서 ID (페이징을 위한 커서, 처음에는 null 또는 0)
+     * @return 공지와 투표 목록 DTO
+     */
+    @Override
+    public List<ClubResponseDTO.NoticeItem> getMemberNoticesAndVotes(String memberId, boolean onlyImportant, Long cursorId, Pageable pageable) {
+
+        int pageSize = pageable.getPageSize();
+
+        // 1. 회원이 가입한 클럽 목록 조회 (MyClubInfo → clubId만 추출)
+        List<Long> clubIds = clubMemberQueryService.getMyClubList(memberId)
+                .getClubList()
+                .stream()
+                .map(ClubSharedDTO.MyClubInfo::getClubId)
+                .toList();
+
+        if (clubIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // 2. 모든 클럽 공지/투표 조회
+        List<Notice> notices = noticeRepository.findByClubIdsAndCursorPaging(
+                clubIds, onlyImportant, cursorId, Pageable.ofSize(pageSize + 1)
+        );
+
+        List<Vote> votes = voteRepository.findByClubIdsAndCursorPaging(
+                clubIds, onlyImportant, cursorId, Pageable.ofSize(pageSize + 1)
+        );
+
+        // 3. 생성 시간 순서대로 합치기
+        return mergeNoticesAndVotes(notices, votes, pageSize);
+    }
+
+    // 3가지 공지를 생성 시간 순서대로 합치는 로직
+    private List<ClubResponseDTO.NoticeItem> mergeNoticesAndVotes(
+            List<Notice> notices, List<Vote> votes, int pageSize
+    ) {
+
         List<ClubResponseDTO.NoticeItem> resultList = new ArrayList<>();
-        int n = notices.size();  // 공지사항 개수
-        int m = votes.size();    // 투표 개수
+        int n = notices.size();
+        int m = votes.size();
 
         // 공지사항과 투표를 생성일시 기준으로 병합하여 pageSize 만큼 결과 채움
         int i = 0, j = 0;

--- a/src/main/java/checkmo/domain/club/web/controller/ClubController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubController.java
@@ -26,6 +26,22 @@ public class ClubController {
     private final ClubQueryFacade clubQueryFacade;
     private final ClubCommandFacade clubCommandFacade;
 
+
+    @Operation(summary = "회원의 공지사항 목록 조회 (미팅, 투표, 공지 모두 포함)", description = "회원의 공지사항 목록을 조회합니다. onlyImportant=true 면 중요 공지사항만 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "모임을 찾을 수 없음")
+    })
+    @GetMapping("/notices")
+    public ApiResponse<ClubResponseDTO.ClubNoticeListDTO> getMemberNoticeList(
+            @CurrentId String memberId,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false, defaultValue = "false") boolean onlyImportant,
+            @RequestParam(required = false) Integer size // 페이지 사이즈
+    ) {
+        return ApiResponse.onSuccess(clubQueryFacade.getNoticeForHome(memberId, cursorId, onlyImportant, size));
+    }
+
     /**
      * 모임 이름 중복 검사 API
      *


### PR DESCRIPTION
## 🚀 변경사항
홈화면 - 회원이 가입한 모든 클럽의 공지 3종 조회하기 API 구현 완료

## 🔗 관련 이슈
- Closes #76 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Introduced an API to fetch a member’s combined club updates (notices, meetings, votes) with cursor-based pagination.
  * Supports filtering by important items and adjustable page size.
  * Responses include hasNext and nextCursor for smooth infinite scrolling.

* Documentation
  * Added Swagger documentation for the new API and its response structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->