### PR TITLE
✨ [FEAT] 미팅 팀 PUT

### DIFF
--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -57,6 +57,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 미팅
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING_4004", "독서모임을 찾을 수 없습니다."),
 
+    // 팀
+    TEAM_NUMBER_DUPLICATED_REQUEST(HttpStatus.BAD_REQUEST, "TEAM_4001", "중복된 팀 번호가 요청되었습니다."),
+
     // 카테고리
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_4004", "카테고리를 찾을 수 없습니다."),
 

--- a/src/main/java/checkmo/domain/club/entity/ClubMember.java
+++ b/src/main/java/checkmo/domain/club/entity/ClubMember.java
@@ -52,7 +52,7 @@ public class ClubMember extends BaseEntity {
     private List<BookRecommend> bookRecommends = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "clubMember", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "clubMember", cascade = CascadeType.REMOVE)
     private List<MemberTeam> memberTeams = new ArrayList<>();
 
     @Builder.Default
@@ -73,12 +73,17 @@ public class ClubMember extends BaseEntity {
         topic.setClubMember(this);
     }
 
-    public enum ClubMemberStatus {
-        MEMBER, STAFF, PENDING, BLOCKED
-    }
-
     public void updateStatus(ClubMemberStatus newStatus) {
         this.clubMemberStatus = newStatus;
+    }
+
+    public void addMemberTeam(MemberTeam memberTeam) {
+        this.memberTeams.add(memberTeam);
+        memberTeam.setClubMember(this);
+    }
+
+    public enum ClubMemberStatus {
+        MEMBER, STAFF, PENDING, BLOCKED
     }
 
 }

--- a/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
+++ b/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
@@ -60,7 +60,7 @@ public class Meeting extends BaseEntity {
     private Book book; // null 허용
 
     @Builder.Default
-    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Team> teams = new ArrayList<>();
 
     @OneToOne(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -130,5 +130,17 @@ public class Meeting extends BaseEntity {
     public void addTopic(Topic topic) {
         this.topics.add(topic);
         topic.setMeeting(this); // 주인 쪽에도 세팅
+    }
+
+    public void addTeam(Team team) {
+        if (team == null) return;
+        this.teams.add(team);
+        team.setMeeting(this);
+    }
+
+    public void removeTeam(Team team) {
+        if (team == null) return;
+        this.teams.remove(team);
+        team.setMeeting(null);
     }
 }

--- a/src/main/java/checkmo/domain/club/entity/meeting/MemberTeam.java
+++ b/src/main/java/checkmo/domain/club/entity/meeting/MemberTeam.java
@@ -5,9 +5,6 @@ import checkmo.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Getter
 @Builder
 @AllArgsConstructor
@@ -24,6 +21,7 @@ public class MemberTeam extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_member_id")
+    @Setter
     private ClubMember clubMember;
 
     @Column(name = "team_id", insertable = false, updatable = false)
@@ -31,5 +29,7 @@ public class MemberTeam extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
+    @Setter
     private Team team;
+
 }

--- a/src/main/java/checkmo/domain/club/entity/meeting/Team.java
+++ b/src/main/java/checkmo/domain/club/entity/meeting/Team.java
@@ -26,13 +26,23 @@ public class Team extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_id", nullable = false)
+    @Setter
     private Meeting meeting;
 
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
     @Builder.Default
     private List<TeamTopic> teamTopics = new ArrayList<>();
 
-    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<MemberTeam> memberTeams = new ArrayList<>();
+
+    public void addMemberTeam(MemberTeam memberTeam) {
+        this.memberTeams.add(memberTeam);
+        memberTeam.setTeam(this);
+    }
+
+    public void clearMemberTeams() {
+        this.memberTeams.clear();
+    }
 }

--- a/src/main/java/checkmo/domain/club/facade/ClubCommandFacade.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubCommandFacade.java
@@ -4,7 +4,6 @@ import checkmo.domain.club.web.dto.bookshelf.BookShelfRequestDTO;
 import checkmo.domain.club.web.dto.club.ClubRequestDTO;
 import checkmo.domain.club.web.dto.club.ClubResponseDTO;
 import checkmo.domain.club.web.dto.meeting.MeetingRequestDTO;
-import checkmo.domain.club.web.dto.meeting.MeetingResponseDTO;
 
 /**
  * Club Domain Command Facade
@@ -215,7 +214,7 @@ public interface ClubCommandFacade {
      * @param meetingId 미팅 ID
      * @param request   팀 구성 요청 DTO
      */
-    void manageTeam(String memberId, Long meetingId, MeetingRequestDTO.TeamManageDTO request);
+    void manageTeams(String memberId, Long meetingId, MeetingRequestDTO.TeamManageDTO request);
 
     /**
      * ClubMeetingCommandService

--- a/src/main/java/checkmo/domain/club/facade/ClubCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubCommandFacadeImpl.java
@@ -44,9 +44,9 @@ public class ClubCommandFacadeImpl implements ClubCommandFacade {
      * ClubMembershipCommandService
      * 독서 모임에 가입을 신청합니다. (내부용)
      *
-     * @param clubId   모임 ID
+     * @param clubId 모임 ID
      * @param memberId 신청자 회원 ID
-     * @param request  가입 신청 메시지 DTO
+     * @param request 가입 신청 메시지 DTO
      * @return 가입 신청 후의 모임 정보 DTO
      */
     @Override
@@ -58,8 +58,8 @@ public class ClubCommandFacadeImpl implements ClubCommandFacade {
      * ClubMembershipCommandService
      * 독서 모임 회원의 등급(상태/역할)을 수정합니다. (내부용)
      *
-     * @param clubId          독서 모임 ID
-     * @param targetMemberId  수정 대상 회원 ID
+     * @param clubId 독서 모임 ID
+     * @param targetMemberId 수정 대상 회원 ID
      * @param currentMemberId 요청자(운영진) 회원 ID
      * @param status 수정할 등급 (MEMBER, STAFF, PENDING, BLOCKED 중 선택)
      * @return 수정된 회원의 응답 DTO
@@ -79,7 +79,7 @@ public class ClubCommandFacadeImpl implements ClubCommandFacade {
      * ClubMembershipCommandService
      * 독서 모임에서 탈퇴합니다. (내부용)
      *
-     * @param clubId   모임 ID
+     * @param clubId 모임 ID
      * @param memberId 탈퇴할 회원 ID
      */
     @Override
@@ -247,8 +247,8 @@ public class ClubCommandFacadeImpl implements ClubCommandFacade {
     }
 
     @Override
-    public void manageTeam(String memberId, Long meetingId, MeetingRequestDTO.TeamManageDTO request) {
-
+    public void manageTeams(String memberId, Long meetingId, MeetingRequestDTO.TeamManageDTO request) {
+        clubMeetingCommandService.manageTeam(memberId, meetingId, request);
     }
 
     // TODO: Aspect 로그

--- a/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,11 +19,17 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     List<Object[]> findClubIdAndNameByMemberId(@Param("memberId") String memberId);
 
     List<ClubMember> findByClubIdAndClubMemberStatusAndIdLessThanOrderByIdDesc(Long clubId, ClubMember.ClubMemberStatus status, Long cursorId, Pageable pageable);
+
     List<ClubMember> findByClubIdAndIdLessThanOrderByIdDesc(Long clubId, Long cursorId, Pageable pageable);
 
     List<ClubMember> findByClubIdAndClubMemberStatusOrderByIdDesc(Long clubId, ClubMember.ClubMemberStatus status, Pageable pageable);
+
     List<ClubMember> findByClubIdOrderByIdDesc(Long clubId, Pageable pageable);
 
     boolean existsByClubIdAndClubMemberStatusAndIdLessThan(Long clubId, ClubMember.ClubMemberStatus status, Long lastId);
+
     boolean existsByClubIdAndIdLessThan(Long clubId, Long lastId);
+
+    @Query("SELECT cm FROM ClubMember cm WHERE cm.club.id = :clubId AND cm.memberId IN :memberIds")
+    List<ClubMember> findClubMembersByClubIdAndMemberIdIn(Long clubId, Collection<String> memberIds);
 }

--- a/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,5 +32,5 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     boolean existsByClubIdAndIdLessThan(Long clubId, Long lastId);
 
     @Query("SELECT cm FROM ClubMember cm WHERE cm.club.id = :clubId AND cm.memberId IN :memberIds")
-    List<ClubMember> findClubMembersByClubIdAndMemberIdIn(Long clubId, Collection<String> memberIds);
+    List<ClubMember> findClubMembersByClubIdAndMemberIdIn(Long clubId, List<String> memberIds);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TeamRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TeamRepository.java
@@ -3,5 +3,8 @@ package checkmo.domain.club.repository.meeting;
 import checkmo.domain.club.entity.meeting.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TeamRepository extends JpaRepository<Team, Long> {
+    List<Team> findTeamsByMeetingId(Long meetingId);
 }

--- a/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandService.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandService.java
@@ -93,9 +93,8 @@ public interface ClubMeetingCommandService {
      * @param memberId 팀 구성자의 ID -> 운영진인지 확인하는 로직 필요 ClubMember에서 Role 확인 -> 어노테이션으로 처리 고려
      * @param meetingId 미팅 ID -> 미팅 ID만 알아도 어느 Club인지 알 수 있기 때문에 ClubId는 필요 없음
      * @param request 팀 구성 요청 DTO
-     * @return 해당 미팅의 ID
      */
-    Long manageTeam(String memberId, Long meetingId, MeetingRequestDTO.TeamManageDTO request);
+    void manageTeam(String memberId, Long meetingId, MeetingRequestDTO.TeamManageDTO request);
 
     /**
      * 독서모임의 한줄평을 작성합니다.

--- a/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
@@ -9,11 +9,10 @@ import checkmo.domain.club.converter.ClubConverter;
 import checkmo.domain.club.entity.Club;
 import checkmo.domain.club.entity.ClubMember;
 import checkmo.domain.club.entity.announcement.Notice;
-import checkmo.domain.club.entity.meeting.BookReview;
-import checkmo.domain.club.entity.meeting.Meeting;
-import checkmo.domain.club.entity.meeting.Topic;
+import checkmo.domain.club.entity.meeting.*;
 import checkmo.domain.club.repository.meeting.BookReviewRepository;
 import checkmo.domain.club.repository.meeting.MeetingRepository;
+import checkmo.domain.club.repository.meeting.TeamRepository;
 import checkmo.domain.club.repository.meeting.TopicRepository;
 import checkmo.domain.club.service.query.ClubMeetingQueryService;
 import checkmo.domain.club.service.query.ClubMemberQueryService;
@@ -23,6 +22,9 @@ import checkmo.domain.club.web.dto.meeting.MeetingRequestDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +40,7 @@ public class ClubMeetingCommandServiceImpl implements ClubMeetingCommandService 
     private final MeetingRepository meetingRepository;
     private final TopicRepository topicRepository;
     private final BookReviewRepository bookReviewRepository;
+    private final TeamRepository teamRepository;
 
     @Override
     public Long createMeeting(Long clubId, String memberId, MeetingRequestDTO.MeetingCreateRequestDTO request) {
@@ -144,8 +147,86 @@ public class ClubMeetingCommandServiceImpl implements ClubMeetingCommandService 
     }
 
     @Override
-    public Long manageTeam(String memberId, Long meetingId, MeetingRequestDTO.TeamManageDTO request) {
-        return 0L;
+    public void manageTeam(String memberId, Long meetingId, MeetingRequestDTO.TeamManageDTO request) {
+        // 1. 미팅과 클럽 멤버 검증
+        Meeting meeting = clubMeetingQueryService.validateMeeting(meetingId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
+        if (!clubMember.isStaff()) {
+            throw new GeneralException(ErrorStatus.CLUB_STAFF_ONLY);
+        }
+
+        // 2. 요청 teamNumber와 nicknameList 검증 및 정리
+        Map<Integer, List<String>> requestTeamNumberToNicknameList = new HashMap<>();
+        Set<Integer> requestTeamNumbers = new HashSet<>();
+        Set<String> requestNicknames = new LinkedHashSet<>();
+
+        for (MeetingRequestDTO.TeamMemberDTO dto : request.getTeamMemberDTOList()) {
+            Integer num = dto.getTeamNumber();
+
+            if (!requestTeamNumbers.add(num)) { // 요청 teamNumber 중 teamNumber가 이미 존재하면 예외 발생
+                throw new GeneralException(ErrorStatus.TEAM_NUMBER_DUPLICATED_REQUEST, num.toString()); //TODO: 팀 넘버 포함 예외 메시지
+            }
+
+            List<String> names = new ArrayList<>(new LinkedHashSet<>(dto.getNicknameList())); // 닉네임 리스트의 중복 제거
+            requestTeamNumberToNicknameList.put(num, names);
+            requestNicknames.addAll(names);
+        }
+
+        // 3. 해당 미팅의 기존 팀들 조회 후 teamNumber -> Team Map (TeamTopic이 유지되도록 Team은 유지)
+        List<Team> existingTeams = teamRepository.findTeamsByMeetingId(meetingId);
+        Map<Integer, Team> existingTeamNumberToTeam = existingTeams.stream()
+                .collect(Collectors.toMap(Team::getTeamNumber, t -> t));
+
+        // 4. 요청에 있는데 아직 없는 teamNumber는 Team 생성
+        for (Integer teamNumber : requestTeamNumbers) {
+            if (!existingTeamNumberToTeam.containsKey(teamNumber)) {
+                Team team = Team.builder()
+                        .TeamNumber(teamNumber)
+                        .build();
+                meeting.addTeam(team);
+                existingTeams.add(team);
+                existingTeamNumberToTeam.put(teamNumber, team);
+            }
+        }
+
+        // 5. 요청에는 없는데 존재하는 teamNumber는 Team 삭제
+        List<Team> toDeleteTeams = existingTeams.stream()
+                .filter(t -> !requestTeamNumbers.contains(t.getTeamNumber()))
+                .toList();
+
+        // 미팅과의 양방향 연관 끊기 -> orphanRemoval이 true이므로 미팅이 flush될 때 Team도 삭제됨
+        toDeleteTeams.forEach(meeting::removeTeam);
+
+        // 기존 팀, 기존 teamNumber -> Team Map 메모리 컬렉션/맵 동기화
+        existingTeams.removeAll(toDeleteTeams);
+        existingTeamNumberToTeam.keySet().removeAll(toDeleteTeams.stream()
+                .map(Team::getTeamNumber)
+                .collect(Collectors.toSet()));
+
+        // 6. 기존 MemberTeam orphanRemoval = true 삭제
+        if (!existingTeams.isEmpty()) {
+            existingTeams.forEach(Team::clearMemberTeams);
+            // 이때 삭제되는 memberTeam의 clubMember도 양방향 연관관계 설정이 다시 필요하지 않나?
+        }
+
+        // 7. 닉네임 → memberId → ClubMember 일괄 매핑
+        Map<String, ClubMember> nicknameToClubMember = clubMemberQueryService.getNicknameToClubMember(meeting.getClubId(), requestNicknames);
+
+        // 8. 요청대로 MemberTeam 배치 재생성
+        for (Map.Entry<Integer, List<String>> e : requestTeamNumberToNicknameList.entrySet()) {
+            Team team = existingTeamNumberToTeam.get(e.getKey());
+            for (String nick : e.getValue()) {
+                ClubMember cm = nicknameToClubMember.get(nick);
+                MemberTeam mt = MemberTeam.builder().build();
+
+                team.addMemberTeam(mt);
+                cm.addMemberTeam(mt);
+            }
+        }
+
+        // 9. 기존 팀과 새로 생성된 Team을 명시적으로 저장 (내부적으로 MemberTeam도 저장됨)
+        meetingRepository.save(meeting);
+        teamRepository.saveAll(existingTeams);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
@@ -10,7 +10,6 @@ import checkmo.domain.club.entity.Club;
 import checkmo.domain.club.entity.ClubMember;
 import checkmo.domain.club.entity.announcement.Notice;
 import checkmo.domain.club.entity.meeting.*;
-import checkmo.domain.club.repository.ClubRepository;
 import checkmo.domain.club.repository.meeting.*;
 import checkmo.domain.club.service.query.ClubMeetingQueryService;
 import checkmo.domain.club.service.query.ClubMemberQueryService;
@@ -37,7 +36,6 @@ public class ClubMeetingCommandServiceImpl implements ClubMeetingCommandService 
     private final ClubMemberQueryService clubMemberQueryService;
     private final ClubMeetingQueryService clubMeetingQueryService;
 
-    private final ClubRepository clubRepository;
     private final MeetingRepository meetingRepository;
     private final TopicRepository topicRepository;
     private final TeamTopicRepository teamTopicRepository;

--- a/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
@@ -249,7 +249,9 @@ public class ClubMeetingCommandServiceImpl implements ClubMeetingCommandService 
         // 6. 기존 MemberTeam orphanRemoval = true 삭제
         if (!existingTeams.isEmpty()) {
             existingTeams.forEach(Team::clearMemberTeams);
-            // 이때 삭제되는 memberTeam의 clubMember도 양방향 연관관계 설정이 다시 필요하지 않나?
+            // 기존 멤버 삭제 시 소유자만 끊고 orphanRemoval=true로 고아 삭제를 걸면 DB 행은 사라지고,
+            // clubMember.memberTeams는 LAZY 초기화를 해서 굳이 연관관계를 설정하지 않는다.
+            // 이때 이 하나의 트랜잭션에서 clubMember.memberTeams를 사용하지 않습니다!!!
         }
 
         // 7. 닉네임 → memberId → ClubMember 일괄 매핑

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryService.java
@@ -4,10 +4,8 @@ import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.club.entity.ClubMember;
 import checkmo.global.dto.ClubSharedDTO;
 
-import java.util.Collection;
-import java.util.Map;
-
 import java.util.List;
+import java.util.Map;
 
 /**
  * 독서클럽 회원에 대한 조회 서비스
@@ -19,7 +17,7 @@ public interface ClubMemberQueryService {
     /**
      * 독서클럽 회원인지 확인합니다.
      *
-     * @param clubId   독서동아리 id
+     * @param clubId 독서동아리 id
      * @param memberId 회원 id
      * @return ClubMember 객체
      * @throws GeneralException 클럽 회원이 존재하지 않을 경우
@@ -40,7 +38,7 @@ public interface ClubMemberQueryService {
      * 특정 회원이 해당 클럽에서 어떤 상태(등급)인지 조회합니다.
      *
      * @param memberId 회원 ID
-     * @param clubId   클럽 ID
+     * @param clubId 클럽 ID
      * @return ClubMemberStatus (MEMBER, STAFF 등) 또는 null (회원 아님)
      */
     ClubMember.ClubMemberStatus getMemberStatusInClub(String memberId, Long clubId);
@@ -63,5 +61,5 @@ public interface ClubMemberQueryService {
      * @return 닉네임과 ClubMember 객체를 매핑한 Map
      * @throws GeneralException 닉네임에 해당하는 ClubMember가 존재하지 않을 경우, CLUB_MEMBER_NOT_FOUND 예외 발생
      */
-    Map<String, ClubMember> getNicknameToClubMember(Long clubId, Collection<String> nicknames) throws GeneralException;
+    Map<String, ClubMember> getNicknameToClubMember(Long clubId, List<String> nicknames) throws GeneralException;
 }

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryService.java
@@ -4,6 +4,9 @@ import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.club.entity.ClubMember;
 import checkmo.global.dto.ClubSharedDTO;
 
+import java.util.Collection;
+import java.util.Map;
+
 /**
  * 독서클럽 회원에 대한 조회 서비스
  * <p>
@@ -14,7 +17,7 @@ public interface ClubMemberQueryService {
     /**
      * 독서클럽 회원인지 확인합니다.
      *
-     * @param clubId   독서동아리 id
+     * @param clubId 독서동아리 id
      * @param memberId 회원 id
      * @return ClubMember 객체
      * @throws GeneralException 클럽 회원이 존재하지 않을 경우
@@ -30,4 +33,14 @@ public interface ClubMemberQueryService {
      * @return 회원이 가입한 독서 클럽의 간략한 정보 목록 DTO
      */
     ClubSharedDTO.MyClubList getMyClubList(String memberId);
+
+    /**
+     * 멤버의 닉네임으로 clubMember를 매핑합니다.
+     *
+     * @param clubId 독서 모임 ID
+     * @param nicknames 멤버 닉네임 리스트
+     * @return 닉네임과 ClubMember 객체를 매핑한 Map
+     * @throws GeneralException 닉네임에 해당하는 ClubMember가 존재하지 않을 경우, CLUB_MEMBER_NOT_FOUND 예외 발생
+     */
+    Map<String, ClubMember> getNicknameToClubMember(Long clubId, Collection<String> nicknames) throws GeneralException;
 }

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
@@ -80,9 +80,13 @@ public class ClubMemberQueryServiceImpl implements ClubMemberQueryService {
 
     @Override
     public Map<String, ClubMember> getNicknameToClubMember(Long clubId, List<String> nicknames) throws GeneralException {
+        if (nicknames == null || nicknames.isEmpty()) {
+            return Map.of();
+        }
+
         Map<String, String> nicknameToMemberId = memberQueryFacade.getMemberIdsByNicknames(nicknames);
         Map<String, ClubMember> memberIdToClubMember = getMemberIdToClubMember(clubId, nicknameToMemberId.values().stream().toList());
-        Map<String, ClubMember> nicknameToClubMember = new HashMap<>();
+        Map<String, ClubMember> nicknameToClubMember = new HashMap<>(nicknameToMemberId.size());
         List<String> missing = new ArrayList<>();
         for (String nickname : nicknames) {
             String memberId = nicknameToMemberId.get(nickname);

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
@@ -11,11 +11,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -49,7 +49,7 @@ public class ClubMemberQueryServiceImpl implements ClubMemberQueryService {
      * 특정 회원이 해당 클럽에서 어떤 상태(등급)인지 조회합니다.
      *
      * @param memberId 회원 ID
-     * @param clubId   클럽 ID
+     * @param clubId 클럽 ID
      * @return ClubMemberStatus (MEMBER, STAFF 등) 또는 null (회원 아님)
      */
     @Override
@@ -79,9 +79,9 @@ public class ClubMemberQueryServiceImpl implements ClubMemberQueryService {
 
 
     @Override
-    public Map<String, ClubMember> getNicknameToClubMember(Long clubId, Collection<String> nicknames) throws GeneralException {
+    public Map<String, ClubMember> getNicknameToClubMember(Long clubId, List<String> nicknames) throws GeneralException {
         Map<String, String> nicknameToMemberId = memberQueryFacade.getMemberIdsByNicknames(nicknames);
-        Map<String, ClubMember> memberIdToClubMember = getMemberIdToClubMember(clubId, nicknameToMemberId.values());
+        Map<String, ClubMember> memberIdToClubMember = getMemberIdToClubMember(clubId, nicknameToMemberId.values().stream().toList());
         Map<String, ClubMember> nicknameToClubMember = new HashMap<>();
         List<String> missing = new ArrayList<>();
         for (String nickname : nicknames) {
@@ -96,7 +96,7 @@ public class ClubMemberQueryServiceImpl implements ClubMemberQueryService {
         return nicknameToClubMember;
     }
 
-    private Map<String, ClubMember> getMemberIdToClubMember(Long clubId, Collection<String> memberIds) {
+    private Map<String, ClubMember> getMemberIdToClubMember(Long clubId, List<String> memberIds) {
         if (memberIds == null || memberIds.isEmpty()) {
             return Map.of();
         }

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
@@ -5,10 +5,14 @@ import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.club.converter.ClubConverter;
 import checkmo.domain.club.entity.ClubMember;
 import checkmo.domain.club.repository.ClubMemberRepository;
+import checkmo.domain.member.facade.MemberQueryFacade;
 import checkmo.global.dto.ClubSharedDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClubMemberQueryServiceImpl implements ClubMemberQueryService {
 
     private final ClubMemberRepository clubMemberRepository;
+    private final MemberQueryFacade memberQueryFacade;
 
     @Override
     public ClubMember validateClubMember(Long clubId, String memberId) throws GeneralException {
@@ -35,5 +40,35 @@ public class ClubMemberQueryServiceImpl implements ClubMemberQueryService {
                 .toList();
 
         return ClubConverter.fromClubInfoListToMyClubList(myClubInfoList);
+    }
+
+    @Override
+    public Map<String, ClubMember> getNicknameToClubMember(Long clubId, Collection<String> nicknames) throws GeneralException {
+        Map<String, String> nicknameToMemberId = memberQueryFacade.getMemberIdsByNicknames(nicknames);
+        Map<String, ClubMember> memberIdToClubMember = getMemberIdToClubMember(clubId, nicknameToMemberId.values());
+        Map<String, ClubMember> nicknameToClubMember = new HashMap<>();
+        List<String> missing = new ArrayList<>();
+        for (String nickname : nicknames) {
+            String memberId = nicknameToMemberId.get(nickname);
+            ClubMember clubMember = (memberId == null) ? null : memberIdToClubMember.get(memberId);
+            if (clubMember == null) missing.add(nickname);
+            else nicknameToClubMember.put(nickname, clubMember);
+        }
+        if (!missing.isEmpty()) {
+            throw new GeneralException(ErrorStatus.CLUB_MEMBER_NOT_FOUND, missing.toString()); // TODO: 잘못에러 메시지 확인
+        }
+        return nicknameToClubMember;
+    }
+
+    private Map<String, ClubMember> getMemberIdToClubMember(Long clubId, Collection<String> memberIds) {
+        if (memberIds == null || memberIds.isEmpty()) {
+            return Map.of();
+        }
+        List<ClubMember> results = clubMemberRepository.findClubMembersByClubIdAndMemberIdIn(clubId, memberIds);
+        return results.stream()
+                .collect(Collectors.toMap(
+                        ClubMember::getMemberId,
+                        cm -> cm)
+                );
     }
 }

--- a/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
@@ -121,7 +121,25 @@ public class ClubMeetingController {
 
     // 토론조 관리
     // GET /api/meetings/{meetingId}/teams - Meeting 참여 인원 전체 조회
-    // POST /api/meetings/{meetingId}/teams - 토론조 생성
+    @Operation(summary = "토론조 관리(생성/수정/삭제) API", description = "Response Body에 따라 정기 독서모임의 토론조를 생성/수정/삭제합니다.")
+    @Parameters({
+            @Parameter(name = "meetingId", description = "팀을 관리할 정기 독서 모임 ID", required = true, example = "1"),
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "독서클럽 운영진만 접근할 수 있습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 클럽의 회원이 아닙니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 정기 독서모임을 찾을 수 없습니다."),
+    })
+    @PutMapping("/api/meetings/{meetingId}/teams")
+    public ApiResponse<Void> manageTeams(
+            @PathVariable Long meetingId,
+            @RequestBody @Valid MeetingRequestDTO.TeamManageDTO request,
+            @CurrentId String memberId
+    ) {
+        clubCommandFacade.manageTeams(memberId, meetingId, request);
+        return ApiResponse.onSuccess(null);
+    }
     // GET api/meetings/{meetingId}?teamNumber=1 - Team에 속한 인원 전체보기
 
     // 팀-발제 연결 관리

--- a/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
@@ -1,11 +1,11 @@
 package checkmo.domain.club.web.dto.meeting;
 
-import checkmo.domain.club.web.dto.club.ClubRequestDTO;
 import checkmo.global.dto.BookSharedDTO;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -54,14 +54,24 @@ public class MeetingRequestDTO {
     @Getter
     @NoArgsConstructor
     public static class TeamManageDTO {
+        @Valid
+        @NotNull(message = "팀 멤버 정보는 null이 될 수 없습니다.")
         private List<TeamMemberDTO> teamMemberDTOList;
     }
 
     @Getter
     @NoArgsConstructor
     public static class TeamMemberDTO {
+        @Min(value = 1, message = "팀 번호는 1 이상의 정수여야 합니다.")
+        @NotNull(message = "팀 번호는 null이 될 수 없습니다.")
         private Integer teamNumber; // 팀 번호
-        private List<String> nicknameList; // 팀원들의 닉네임 리스트
+        @NotNull(message = "닉네임 리스트는 null이 될 수 없습니다.")
+        private List<
+                @NotBlank(message = "닉네임은 필수입니다")
+                @Pattern(regexp = "^[a-z0-9!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]*$",
+                        message = "닉네임은 영어 소문자 및 특수문자만 사용 가능합니다")
+                        // @Size(max = 6, message = "닉네임은 6자 이하여야 합니다.")
+                        String> nicknameList; // 팀원들의 닉네임 리스트, 닉네임에 대한 검증은 AdditionalInfoDTO에서 가져왔습니다
     }
 
     @Getter

--- a/src/main/java/checkmo/domain/member/facade/MemberQueryFacade.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberQueryFacade.java
@@ -4,6 +4,7 @@ import checkmo.domain.member.entity.Member;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
 import checkmo.global.dto.MemberSharedDTO;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -97,6 +98,14 @@ public interface MemberQueryFacade {
      * @return 회원 ID
      */
     String getMemberIdByNickname(String nickname);
+
+    /**
+     * 닉네임 목록으로 회원 ID 조회 (외부용)
+     *
+     * @param nicknames 닉네임 목록
+     * @return 닉네임과 회원 ID 매핑 정보
+     */
+    Map<String, String> getMemberIdsByNicknames(Collection<String> nicknames);
 
     /**
      * 특정 회원의 팔로우 여부 확인 (외부용)

--- a/src/main/java/checkmo/domain/member/facade/MemberQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/member/facade/MemberQueryFacadeImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -142,6 +143,14 @@ public class MemberQueryFacadeImpl implements MemberQueryFacade {
     @Override
     public String getMemberIdByNickname(String nickname) {
         return memberQueryService.getMemberIdByNickname(nickname);
+    }
+
+    @Override
+    public Map<String, String> getMemberIdsByNicknames(Collection<String> nicknames) {
+        if (nicknames == null || nicknames.isEmpty()) {
+            return Map.of();
+        }
+        return memberQueryService.getMemberIdsByNicknames(nicknames);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/checkmo/domain/member/repository/MemberRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,7 +25,7 @@ public interface MemberRepository extends JpaRepository<Member, String> {
     Optional<String> findNicknameById(@Param("memberId") String memberId);
 
     @Query("select m.nickName, m.id from Member m where m.nickName in :nicknames")
-    List<Object[]> findNicknameAndIdByNicknameIn(Collection<String> nicknames);
+    List<Object[]> findNicknameAndIdByNicknameIn(List<String> nicknames);
 
     @Query("select m.id, m.nickName from Member m where m.id in :memberIds")
     List<Object[]> findIdAndNicknameByIdIn(@Param("memberIds") List<String> memberIds);

--- a/src/main/java/checkmo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/checkmo/domain/member/repository/MemberRepository.java
@@ -1,12 +1,13 @@
 package checkmo.domain.member.repository;
 
 import checkmo.domain.member.entity.Member;
-
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
 
@@ -23,6 +24,9 @@ public interface MemberRepository extends JpaRepository<Member, String> {
 
     @Query("select m.nickName from Member m where m.id = :memberId")
     Optional<String> findNicknameById(@Param("memberId") String memberId);
+
+    @Query("select m.nickName, m.id from Member m where m.nickName in :nicknames")
+    List<Object[]> findNicknameAndIdByNicknameIn(Collection<String> nicknames);
 
     @Query("select m.id, m.nickName from Member m where m.id in :memberIds")
     List<Object[]> findIdAndNicknameByIdIn(@Param("memberIds") List<String> memberIds);

--- a/src/main/java/checkmo/domain/member/service/query/MemberQueryService.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberQueryService.java
@@ -3,6 +3,7 @@ package checkmo.domain.member.service.query;
 import checkmo.domain.member.web.dto.MemberResponseDTO;
 import checkmo.global.dto.MemberSharedDTO;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -61,6 +62,14 @@ public interface MemberQueryService {
      * @return 회원 ID
      */
     String getMemberIdByNickname(String nickname);
+
+    /**
+     * 닉네임 목록으로 회원 ID 배치 조회
+     *
+     * @param nicknames 닉네임 목록
+     * @return 닉네임과 회원 ID의 매핑 정보
+     */
+    Map<String, String> getMemberIdsByNicknames(Collection<String> nicknames);
 
     /**
      * 회원ID로 회원 닉네임 조회

--- a/src/main/java/checkmo/domain/member/service/query/MemberQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/member/service/query/MemberQueryServiceImpl.java
@@ -13,6 +13,7 @@ import checkmo.global.dto.MemberSharedDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -92,6 +93,16 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     public String getMemberIdByNickname(String nickname) {
         return memberRepository.findIdByNickName(nickname)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    @Override
+    public Map<String, String> getMemberIdsByNicknames(Collection<String> nicknames) {
+        List<Object[]> results = memberRepository.findNicknameAndIdByNicknameIn(nicknames);
+        return results.stream()
+                .collect(Collectors.toMap(
+                        row -> (String) row[0], // key: nickname
+                        row -> (String) row[1]  // value: memberId
+                ));
     }
 
     @Override


### PR DESCRIPTION
## 🚀 변경사항
<!-- 뭘 구현했는지/수정했는지 간단히 -->
### 미팅 팀 PUT API
팀을 생성/수정/삭제하면, (요청으로부터 유지되는) 팀은 계속 존재하고, 멤버 팀만 전부 삭제됐다가 재생성하는 방식으로 개발했습니다.
이렇게 하면 팀과 연결된 팀 토픽은 삭제되지 않되, 개발하는 게 그나마 간단했습니다.
해당 기능의 전체적인 로직은 다음과 같습니다.

1. 기존에 존재하는 팀 조회
2. 요청에 따라 팀 생성 또는 삭제(요청에 없는데 팀이 존재하면, 팀 삭제 / 요청이 있는데 팀이 존재하지 않으면 생성)
3. 앞선 1,2번의 팀들의 모든 memberTeam 연관관계 끊어서 삭제
4. 요청 닉네임으로 클럽 멤버 배치조회
5. 클럽멤버로 멤버 팀 생성
6. 팀을 명시적으로 저장 (cascade로 memberTeam까지 저장됨)

### 올바른 요청

[1] 어떤 팀도 존재하지 않을 경우 (O) (만약 전에 팀이 존재했다면 팀 발제, 팀원 정보 포함 모든 팀이 삭제됩니다!)

```java
{
  "teamMemberDTOList": [
  ]
}
```

[2] 1번 팀이 존재만 하고, 어떤 팀원도 들어가 있지 않을 경우 (O)

```json
{
  "teamMemberDTOList": [
    {
      "teamNumber": 1,
      "nicknameList": [
      ]
    }
  ]
}
```

[3]  1번 팀에 오즈, 효정이 존재하고, 2번 팀에 모두까기가 존재 (O)

```java
{
  "teamMemberDTOList": [
    {
      "teamNumber": 1,
      "nicknameList": [
				"oz","hyojeong"
      ]
    },
		{
			"teamNumber":2,
			"nicknameList":[
			"moduggagi"
			]
		}
	]
}
```

### 잘못된 요청

[1] 요청하는 팀 번호가 중복될 경우 (X)

```java
{
  "teamMemberDTOList": [
    {
      "teamNumber": 1,
      "nicknameList": [
				"oz","hyojeong"
      ]
    },
		{
			"teamNumber":1,
			"nicknameList":[
			"moduggagi"
			]
		}
	]
}
```

[2] 리스트의 요소가 하나 이상 존재하지만, @NotNull로 검증 실패 (X)

```java
{
  "teamMemberDTOList": [
  {}
  ]
}
```

[3] 닉네임 리스트가 빈 문자열 리스트도 아니고 null 처리되어서 실패 (X)

### 향후 고려해 볼 점
1. PM님께서 팀이나 팀 멤버가 많지 않다고 언급하셔서 소규모 delete의 경우, 간단하게 고아객체로 만들어서 처리했습니다.
소규모(팀 6개, 팀원 총 30명)라 크게 성능상 크게 문제 될 것 같지는 않고 
현재 메서드에서 올라와 있는 영속성 컨텍스트가 많아서 따로 관리하는 게 복잡해서 깔끔하게 고아객체로 처리했습니다.
나중에 성능 상 문제될 것 같다! 싶으면 배치 삭제도 고려해보겠습니다.
2. 자세한 에러 메시지를 위해 ExceptionAdvice는 나중에 수정해보겠습니다. (일단 프론트엔드랑 연결 끝난 다음에 처리하겠습니당^^...)

## 🔗 관련 이슈
- Closes #77 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PUT /api/meetings/{meetingId}/teams to create, update, remove, and reassign discussion teams by nickname.
  - Batch nickname lookup to support multi-member assignments.

- **Bug Fixes / Behavior**
  - Enforces staff-only access for team management.
  - Duplicate team numbers now return a clear client error.

- **Validation**
  - Team numbers required and must be ≥1; nicknames required and format-checked.

- **Documentation**
  - OpenAPI/Swagger added for the new endpoint and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->