### PR TITLE
♻️[Refactor] API 응답 코드 추가

### DIFF
--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -65,12 +65,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 회원
     MEMBER_INACTIVE(HttpStatus.FORBIDDEN, "MEMBER_401", "비활성화된 회원입니다."),
-    MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER402", "이미 존재하는 회원입니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "해당 회원을 찾을 수 없습니다."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER_402", "이미 존재하는 회원입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_404", "해당 회원을 찾을 수 없습니다."),
     MEMBER_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "MEMBER_403", "인증되지 않은 회원입니다."),
     MEMBER_PROFILE_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER_406", "이미 프로필이 완성된 회원입니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER_407", "이미 존재하는 닉네임입니다."),
-    MEMBER_PROFILE_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER_408", "프로필이 완성되지 않은 회원입니다."),
+    MEMBER_PROFILE_NOT_COMPLETED(HttpStatus.FORBIDDEN, "MEMBER_408", "프로필이 완성되지 않은 회원입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "MEMBER_409", "이메일 또는 비밀번호가 일치하지 않습니다."),
     MEMBER_CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST, "MEMBER_410", "자기 자신을 팔로잉할 수 없습니다."),
     MEMBER_ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "MEMBER_411", "이미 팔로잉 중인 회원입니다."),

--- a/src/main/java/checkmo/domain/member/web/controller/AuthController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/AuthController.java
@@ -39,6 +39,10 @@ public class AuthController {
     @Operation(summary = "이메일 인증번호 요청", description = "회원가입 시 이메일 인증번호를 요청합니다.")
     @Parameter(name = "email", description = "인증을 요청할 이메일 주소", required = true, example = "test@example.com")
     @PostMapping("/email-verification")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
     public ApiResponse<String> sendEmailVerification(@RequestParam
                                                      @Email(message = "유효한 이메일 주소를 입력해주세요")
                                                      @NotBlank(message = "이메일은 필수입니다")
@@ -50,6 +54,10 @@ public class AuthController {
     // 이메일 인증 확인
     @Operation(summary = "이메일 인증번호 확인", description = "이메일 인증번호를 확인합니다.")
     @PostMapping("/email-verification/confirm")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
     public ApiResponse<Boolean> verifyEmailCode(
         @Valid @RequestBody MemberRequestDTO.EmailVerificationRequestDTO request) {
         boolean isVerified = memberCommandFacade.verifyEmailCode(request);
@@ -59,6 +67,11 @@ public class AuthController {
     // 회원가입
     @Operation(summary = "회원가입", description = "이메일 인증 완료 후 회원가입을 진행합니다.")
     @PostMapping("/signup")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류입니다. 관리자에게 문의 바랍니다.")
+    })
     public ApiResponse<MemberResponseDTO.SignUpResponseDTO> signUp(
         @Valid @RequestBody MemberRequestDTO.SignUpRequestDTO request,
         HttpServletResponse response) {
@@ -68,6 +81,12 @@ public class AuthController {
     // 회원 추가 정보 입력
     @Operation(summary = "회원 추가 정보 입력", description = "회원가입 후 추가 정보를 입력합니다.")
     @PostMapping("/additional-info")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 회원입니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
+    })
     public ApiResponse<Void> addAdditionalInfo(
         @Valid @RequestBody MemberRequestDTO.AdditionalInfoDTO request) {
         memberCommandFacade.addAdditionalInfo(request);
@@ -77,6 +96,10 @@ public class AuthController {
     // 닉네임 중복 확인
     @Operation(summary = "닉네임 중복 확인", description = "회원가입 시 닉네임 중복을 확인합니다.")
     @PostMapping("/check-nickname")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
     public ApiResponse<Boolean> checkNickname(@RequestParam
                                               @NotBlank(message = "닉네임은 필수입니다")
                                               @Size(max = 6, message = "닉네임은 최대 6자까지 가능합니다") String nickname) {
@@ -87,6 +110,11 @@ public class AuthController {
     // 이메일 로그인
     @Operation(summary = "이메일 로그인", description = "이메일과 비밀번호로 로그인합니다.")
     @PostMapping("/login")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "이메일 또는 비밀번호가 일치하지 않습니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 내부 오류입니다. 관리자에게 문의 바랍니다.")
+    })
     public ApiResponse<MemberResponseDTO.LoginResponseDTO> login(
         @Valid @RequestBody MemberRequestDTO.LoginRequestDTO request,
         HttpServletResponse response) {
@@ -96,6 +124,9 @@ public class AuthController {
     // 로그아웃
     @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
     @PostMapping("/logout")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
+    })
     public ApiResponse<Void> logout(HttpServletRequest request, HttpServletResponse response) {
         memberCommandFacade.logout(request, response);
         return ApiResponse.onSuccess(null);

--- a/src/main/java/checkmo/domain/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/MemberController.java
@@ -124,6 +124,12 @@ public class MemberController {
 
     @Operation(summary = "내 프로필 편집 API", description = "내 프로필을 편집합니다. 프로필 이미지, 소개, 관심 카테고리를 수정할 수 있습니다.")
     @PatchMapping("/me")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
+    })
     public ApiResponse<MemberResponseDTO.MemberProfileWithCategoryResponseDTO> updateMemberProfile(
             @CurrentId String memberId,
             @RequestBody MemberRequestDTO.MemberProfileUpdateRequestDTO request
@@ -133,6 +139,11 @@ public class MemberController {
 
     @Operation(summary = "내 프로필 조회 API", description = "내 프로필 정보(관심 카테고리 정보 포함)를 조회합니다.")
     @GetMapping("/me")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
+    })
     public ApiResponse<MemberResponseDTO.MemberProfileWithCategoryResponseDTO> getMemberProfile(
             @CurrentId String memberId
     ) {

--- a/src/main/java/checkmo/domain/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/domain/member/web/controller/MemberController.java
@@ -128,6 +128,7 @@ public class MemberController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "프로필이 완성되지 않은 회원입니다."),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
     })
     public ApiResponse<MemberResponseDTO.MemberProfileWithCategoryResponseDTO> updateMemberProfile(
@@ -142,6 +143,7 @@ public class MemberController {
     @io.swagger.v3.oas.annotations.responses.ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "프로필이 완성되지 않은 회원입니다."),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
     })
     public ApiResponse<MemberResponseDTO.MemberProfileWithCategoryResponseDTO> getMemberProfile(


### PR DESCRIPTION
## 🚀 변경사항
- 프로필이 완성되지 않은 회원은 ProfileCompletionAuthorizationFilter에서 FORBIDDEN을 뱉고 있으므로 통일
- 멤버 관련 각 API에 대한 응답/에러 코드 추가

## 🔗 관련 이슈
- Closes #85 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized member-related error codes to underscore format (e.g., MEMBER_402, MEMBER_404).
  * "Profile not completed" now returns HTTP 403 Forbidden instead of 400.

* **Documentation**
  * Added/expanded API response docs for auth and member endpoints (email verification/confirm, signup, additional-info, nickname check, login, logout, profile get/update), detailing success and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->