### PR TITLE
✨ [FEAT] 독서모임 상세조회 기능

### DIFF
--- a/src/main/java/checkmo/domain/club/converter/ClubConverter.java
+++ b/src/main/java/checkmo/domain/club/converter/ClubConverter.java
@@ -585,10 +585,7 @@ public class ClubConverter {
                             ))
                             .toList();
 
-                    return MeetingResponseDTO.TeamTopicDTO.builder()
-                            .teamNumber(team.getTeamNumber())
-                            .topics(teamTopicDTOs)
-                            .build();
+                    return fromTopicDTOListToTeamTopicDTO(team.getTeamNumber(), teamTopicDTOs);
                 })
                 .toList();
         return fromMeetingInfoDTOAndTopicDTOListAndTeamTopicDTOListToTopicDTO(

--- a/src/main/java/checkmo/domain/club/converter/ClubConverter.java
+++ b/src/main/java/checkmo/domain/club/converter/ClubConverter.java
@@ -7,9 +7,7 @@ import checkmo.domain.club.entity.ClubMember;
 import checkmo.domain.club.entity.announcement.MemberVote;
 import checkmo.domain.club.entity.announcement.Notice;
 import checkmo.domain.club.entity.announcement.Vote;
-import checkmo.domain.club.entity.meeting.BookReview;
-import checkmo.domain.club.entity.meeting.Meeting;
-import checkmo.domain.club.entity.meeting.Topic;
+import checkmo.domain.club.entity.meeting.*;
 import checkmo.domain.club.web.dto.bookshelf.BookShelfRequestDTO;
 import checkmo.domain.club.web.dto.bookshelf.BookShelfResponseDTO;
 import checkmo.domain.club.web.dto.club.ClubRequestDTO;
@@ -24,7 +22,9 @@ import checkmo.global.dto.MemberSharedDTO;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ClubConverter {
@@ -539,6 +539,9 @@ public class ClubConverter {
                 .toList();
     }
 
+    /**
+     * Topic 엔티티 + MemberSharedDTO.BasicInfoDTO + 팀 번호 리스트 -> MeetingResponseDTO.TopicDTO 변환
+     */
     public static MeetingResponseDTO.TopicDTO fromTopicAndMemberSharedDTOAndTeamNumberListToTopicDTO(
             Topic topic,
             MemberSharedDTO.BasicInfoDTO authorSharedDTO,
@@ -550,6 +553,55 @@ public class ClubConverter {
                 .authorInfo(authorSharedDTO)
                 .teamNumbers(teamNumbers)
                 .build();
+    }
+
+    /**
+     * Meeting 엔티티 + BookSharedDTO.BasicInfoDTO + Topic 리스트 + 팀별 Topic 리스트 -> MeetingResponseDTO.MeetingDetailDTO 변환
+     */
+    public static MeetingResponseDTO.MeetingDetailDTO fromMeetingAndBookSharedDTOEtcToMeetingDetailDTO(
+            Meeting meeting,
+            BookSharedDTO.BasicInfoDTO bookSharedDTO,
+            List<Topic> topics,
+            Map<Long, List<Integer>> teamTopicsWithTeamByTopicIds,
+            List<Team> teams,
+            Map<Integer, List<TeamTopic>> teamTopicsGroupingByTeamNumber,
+            Map<String, MemberSharedDTO.BasicInfoDTO> authorInfoMap
+    ) {
+        MeetingResponseDTO.MeetingInfoDTO meetingInfoDTO = ClubConverter.fromMeetingAndBookSharedDTOToMeetingInfoDTO(meeting, bookSharedDTO);
+
+        List<MeetingResponseDTO.TopicDTO> topicDTOList = topics.stream()
+                .map(topic -> ClubConverter.fromTopicAndMemberSharedDTOAndTeamNumberListToTopicDTO(
+                        topic,
+                        authorInfoMap.get(topic.getClubMember().getMemberId()),
+                        teamTopicsWithTeamByTopicIds.getOrDefault(topic.getId(), List.of())
+                ))
+                .toList();
+
+        List<MeetingResponseDTO.TeamTopicDTO> teamTopicDTOList = teams.stream()
+                .sorted(Comparator.comparing(Team::getTeamNumber)) // 팀 번호 기준 정렬
+                .map(team -> {
+                    List<TeamTopic> teamTopics =
+                            teamTopicsGroupingByTeamNumber.get(team.getTeamNumber());
+
+                    List<MeetingResponseDTO.TopicDTO> teamTopicDTOs = teamTopics.stream()
+                            .map(tt -> ClubConverter.fromTopicAndMemberSharedDTOAndTeamNumberListToTopicDTO(
+                                    tt.getTopic(),
+                                    authorInfoMap.get(tt.getTopic().getClubMember().getMemberId()),
+                                    null // TeamTopicDTO-TopicDTO에서는 teamNumbers 필드가 NULL이어야 함
+                            ))
+                            .toList();
+
+                    return MeetingResponseDTO.TeamTopicDTO.builder()
+                            .teamNumber(team.getTeamNumber())
+                            .topics(teamTopicDTOs)
+                            .build();
+                })
+                .toList();
+        return fromMeetingInfoDTOAndTopicDTOListAndTeamTopicDTOListToTopicDTO(
+                meetingInfoDTO,
+                topicDTOList,
+                teamTopicDTOList
+        );
     }
 
     // =====================================================
@@ -665,6 +717,21 @@ public class ClubConverter {
         return MeetingResponseDTO.TeamTopicDTO.builder()
                 .teamNumber(teamNumber)
                 .topics(topicList)
+                .build();
+    }
+
+    /**
+     * MeetingResponseDTO.MeetingInfoDTO + List<TopicDTO> + List<TeamTopicDTO> -> MeetingResponseDTO.MeetingDetailDTO 변환
+     */
+    public static MeetingResponseDTO.MeetingDetailDTO fromMeetingInfoDTOAndTopicDTOListAndTeamTopicDTOListToTopicDTO(
+            MeetingResponseDTO.MeetingInfoDTO meetingInfoDTO,
+            List<MeetingResponseDTO.TopicDTO> topicDTOList,
+            List<MeetingResponseDTO.TeamTopicDTO> teamTopicDTOList
+    ) {
+        return MeetingResponseDTO.MeetingDetailDTO.builder()
+                .meetingInfo(meetingInfoDTO)
+                .topics(topicDTOList)
+                .teams(teamTopicDTOList)
                 .build();
     }
 

--- a/src/main/java/checkmo/domain/club/converter/ClubConverter.java
+++ b/src/main/java/checkmo/domain/club/converter/ClubConverter.java
@@ -569,13 +569,7 @@ public class ClubConverter {
     ) {
         MeetingResponseDTO.MeetingInfoDTO meetingInfoDTO = ClubConverter.fromMeetingAndBookSharedDTOToMeetingInfoDTO(meeting, bookSharedDTO);
 
-        List<MeetingResponseDTO.TopicDTO> topicDTOList = topics.stream()
-                .map(topic -> ClubConverter.fromTopicAndMemberSharedDTOAndTeamNumberListToTopicDTO(
-                        topic,
-                        authorInfoMap.get(topic.getClubMember().getMemberId()),
-                        teamTopicsWithTeamByTopicIds.getOrDefault(topic.getId(), List.of())
-                ))
-                .toList();
+        List<MeetingResponseDTO.TopicDTO> topicDTOList = fromTopicListAndTopicSelectionAndMemberSharedDTOToTopicDTOList(topics, authorInfoMap, teamTopicsWithTeamByTopicIds);
 
         List<MeetingResponseDTO.TeamTopicDTO> teamTopicDTOList = teams.stream()
                 .sorted(Comparator.comparing(Team::getTeamNumber)) // 팀 번호 기준 정렬
@@ -602,6 +596,24 @@ public class ClubConverter {
                 topicDTOList,
                 teamTopicDTOList
         );
+    }
+
+    /**
+     * Topic 리스트 + Topic별 팀 선택 정보 + 작성자 정보 맵 -> List<MeetingResponseDTO.TopicDTO> 변환
+     */
+    public static List<MeetingResponseDTO.TopicDTO> fromTopicListAndTopicSelectionAndMemberSharedDTOToTopicDTOList(
+            List<Topic> topics,
+            Map<String, MemberSharedDTO.BasicInfoDTO> authorInfoMap,
+            Map<Long, List<Integer>> teamTopicsWithTeamByTopicIds
+    ) {
+        List<MeetingResponseDTO.TopicDTO> topicDTOList = topics.stream()
+                .map(topic -> ClubConverter.fromTopicAndMemberSharedDTOAndTeamNumberListToTopicDTO(
+                        topic,
+                        authorInfoMap.get(topic.getClubMember().getMemberId()),
+                        teamTopicsWithTeamByTopicIds.getOrDefault(topic.getId(), List.of())
+                ))
+                .toList();
+        return topicDTOList;
     }
 
     // =====================================================

--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacade.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacade.java
@@ -5,7 +5,6 @@ import checkmo.domain.club.web.dto.bookshelf.BookShelfResponseDTO;
 import checkmo.domain.club.web.dto.club.ClubResponseDTO;
 import checkmo.domain.club.web.dto.meeting.MeetingResponseDTO;
 import checkmo.global.dto.ClubSharedDTO;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -198,7 +197,7 @@ public interface ClubQueryFacade {
      * @param memberId 요청자 회원 ID
      * @return 미팅 상세 정보 DTO
      */
-    MeetingResponseDTO.MeetingDetailDTO findMeetingById(Long meetingId, String memberId);
+    MeetingResponseDTO.MeetingDetailDTO findMeetingDetailById(Long meetingId, String memberId);
 
     /**
      * ClubMeetingQueryService

--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
@@ -310,7 +310,7 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
 
     @Override
     public BookShelfResponseDTO.BookShelfListDTO getBookShelfList(Long clubId, Long cursorId, Integer size, Integer generation, String memberId) {
-        List<Meeting> meetings = clubMeetingQueryService.getBookShelfList(clubId, generation, cursorId, size, memberId);
+        List<Meeting> meetings = clubMeetingQueryService.getBookShelfList(clubId, generation, cursorId, size + 1, memberId);
         boolean hasNext = meetings.size() > size;
         if (hasNext) {
             meetings = meetings.subList(0, size);
@@ -337,7 +337,7 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
         Meeting meeting = clubMeetingQueryService.validateMeeting(meetingId);
         clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
 
-        List<Topic> topics = clubMeetingQueryService.findTopicsByMeeting(meetingId, null, TOPIC_SIZE);
+        List<Topic> topics = clubMeetingQueryService.findTopicsWithClubMemberByMeeting(meetingId, null, TOPIC_SIZE + 1);
 
         boolean hasNext = topics.size() > TOPIC_SIZE;
         if (hasNext) {
@@ -365,7 +365,7 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
         Meeting meeting = clubMeetingQueryService.validateMeeting(meetingId);
         clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
 
-        List<Topic> topics = clubMeetingQueryService.findTopicsByMeeting(meetingId, cursorId, size);
+        List<Topic> topics = clubMeetingQueryService.findTopicsWithClubMemberByMeeting(meetingId, cursorId, size + 1);
 
         boolean hasNext = topics.size() > size;
         if (hasNext) {
@@ -420,7 +420,7 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
         clubQueryService.validateClub(clubId);
         clubMemberQueryService.validateClubMember(clubId, memberId);
 
-        List<Meeting> meetings = clubMeetingQueryService.findMeetingsByClubAndCursor(clubId, cursorId, size);
+        List<Meeting> meetings = clubMeetingQueryService.findMeetingsByClubAndCursor(clubId, cursorId, size + 1);
         boolean hasNext = meetings.size() > size;
         if (hasNext) {
             meetings = meetings.subList(0, size);
@@ -448,7 +448,7 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
         clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
 
         // 2. 토픽 리스트 조회
-        List<Topic> topics = clubMeetingQueryService.findTopicsByMeeting(meetingId, null, null);
+        List<Topic> topics = clubMeetingQueryService.findTopicsWithClubMemberByMeeting(meetingId, null, null);
 
         // 3. 토픽 작성자 정보 배치 조회
         List<String> authorIds = topics.stream()

--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
@@ -21,6 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -437,8 +440,52 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
     }
 
     @Override
-    public MeetingResponseDTO.MeetingDetailDTO findMeetingById(Long meetingId, String memberId) {
-        return null;
+    public MeetingResponseDTO.MeetingDetailDTO findMeetingDetailById(Long meetingId, String memberId) {
+        // 1. 미팅과 클럽 멤버 검증
+        Meeting meeting = clubMeetingQueryService.validateMeeting(meetingId);
+        clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
+
+        // 2. [발제 전체보기 - 미리보기] 발제 최신순 상위 4개 토픽 리스트 조회
+        List<Topic> topics = clubMeetingQueryService.findTopicsWithClubMemberByMeeting(meetingId, null, 4);
+
+        // 3. [발제 전체보기 - 미리보기] TeamTopic과 Team 배치 조회
+        List<Long> topicIds = topics.stream()
+                .map(Topic::getId)
+                .toList();
+        Map<Long, List<Integer>> teamTopicsWithTeamByTopicIds = clubMeetingQueryService.findTeamTopicsWithTeamByTopicIds(topicIds);
+
+        // 4. [토론 x조 - 미리보기] 해당하는 미팅의 존재하는 모든 팀 조회
+        List<Team> teams = clubMeetingQueryService.findTeamsByMeeting(meetingId);
+
+        // 5. [토론 x조 - 미리보기] 모든 팀의 발제 등록순 상위 4개 토픽 조회
+        Map<Integer, List<TeamTopic>> teamTopicsGroupingByTeamNumber = teams.stream()
+                .collect(Collectors.toMap(
+                        Team::getTeamNumber, // key: 팀 번호
+                        team -> clubMeetingQueryService.findTeamTopicsWithTopicAndClubMemberByTeamId(team.getId(), 4) //value : 해당 팀의 발제 최신순 상위 4개 팀 토픽 리스트
+                ));
+
+        // 6. 조회한 모든 발제(topics와 teamTopics)의 작성자 id를 중복 없이 리스트 조회
+        List<String> authorIds = Stream.concat(
+                        topics.stream().map(t -> t.getClubMember().getMemberId()),
+                        teamTopicsGroupingByTeamNumber.values().stream()
+                                .flatMap(List::stream)
+                                .map(tt -> tt.getTopic().getClubMember().getMemberId())
+                )
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+
+        // 7. 발제의 작성자 정보 배치 조회
+        Map<String, MemberSharedDTO.BasicInfoDTO> authorInfoMap =
+                memberQueryFacade.getMemberBasicInfoMapForShare(authorIds);
+
+        // 7. DTO 변환
+        return ClubConverter.fromMeetingAndBookSharedDTOEtcToMeetingDetailDTO(
+                meeting, bookQueryFacade.getBookBasicInfoForShare(meeting.getBookId()), // -> MeetingInfoDTO
+                topics, teamTopicsWithTeamByTopicIds, // -> List<TopicDTO>
+                teams, teamTopicsGroupingByTeamNumber, // -> List<TeamTopicDTO>
+                authorInfoMap // -> List<TopicDTO>, List<TeamTopicDTO> 작성자 정보
+        );
     }
 
     @Override

--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
@@ -480,8 +480,8 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
         clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
         Team team = clubMeetingQueryService.validateTeam(meetingId, teamNumber);
 
-        // 2. 팀 토픽 > 토픽 > 클럽 멤버 정보 조회
-        List<TeamTopic> teamTopics = clubMeetingQueryService.findTeamTopicsByTeam(team.getId());
+        // 2. 팀 토픽 > 토픽 > 클럽 멤버 정보 전체 조회
+        List<TeamTopic> teamTopics = clubMeetingQueryService.findTeamTopicsWithTopicAndClubMemberByTeamId(team.getId(), null);
 
         // 3. 토픽 작성자 정보 배치 조회
         List<String> authorIds = teamTopics.stream()

--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
@@ -512,13 +512,11 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
         Map<Long, List<Integer>> teamTopicsWithTeamByTopicIds = clubMeetingQueryService.findTeamTopicsWithTeamByTopicIds(topicIds);
 
         // 5. MeetingResponseDTO.TopicListDTO 변환
-        return topics.stream()
-                .map(topic -> ClubConverter.fromTopicAndMemberSharedDTOAndTeamNumberListToTopicDTO(
-                                topic,
-                                authorInfoMap.get(topic.getClubMember().getMemberId()),
-                                teamTopicsWithTeamByTopicIds.getOrDefault(topic.getId(), List.of())
-                        )
-                ).toList();
+        return ClubConverter.fromTopicListAndTopicSelectionAndMemberSharedDTOToTopicDTOList(
+                topics,
+                authorInfoMap,
+                teamTopicsWithTeamByTopicIds
+        );
     }
 
     public MeetingResponseDTO.TeamTopicDTO findMeetingTopicsByTeam(Long meetingId, Integer teamNumber, String memberId) {

--- a/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
@@ -19,12 +19,15 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
 
     List<ClubMember> findAllByMemberIdAndClubIdIn(String memberId, List<Long> clubIds);
 
-    List<ClubMember> findByClubIdAndClubMemberStatusAndIdLessThanOrderByIdDesc(Long clubId, ClubMember.ClubMemberStatus status, Long cursorId, Pageable pageable);
-    List<ClubMember> findByClubIdAndIdLessThanOrderByIdDesc(Long clubId, Long cursorId, Pageable pageable);
+    List<ClubMember> findAllByClubIdAndClubMemberStatusAndIdLessThanOrderByIdDesc(Long clubId, ClubMember.ClubMemberStatus status, Long cursorId, Pageable pageable);
 
-    List<ClubMember> findByClubIdAndClubMemberStatusOrderByIdDesc(Long clubId, ClubMember.ClubMemberStatus status, Pageable pageable);
-    List<ClubMember> findByClubIdOrderByIdDesc(Long clubId, Pageable pageable);
+    List<ClubMember> findAllByClubIdAndIdLessThanOrderByIdDesc(Long clubId, Long cursorId, Pageable pageable);
+
+    List<ClubMember> findAllByClubIdAndClubMemberStatusOrderByIdDesc(Long clubId, ClubMember.ClubMemberStatus status, Pageable pageable);
+
+    List<ClubMember> findAllByClubIdOrderByIdDesc(Long clubId, Pageable pageable);
 
     boolean existsByClubIdAndClubMemberStatusAndIdLessThan(Long clubId, ClubMember.ClubMemberStatus status, Long lastId);
+
     boolean existsByClubIdAndIdLessThan(Long clubId, Long lastId);
 }

--- a/src/main/java/checkmo/domain/club/repository/announcement/NoticeRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/announcement/NoticeRepository.java
@@ -1,23 +1,23 @@
 package checkmo.domain.club.repository.announcement;
 
 import checkmo.domain.club.entity.announcement.Notice;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     @Query("""
-        SELECT n FROM Notice n 
-        WHERE n.club.id = :clubId
-          AND (:onlyImportant = false OR n.important = true)
-          AND (:cursorId IS NULL OR n.id < :cursorId)
-        ORDER BY n.createdAt DESC
-        """)
-    List<Notice> findByClubIdAndCursorPaging(
+            SELECT n FROM Notice n 
+            WHERE n.club.id = :clubId
+              AND (:onlyImportant = false OR n.important = true)
+              AND (:cursorId IS NULL OR n.id < :cursorId)
+            ORDER BY n.createdAt DESC
+            """)
+    List<Notice> findAllByClubIdAndCursorPaging(
             @Param("clubId") Long clubId,
             @Param("onlyImportant") boolean onlyImportant,
             @Param("cursorId") Long cursorId,
@@ -25,13 +25,13 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     );
 
     @Query("""
-        SELECT n FROM Notice n 
-        WHERE n.club.id IN :clubIds
-          AND (:onlyImportant = false OR n.important = true)
-          AND (:cursorId IS NULL OR n.id < :cursorId)
-        ORDER BY n.createdAt DESC
-        """)
-    List<Notice> findByClubIdsAndCursorPaging(
+            SELECT n FROM Notice n 
+            WHERE n.club.id IN :clubIds
+              AND (:onlyImportant = false OR n.important = true)
+              AND (:cursorId IS NULL OR n.id < :cursorId)
+            ORDER BY n.createdAt DESC
+            """)
+    List<Notice> findAllByClubIdsAndCursorPaging(
             @Param("clubIds") List<Long> clubIds,
             @Param("onlyImportant") boolean onlyImportant,
             @Param("cursorId") Long cursorId,

--- a/src/main/java/checkmo/domain/club/repository/meeting/MeetingRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/MeetingRepository.java
@@ -14,5 +14,5 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long>, Meeting
             "AND m.meetingTime < :endDate " +
             "ORDER BY m.meetingTime ASC")
         // DATE_FORMAT이나 TO_CHAR은 모든 ROW에 대해 해당 함수를 적용하기 때문에 성능 상 범위 탐색으로 찾기
-    List<Meeting> findByClubIdAndMeetingTimeBetweenAsc(Long clubId, LocalDateTime startDate, LocalDateTime endDate);
+    List<Meeting> findAllByClubIdBetweenMeetingTimeAsc(Long clubId, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/MeetingRepositoryCustom.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/MeetingRepositoryCustom.java
@@ -5,6 +5,7 @@ import checkmo.domain.club.entity.meeting.Meeting;
 import java.util.List;
 
 public interface MeetingRepositoryCustom {
-    List<Meeting> findMeetingsByClubIdAndCursorDesc(Long clubId, Long cursorId, Integer size);
-    List<Meeting> findMeetingsByClubIdAndGenerationAndCursorDesc(Long clubId, Integer generation, Long cursorId, Integer size);
+    List<Meeting> findAllByClubIdAndCursorDesc(Long clubId, Long cursorId, Integer size);
+
+    List<Meeting> findAllByClubIdAndGenerationAndCursorDesc(Long clubId, Integer generation, Long cursorId, Integer size);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/MeetingRepositoryCustomImpl.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/MeetingRepositoryCustomImpl.java
@@ -16,7 +16,7 @@ public class MeetingRepositoryCustomImpl implements MeetingRepositoryCustom {
     private final QMeeting meeting = QMeeting.meeting;
 
     @Override
-    public List<Meeting> findMeetingsByClubIdAndCursorDesc(Long clubId, Long cursorId, Integer size) {
+    public List<Meeting> findAllByClubIdAndCursorDesc(Long clubId, Long cursorId, Integer size) {
         BooleanBuilder predicate = new BooleanBuilder();
         predicate.and(meeting.club.id.eq(clubId));
         if (cursorId != null) {
@@ -33,7 +33,7 @@ public class MeetingRepositoryCustomImpl implements MeetingRepositoryCustom {
     }
 
     @Override
-    public List<Meeting> findMeetingsByClubIdAndGenerationAndCursorDesc(Long clubId, Integer generation, Long cursorId, Integer size) {
+    public List<Meeting> findAllByClubIdAndGenerationAndCursorDesc(Long clubId, Integer generation, Long cursorId, Integer size) {
         BooleanBuilder predicate = new BooleanBuilder();
         predicate.and(meeting.club.id.eq(clubId));
 

--- a/src/main/java/checkmo/domain/club/repository/meeting/TeamRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TeamRepository.java
@@ -3,8 +3,11 @@ package checkmo.domain.club.repository.meeting;
 import checkmo.domain.club.entity.meeting.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByMeetingIdAndTeamNumber(Long meetingId, Integer teamNumber);
+
+    List<Team> findTeamsByMeetingIdOrderByTeamNumberAsc(Long meetingId);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TeamRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TeamRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByMeetingIdAndTeamNumber(Long meetingId, Integer teamNumber);
 
-    List<Team> findTeamsByMeetingIdOrderByTeamNumberAsc(Long meetingId);
+    List<Team> findAllByMeetingIdOrderByTeamNumberAsc(Long meetingId);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TeamTopicRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TeamTopicRepository.java
@@ -1,6 +1,7 @@
 package checkmo.domain.club.repository.meeting;
 
 import checkmo.domain.club.entity.meeting.TeamTopic;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -10,7 +11,7 @@ import java.util.Optional;
 public interface TeamTopicRepository extends JpaRepository<TeamTopic, Long> {
     @Query("SELECT tt FROM TeamTopic tt " +
             "JOIN FETCH tt.team t " +
-            "WHERE tt.topic.id IN :topicIds " +
+            "WHERE tt.topicId IN :topicIds " +
             "ORDER BY t.teamNumber ASC")
     List<TeamTopic> findTeamTopicsWithTeamByTopicIds(List<Long> topicIds);
 
@@ -20,7 +21,7 @@ public interface TeamTopicRepository extends JpaRepository<TeamTopic, Long> {
             "JOIN FETCH t.clubMember cm " +
             "WHERE tt.teamId = :teamId " +
             "ORDER BY t.id DESC ")
-    List<TeamTopic> findTeamTopicsWithTopicAndClubMemberByTeamIdOrderByDesc(Long teamId);
+    List<TeamTopic> findTeamTopicsWithTopicAndClubMemberByTeamIdOrderByDesc(Long teamId, Pageable pageable);
 
     Optional<TeamTopic> findByTeamIdAndTopicId(Long teamId, Long topicId);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TeamTopicRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TeamTopicRepository.java
@@ -13,7 +13,7 @@ public interface TeamTopicRepository extends JpaRepository<TeamTopic, Long> {
             "JOIN FETCH tt.team t " +
             "WHERE tt.topicId IN :topicIds " +
             "ORDER BY t.teamNumber ASC")
-    List<TeamTopic> findTeamTopicsWithTeamByTopicIds(List<Long> topicIds);
+    List<TeamTopic> findAllWithTeamByTopicIds(List<Long> topicIds);
 
     @Query("SELECT tt " +
             "FROM TeamTopic tt " +
@@ -21,7 +21,7 @@ public interface TeamTopicRepository extends JpaRepository<TeamTopic, Long> {
             "JOIN FETCH t.clubMember cm " +
             "WHERE tt.teamId = :teamId " +
             "ORDER BY t.id DESC ")
-    List<TeamTopic> findTeamTopicsWithTopicAndClubMemberByTeamIdOrderByDesc(Long teamId, Pageable pageable);
+    List<TeamTopic> findAllWithTopicAndClubMemberByTeamIdOrderByDesc(Long teamId, Pageable pageable);
 
     Optional<TeamTopic> findByTeamIdAndTopicId(Long teamId, Long topicId);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TopicRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TopicRepository.java
@@ -3,11 +3,8 @@ package checkmo.domain.club.repository.meeting;
 import checkmo.domain.club.entity.meeting.Topic;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface TopicRepository extends JpaRepository<Topic, Long>, TopicRepositoryCustom {
     Optional<Topic> findByIdAndMeetingId(Long topicId, Long meetingId);
-
-    List<Topic> findTopicsByMeetingIdOrderByIdDesc(Long meetingId);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustom.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustom.java
@@ -5,5 +5,5 @@ import checkmo.domain.club.entity.meeting.Topic;
 import java.util.List;
 
 public interface TopicRepositoryCustom {
-    List<Topic> findTopicsByCursorOrderByIdDesc(Long meetingId, Long cursorId, Integer size);
+    List<Topic> findTopicsWithClubMemberByCursorOrderByIdDesc(Long meetingId, Long cursorId, Integer size);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustom.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustom.java
@@ -5,5 +5,5 @@ import checkmo.domain.club.entity.meeting.Topic;
 import java.util.List;
 
 public interface TopicRepositoryCustom {
-    List<Topic> findTopicsWithClubMemberByCursorOrderByIdDesc(Long meetingId, Long cursorId, Integer size);
+    List<Topic> findAllWithClubMemberByCursorOrderByIdDesc(Long meetingId, Long cursorId, Integer size);
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustomImpl.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package checkmo.domain.club.repository.meeting;
 import checkmo.domain.club.entity.meeting.QTopic;
 import checkmo.domain.club.entity.meeting.Topic;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,20 +17,25 @@ public class TopicRepositoryCustomImpl implements TopicRepositoryCustom {
     private final QTopic topic = QTopic.topic;
 
     @Override
-    public List<Topic> findTopicsByCursorOrderByIdDesc(Long meetingId, Long cursorId, Integer size) {
+    public List<Topic> findTopicsWithClubMemberByCursorOrderByIdDesc(Long meetingId, Long cursorId, Integer size) {
         BooleanBuilder predicate = new BooleanBuilder();
-        predicate.and(topic.meeting.id.eq(meetingId));
+        predicate.and(topic.meetingId.eq(meetingId));
 
         if (cursorId != null) {
             predicate.and(topic.id.lt(cursorId));
         }
-        return queryFactory
+
+        JPAQuery<Topic> query = queryFactory
                 .selectFrom(topic)
                 .distinct()
                 .where(predicate)
                 .join(topic.clubMember).fetchJoin()
-                .orderBy(topic.id.desc())
-                .limit(size)
-                .fetch();
+                .orderBy(topic.id.desc());
+
+        if (size != null) {
+            query.limit(size);
+        }
+
+        return query.fetch();
     }
 }

--- a/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustomImpl.java
+++ b/src/main/java/checkmo/domain/club/repository/meeting/TopicRepositoryCustomImpl.java
@@ -17,7 +17,7 @@ public class TopicRepositoryCustomImpl implements TopicRepositoryCustom {
     private final QTopic topic = QTopic.topic;
 
     @Override
-    public List<Topic> findTopicsWithClubMemberByCursorOrderByIdDesc(Long meetingId, Long cursorId, Integer size) {
+    public List<Topic> findAllWithClubMemberByCursorOrderByIdDesc(Long meetingId, Long cursorId, Integer size) {
         BooleanBuilder predicate = new BooleanBuilder();
         predicate.and(topic.meetingId.eq(meetingId));
 

--- a/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryServiceImpl.java
@@ -20,10 +20,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -44,7 +44,7 @@ public class ClubCommunicationQueryServiceImpl implements ClubCommunicationQuery
      *
      * @param clubId 클럽 ID
      * @param itemId 공지 또는 투표 ID
-     * @param tag    "공지", "모임", "투표" 중 하나
+     * @param tag "공지", "모임", "투표" 중 하나
      * @return 공통된 NoticeItem DTO
      */
     @Override
@@ -156,7 +156,7 @@ public class ClubCommunicationQueryServiceImpl implements ClubCommunicationQuery
         int pageSize = pageable.getPageSize();
 
         // 1. 공지사항 리스트 조회
-        List<Notice> notices = noticeRepository.findByClubIdAndCursorPaging(clubId, onlyImportant, cursorId, Pageable.ofSize(pageSize + 1));
+        List<Notice> notices = noticeRepository.findAllByClubIdAndCursorPaging(clubId, onlyImportant, cursorId, Pageable.ofSize(pageSize + 1));
 
         // 2. 투표 리스트 조회
         List<Vote> votes = voteRepository.findByClubIdAndCursorPaging(clubId, onlyImportant, cursorId, Pageable.ofSize(pageSize + 1));
@@ -189,7 +189,7 @@ public class ClubCommunicationQueryServiceImpl implements ClubCommunicationQuery
         }
 
         // 2. 모든 클럽 공지/투표 조회
-        List<Notice> notices = noticeRepository.findByClubIdsAndCursorPaging(
+        List<Notice> notices = noticeRepository.findAllByClubIdsAndCursorPaging(
                 clubIds, onlyImportant, cursorId, Pageable.ofSize(pageSize + 1)
         );
 

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryService.java
@@ -103,6 +103,13 @@ public interface ClubMeetingQueryService {
     List<Meeting> getBookShelfList(Long clubId, Integer generation, Long cursorId, Integer size, String memberId);
 
     /**
+     * 독서 모임 특정 미팅에 존재하는 모든 팀 정보를 조회합니다.
+     *
+     * @return 조회한 팀 리스트
+     * @Param meetingId 미팅 ID
+     */
+    List<Team> findTeamsByMeeting(Long meetingId);
+    /**
      * 독서모임이 존재하는지 확인합니다.
      *
      * @param meetingId 미팅 ID

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryService.java
@@ -47,7 +47,7 @@ public interface ClubMeetingQueryService {
      * @param size 조회할 토픽 개수 (null이면 전체 조회)
      * @return 조회한 토픽 정보 DTO
      */
-    List<Topic> findTopicsByMeeting(Long meetingId, Long cursorId, Integer size);
+    List<Topic> findTopicsWithClubMemberByMeeting(Long meetingId, Long cursorId, Integer size);
 
     /**
      * 특정 토픽 ID 목록에 해당하는 팀 토픽과 팀 정보를 조회한 후,
@@ -57,16 +57,6 @@ public interface ClubMeetingQueryService {
      * @return 토픽 id를 기준으로 선택한 팀 번호 리스트 Map
      */
     Map<Long, List<Integer>> findTeamTopicsWithTeamByTopicIds(List<Long> topicIds);
-
-    /**
-     * 독서 모임 미팅의 팀별 발제 조회
-     *
-     * 피그마 참고 페이지 : #독서모임 - 운영진 화면 모임 - 특정 조 전체보기 클릭시
-     *
-     * @param teamId 미팅 ID
-     * @return TeamTopic 리스트
-     */
-    List<TeamTopic> findTeamTopicsByTeam(Long teamId);
 
     /**
      * 독서 모임의 책장(한줄평) 리스트를 조회합니다.
@@ -109,6 +99,16 @@ public interface ClubMeetingQueryService {
      * @Param meetingId 미팅 ID
      */
     List<Team> findTeamsByMeeting(Long meetingId);
+
+    /**
+     * 독서 모임 미팅의 팀별 발제 조회
+     *
+     * @param teamId 미팅 ID
+     * @param size 조회할 팀 토픽 개수 (null이면 전체 조회)
+     * @return TeamTopic 리스트
+     */
+    List<TeamTopic> findTeamTopicsWithTopicAndClubMemberByTeamId(Long teamId, Integer size);
+
     /**
      * 독서모임이 존재하는지 확인합니다.
      *

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
@@ -8,6 +8,8 @@ import checkmo.domain.club.entity.meeting.*;
 import checkmo.domain.club.repository.meeting.*;
 import checkmo.domain.club.web.dto.meeting.MeetingResponseDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +38,7 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
 
     @Override
     public List<Meeting> findMeetingsByClubAndCursor(Long clubId, Long cursorId, Integer size) {
-        return meetingRepository.findMeetingsByClubIdAndCursorDesc(clubId, cursorId, size + 1);
+        return meetingRepository.findMeetingsByClubIdAndCursorDesc(clubId, cursorId, size);
     }
 
     @Override
@@ -68,7 +70,7 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
         clubQueryService.validateClub(clubId);
         clubMemberQueryService.validateClubMember(clubId, memberId);
 
-        return meetingRepository.findMeetingsByClubIdAndGenerationAndCursorDesc(clubId, generation, cursorId, size + 1);
+        return meetingRepository.findMeetingsByClubIdAndGenerationAndCursorDesc(clubId, generation, cursorId, size);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
@@ -62,11 +62,6 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
     }
 
     @Override
-    public List<TeamTopic> findTeamTopicsByTeam(Long teamId) {
-        return teamTopicRepository.findTeamTopicsWithTopicAndClubMemberByTeamIdOrderByDesc(teamId);
-    }
-
-    @Override
     public List<BookReview> findBookReviewsByMeeting(Long meetingId, Long lastReviewId, int size) {
         return bookReviewRepository.findBookReviewsByCusor(meetingId, lastReviewId, size + 1);
     }
@@ -90,6 +85,12 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
         List<Meeting> meetings = meetingRepository.findByClubIdAndMeetingTimeBetweenAsc(clubId, startDateTime, endDateTime);
 
         return ClubConverter.fromMeetingListToMeetingInfoDTOList(meetings);
+    }
+
+    @Override
+    public List<TeamTopic> findTeamTopicsWithTopicAndClubMemberByTeamId(Long teamId, Integer size) {
+        Pageable pageable = (size == null) ? Pageable.unpaged() : PageRequest.of(0, size);
+        return teamTopicRepository.findTeamTopicsWithTopicAndClubMemberByTeamIdOrderByDesc(teamId, pageable);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
@@ -38,12 +38,12 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
 
     @Override
     public List<Meeting> findMeetingsByClubAndCursor(Long clubId, Long cursorId, Integer size) {
-        return meetingRepository.findMeetingsByClubIdAndCursorDesc(clubId, cursorId, size);
+        return meetingRepository.findAllByClubIdAndCursorDesc(clubId, cursorId, size);
     }
 
     @Override
     public List<Topic> findTopicsWithClubMemberByMeeting(Long meetingId, Long cursorId, Integer size) {
-        return topicRepository.findTopicsWithClubMemberByCursorOrderByIdDesc(meetingId, cursorId, size);
+        return topicRepository.findAllWithClubMemberByCursorOrderByIdDesc(meetingId, cursorId, size);
     }
 
     @Override
@@ -52,7 +52,7 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
             return Map.of();
         }
 
-        List<TeamTopic> teamTopics = teamTopicRepository.findTeamTopicsWithTeamByTopicIds(topicIds);
+        List<TeamTopic> teamTopics = teamTopicRepository.findAllWithTeamByTopicIds(topicIds);
         return teamTopics.stream()
                 .collect(Collectors.groupingBy(
                         TeamTopic::getTopicId, //key: 토픽 ID(토픽 ID로 그룹화)
@@ -70,7 +70,7 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
         clubQueryService.validateClub(clubId);
         clubMemberQueryService.validateClubMember(clubId, memberId);
 
-        return meetingRepository.findMeetingsByClubIdAndGenerationAndCursorDesc(clubId, generation, cursorId, size);
+        return meetingRepository.findAllByClubIdAndGenerationAndCursorDesc(clubId, generation, cursorId, size);
     }
 
     @Override
@@ -81,20 +81,20 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
         LocalDateTime startDateTime = LocalDateTime.of(year, month, 1, 0, 0, 0);
         LocalDateTime endDateTime = startDateTime.plusMonths(1); //12월의 경우 다음 해 1월로 넘어감
 
-        List<Meeting> meetings = meetingRepository.findByClubIdAndMeetingTimeBetweenAsc(clubId, startDateTime, endDateTime);
+        List<Meeting> meetings = meetingRepository.findAllByClubIdBetweenMeetingTimeAsc(clubId, startDateTime, endDateTime);
 
         return ClubConverter.fromMeetingListToMeetingInfoDTOList(meetings);
     }
 
     @Override
     public List<Team> findTeamsByMeeting(Long meetingId) {
-        return teamRepository.findTeamsByMeetingIdOrderByTeamNumberAsc(meetingId);
+        return teamRepository.findAllByMeetingIdOrderByTeamNumberAsc(meetingId);
     }
 
     @Override
     public List<TeamTopic> findTeamTopicsWithTopicAndClubMemberByTeamId(Long teamId, Integer size) {
         Pageable pageable = (size == null) ? Pageable.unpaged() : PageRequest.of(0, size);
-        return teamTopicRepository.findTeamTopicsWithTopicAndClubMemberByTeamIdOrderByDesc(teamId, pageable);
+        return teamTopicRepository.findAllWithTopicAndClubMemberByTeamIdOrderByDesc(teamId, pageable);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
@@ -85,6 +85,11 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
     }
 
     @Override
+    public List<Team> findTeamsByMeeting(Long meetingId) {
+        return teamRepository.findTeamsByMeetingIdOrderByTeamNumberAsc(meetingId);
+    }
+
+    @Override
     public List<TeamTopic> findTeamTopicsWithTopicAndClubMemberByTeamId(Long teamId, Integer size) {
         Pageable pageable = (size == null) ? Pageable.unpaged() : PageRequest.of(0, size);
         return teamTopicRepository.findTeamTopicsWithTopicAndClubMemberByTeamIdOrderByDesc(teamId, pageable);

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
@@ -40,11 +40,8 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
     }
 
     @Override
-    public List<Topic> findTopicsByMeeting(Long meetingId, Long cursorId, Integer size) {
-        if (size == null) { // size가 null인 경우 전체 토픽 조회
-            return topicRepository.findTopicsByMeetingIdOrderByIdDesc(meetingId);
-        }
-        return topicRepository.findTopicsByCursorOrderByIdDesc(meetingId, cursorId, size + 1);
+    public List<Topic> findTopicsWithClubMemberByMeeting(Long meetingId, Long cursorId, Integer size) {
+        return topicRepository.findTopicsWithClubMemberByCursorOrderByIdDesc(meetingId, cursorId, size);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/club/service/query/ClubQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubQueryServiceImpl.java
@@ -115,15 +115,15 @@ public class ClubQueryServiceImpl implements ClubQueryService {
 
         if (clubMemberStatus == null) {
             if (cursorId == null) {
-                return clubMemberRepository.findByClubIdOrderByIdDesc(clubId, pageable);
+                return clubMemberRepository.findAllByClubIdOrderByIdDesc(clubId, pageable);
             } else {
-                return clubMemberRepository.findByClubIdAndIdLessThanOrderByIdDesc(clubId, cursorId, pageable);
+                return clubMemberRepository.findAllByClubIdAndIdLessThanOrderByIdDesc(clubId, cursorId, pageable);
             }
         } else {
             if (cursorId == null) {
-                return clubMemberRepository.findByClubIdAndClubMemberStatusOrderByIdDesc(clubId, clubMemberStatus, pageable);
+                return clubMemberRepository.findAllByClubIdAndClubMemberStatusOrderByIdDesc(clubId, clubMemberStatus, pageable);
             } else {
-                return clubMemberRepository.findByClubIdAndClubMemberStatusAndIdLessThanOrderByIdDesc(clubId, clubMemberStatus, cursorId, pageable);
+                return clubMemberRepository.findAllByClubIdAndClubMemberStatusAndIdLessThanOrderByIdDesc(clubId, clubMemberStatus, cursorId, pageable);
             }
         }
 

--- a/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
@@ -93,7 +93,24 @@ public class ClubMeetingController {
         MeetingResponseDTO.MeetingListDTO meetings = clubQueryFacade.getMeetingsByClub(clubId, cursorId, size, memberId);
         return ApiResponse.onSuccess(meetings);
     }
-    // GET /api/meetings/{meetingId} - Meeting 상세 보기
+
+    @Operation(summary = "정기 독서모임 상세 조회 API", description = "정기 독서모임의 상세 정보를 조회합니다.")
+    @Parameters({
+            @Parameter(name = "meetingId", description = "정기 독서 모임 ID", required = true, example = "1"),
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 모임의 회원이 아닙니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 정기 독서모임을 찾을 수 없습니다."),
+    })
+    @GetMapping("/api/meetings/{meetingId}")
+    public ApiResponse<MeetingResponseDTO.MeetingDetailDTO> getMeetingDetail(
+            @PathVariable Long meetingId,
+            @CurrentId String memberId
+    ) {
+        MeetingResponseDTO.MeetingDetailDTO meetingDetail = clubQueryFacade.findMeetingDetailById(meetingId, memberId);
+        return ApiResponse.onSuccess(meetingDetail);
+    }
 
     @Operation(summary = "독서모임 캘린더 조회 API", description = "독서모임의 모임 캘린더를 조회합니다.")
     @Parameters({


### PR DESCRIPTION
## 🚀 변경사항
<!-- 뭘 구현했는지/수정했는지 간단히 -->
- 독서모임 상세조회 기능

## 🔗 관련 이슈
- Closes #83 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added meeting detail API: GET /api/meetings/{meetingId} returning meeting info, book, topics (with authors) and team-topic selections.
* **Improvements**
  * More consistent cursor-based pagination across meetings, topics and team topics for smoother scrolling and accurate next-cursors.
  * Topics and team-topic listings now include member-aware context and per-team selections.
* **Documentation**
  * OpenAPI docs added for the meeting detail endpoint.
* **Refactor**
  * Backend data assembly streamlined to deliver richer, combined meeting/topic/team views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->