### PR TITLE
✨ [FEAT] 모임 공지사항 상세조회 API

### DIFF
--- a/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/checkmo/apiPayload/code/status/ErrorStatus.java
@@ -41,6 +41,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 공지사항
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE_4004", "공지사항을 찾을 수 없습니다."),
+    NOTICE_MEETING_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTICE_4005", "모임 공지사항은 삭제할 수 없습니다."),
 
     // 투표
     VOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "VOTE_4004", "투표를 찾을 수 없습니다."),

--- a/src/main/java/checkmo/domain/club/entity/announcement/Notice.java
+++ b/src/main/java/checkmo/domain/club/entity/announcement/Notice.java
@@ -23,6 +23,7 @@ public class Notice extends BaseEntity {
 
     private boolean important;
 
+    @Column(nullable = false)
     private String tag; //TODO: "공지", "모임" 2개 값만 가능
 
     @Column(name = "meeting_id", insertable = false, updatable = false)
@@ -39,5 +40,5 @@ public class Notice extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id")
     private Club club;
-    
+
 }

--- a/src/main/java/checkmo/domain/club/repository/announcement/NoticeRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/announcement/NoticeRepository.java
@@ -1,5 +1,6 @@
 package checkmo.domain.club.repository.announcement;
 
+import checkmo.domain.club.entity.Club;
 import checkmo.domain.club.entity.announcement.Notice;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
@@ -39,4 +41,10 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     );
 
 
+    List<Notice> club(Club club);
+
+    Optional<Notice> findByIdAndClubId(Long id, Long clubId);
+
+    @Query("SELECT n FROM Notice n JOIN FETCH n.meeting m WHERE n.id = :id AND n.club.id = :clubId")
+    Optional<Notice> findWithMeetingByIdAndClubId(Long id, Long clubId);
 }

--- a/src/main/java/checkmo/domain/club/repository/announcement/VoteRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/announcement/VoteRepository.java
@@ -1,22 +1,23 @@
 package checkmo.domain.club.repository.announcement;
 
 import checkmo.domain.club.entity.announcement.Vote;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
     @Query("""
-        SELECT v FROM Vote v
-        WHERE v.club.id = :clubId
-          AND (:onlyImportant = false OR v.important = true)
-          AND (:cursorId IS NULL OR v.id < :cursorId)
-        ORDER BY v.createdAt DESC
-        """)
+            SELECT v FROM Vote v
+            WHERE v.club.id = :clubId
+              AND (:onlyImportant = false OR v.important = true)
+              AND (:cursorId IS NULL OR v.id < :cursorId)
+            ORDER BY v.createdAt DESC
+            """)
     List<Vote> findByClubIdAndCursorPaging(
             @Param("clubId") Long clubId,
             @Param("onlyImportant") boolean onlyImportant,
@@ -25,12 +26,12 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
     );
 
     @Query("""
-        SELECT v FROM Vote v 
-        WHERE v.club.id IN :clubIds
-          AND (:onlyImportant = false OR v.important = true)
-          AND (:cursorId IS NULL OR v.id < :cursorId)
-        ORDER BY v.createdAt DESC
-        """)
+            SELECT v FROM Vote v 
+            WHERE v.club.id IN :clubIds
+              AND (:onlyImportant = false OR v.important = true)
+              AND (:cursorId IS NULL OR v.id < :cursorId)
+            ORDER BY v.createdAt DESC
+            """)
     List<Vote> findByClubIdsAndCursorPaging(
             @Param("clubIds") List<Long> clubIds,
             @Param("onlyImportant") boolean onlyImportant,
@@ -38,4 +39,5 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
             Pageable pageable
     );
 
+    Optional<Vote> findByIdAndClubId(Long id, Long clubId);
 }

--- a/src/main/java/checkmo/domain/club/service/command/ClubCommunicationCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubCommunicationCommandServiceImpl.java
@@ -62,7 +62,7 @@ public class ClubCommunicationCommandServiceImpl implements ClubCommunicationCom
     /**
      * 독서 모임의 공지사항을 삭제합니다.
      *
-     * @param clubId   독서 모임 ID
+     * @param clubId 독서 모임 ID
      * @param memberId 운영진 ID -> 운영진인지 확인하는 로직 필요 ClubMember에서 Role 확인 -> 어노테이션으로 처리 고려
      * @param noticeId 삭제할 공지사항 ID
      */
@@ -80,7 +80,12 @@ public class ClubCommunicationCommandServiceImpl implements ClubCommunicationCom
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOTICE_NOT_FOUND));
 
-        // 3. 삭제
+        // 3. 공지사항의 태그가 "모임"인 경우 예외 처리(모임 공지사항은 삭제할 수 없음)
+        if ("모임".equals(notice.getTag())) {
+            throw new GeneralException(ErrorStatus.NOTICE_MEETING_DELETE_FORBIDDEN);
+        }
+
+        // 4. 삭제
         noticeRepository.delete(notice);
     }
 

--- a/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryServiceImpl.java
@@ -56,9 +56,9 @@ public class ClubCommunicationQueryServiceImpl implements ClubCommunicationQuery
 
         return switch (tag) {
             case "공지" -> {
-                Notice notice = noticeRepository.findById(itemId)
+                Notice notice = noticeRepository.findByIdAndClubId(itemId, clubId)
                         .orElseThrow(() -> new GeneralException(ErrorStatus.NOTICE_NOT_FOUND));
-                if (notice.getTag().equals("모임")) {
+                if ("모임".equals(notice.getTag())) {
                     throw new GeneralException(ErrorStatus.NOTICE_NOT_FOUND);
                 }
 
@@ -68,9 +68,9 @@ public class ClubCommunicationQueryServiceImpl implements ClubCommunicationQuery
                         .build();
             }
             case "모임" -> {
-                Notice notice = noticeRepository.findById(itemId)
+                Notice notice = noticeRepository.findWithMeetingByIdAndClubId(itemId, clubId)
                         .orElseThrow(() -> new GeneralException(ErrorStatus.NOTICE_NOT_FOUND));
-                if (notice.getTag().equals("공지")) {
+                if ("공지".equals(notice.getTag())) {
                     throw new GeneralException(ErrorStatus.NOTICE_NOT_FOUND);
                 }
 
@@ -82,7 +82,7 @@ public class ClubCommunicationQueryServiceImpl implements ClubCommunicationQuery
                         .build();
             }
             case "투표" -> {
-                Vote vote = voteRepository.findById(itemId)
+                Vote vote = voteRepository.findByIdAndClubId(itemId, clubId)
                         .orElseThrow(() -> new GeneralException(ErrorStatus.VOTE_NOT_FOUND));
 
                 List<String> voteItems = vote.getItems();

--- a/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryServiceImpl.java
@@ -20,10 +20,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -44,7 +44,7 @@ public class ClubCommunicationQueryServiceImpl implements ClubCommunicationQuery
      *
      * @param clubId 클럽 ID
      * @param itemId 공지 또는 투표 ID
-     * @param tag    "공지", "모임", "투표" 중 하나
+     * @param tag "공지", "모임", "투표" 중 하나
      * @return 공통된 NoticeItem DTO
      */
     @Override
@@ -58,6 +58,9 @@ public class ClubCommunicationQueryServiceImpl implements ClubCommunicationQuery
             case "공지" -> {
                 Notice notice = noticeRepository.findById(itemId)
                         .orElseThrow(() -> new GeneralException(ErrorStatus.NOTICE_NOT_FOUND));
+                if (notice.getTag().equals("모임")) {
+                    throw new GeneralException(ErrorStatus.NOTICE_NOT_FOUND);
+                }
 
                 yield ClubResponseDTO.ClubNoticeDetailDTO.builder()
                         .isStaff(clubMember.isStaff())

--- a/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubCommunicationQueryServiceImpl.java
@@ -67,7 +67,20 @@ public class ClubCommunicationQueryServiceImpl implements ClubCommunicationQuery
                         .noticeItem(ClubConverter.toPureNoticeDTO(notice))
                         .build();
             }
+            case "모임" -> {
+                Notice notice = noticeRepository.findById(itemId)
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.NOTICE_NOT_FOUND));
+                if (notice.getTag().equals("공지")) {
+                    throw new GeneralException(ErrorStatus.NOTICE_NOT_FOUND);
+                }
 
+                BookSharedDTO.BasicInfoDTO bookInfo = bookQueryFacade.getBookBasicInfoForShare(notice.getMeeting().getBookId());
+
+                yield ClubResponseDTO.ClubNoticeDetailDTO.builder()
+                        .isStaff(clubMember.isStaff())
+                        .noticeItem(ClubConverter.toMeetingNoticeDTO(notice, bookInfo))
+                        .build();
+            }
             case "투표" -> {
                 Vote vote = voteRepository.findById(itemId)
                         .orElseThrow(() -> new GeneralException(ErrorStatus.VOTE_NOT_FOUND));

--- a/src/main/java/checkmo/domain/club/web/controller/ClubNoticeController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubNoticeController.java
@@ -7,6 +7,8 @@ import checkmo.domain.club.web.dto.club.ClubRequestDTO;
 import checkmo.domain.club.web.dto.club.ClubResponseDTO;
 import checkmo.global.auth.CurrentId;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -81,6 +83,26 @@ public class ClubNoticeController {
     ) {
         clubCommandFacade.deleteNotice(clubId, memberId, noticeId);
         return ApiResponse.onSuccess("공지사항이 삭제되었습니다.");
+    }
+
+    @Operation(summary = "모임 공지사항 상세 조회", description = "특정 모임 공지사항 상세 정보를 조회합니다.")
+    @Parameters({
+            @Parameter(name = "clubId", description = "클럽 ID", required = true, example = "1"),
+            @Parameter(name = "noticeId", description = "모임 공지사항 ID", required = true, example = "1"),
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "모임 멤버가 아님"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "공지사항을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "모임을 찾을 수 없음"),
+    })
+    @GetMapping("/meeting/{noticeId}")
+    public ApiResponse<ClubResponseDTO.ClubNoticeDetailDTO> getMeetingDetail(
+            @PathVariable Long clubId,
+            @PathVariable Long noticeId,
+            @CurrentId String memberId
+    ) {
+        return ApiResponse.onSuccess(clubQueryFacade.getNoticeDetail(clubId, noticeId, "모임", memberId));
     }
 
     @Operation(summary = "투표 생성", description = "특정 모임에 투표를 생성합니다. (운영진만 생성 가능)")

--- a/src/main/java/checkmo/domain/club/web/controller/ClubNoticeController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubNoticeController.java
@@ -38,7 +38,7 @@ public class ClubNoticeController {
         return ApiResponse.onSuccess(clubQueryFacade.getLatestNotices(clubId, memberId, cursorId, onlyImportant, size));
     }
 
-    @Operation(summary = "공지사항 작성", description = "특정 모임에 공지사항을 작성합니다. (운영진만 작성 가능)")
+    @Operation(summary = "순수 공지사항 작성", description = "특정 모임에 순수 공지사항을 작성합니다. (운영진만 작성 가능)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "운영진만 작성 가능"),
@@ -51,6 +51,36 @@ public class ClubNoticeController {
             @RequestBody @Valid ClubRequestDTO.CreateClubNoticeDTO request
     ) {
         return ApiResponse.onSuccess(clubCommandFacade.createNotice(clubId, memberId, request));
+    }
+
+    @Operation(summary = "순수 공지사항 상세 조회", description = "특정 순수 공지사항 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "공지사항을 찾을 수 없음")
+    })
+    @GetMapping("/{noticeId}")
+    public ApiResponse<ClubResponseDTO.ClubNoticeDetailDTO> getNoticeDetail(
+            @PathVariable Long clubId,
+            @PathVariable Long noticeId,
+            @CurrentId String memberId
+    ) {
+        return ApiResponse.onSuccess(clubQueryFacade.getNoticeDetail(clubId, noticeId, "공지", memberId));
+    }
+
+    @Operation(summary = "순수 공지사항 삭제", description = "순수 공지사항을 삭제합니다. (운영진만 삭제 가능)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "운영진만 삭제 가능"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "공지사항을 찾을 수 없음")
+    })
+    @DeleteMapping("/{noticeId}")
+    public ApiResponse<String> deleteNotice(
+            @PathVariable Long clubId,
+            @PathVariable Long noticeId,
+            @CurrentId String memberId
+    ) {
+        clubCommandFacade.deleteNotice(clubId, memberId, noticeId);
+        return ApiResponse.onSuccess("공지사항이 삭제되었습니다.");
     }
 
     @Operation(summary = "투표 생성", description = "특정 모임에 투표를 생성합니다. (운영진만 생성 가능)")
@@ -66,20 +96,6 @@ public class ClubNoticeController {
             @RequestBody @Valid ClubRequestDTO.CreateClubVoteDTO request
     ) {
         return ApiResponse.onSuccess(clubCommandFacade.createVote(clubId, memberId, request));
-    }
-
-    @Operation(summary = "공지사항 상세 조회", description = "특정 공지사항 상세 정보를 조회합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "공지사항을 찾을 수 없음")
-    })
-    @GetMapping("/{noticeId}")
-    public ApiResponse<ClubResponseDTO.ClubNoticeDetailDTO> getNoticeDetail(
-            @PathVariable Long clubId,
-            @PathVariable Long noticeId,
-            @CurrentId String memberId
-    ) {
-        return ApiResponse.onSuccess(clubQueryFacade.getNoticeDetail(clubId, noticeId, "공지", memberId));
     }
 
     @Operation(summary = "투표 상세 조회", description = "특정 투표의 상세 정보를 조회합니다.")
@@ -110,22 +126,6 @@ public class ClubNoticeController {
             @RequestBody @Valid ClubRequestDTO.VoteResultDTO request
     ) {
         return ApiResponse.onSuccess(clubCommandFacade.participateInPoll(clubId, memberId, voteId, request));
-    }
-
-    @Operation(summary = "공지사항 삭제", description = "특정 공지사항을 삭제합니다. (운영진만 삭제 가능)")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "운영진만 삭제 가능"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "공지사항을 찾을 수 없음")
-    })
-    @DeleteMapping("/{noticeId}")
-    public ApiResponse<String> deleteNotice(
-            @PathVariable Long clubId,
-            @PathVariable Long noticeId,
-            @CurrentId String memberId
-    ) {
-        clubCommandFacade.deleteNotice(clubId, memberId, noticeId);
-        return ApiResponse.onSuccess("공지사항이 삭제되었습니다.");
     }
 
     @Operation(summary = "투표 삭제", description = "특정 투표를 삭제합니다. (운영진만 삭제 가능)")


### PR DESCRIPTION
## 🚀 변경사항
- 기존 공지사항 상세 조회 API -> "공지" 공지사항만 조회하도록 수정
- 기존 공지사항 삭제 API -> "공지" 공지사항만 삭제하도록 수정(기능명세서 참고)
- New! 모임 공지사항 상세 조회 API

## 🔗 관련 이슈
- Closes #91 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added dedicated endpoints for single notice detail, meeting notice detail, notice deletion, and vote creation.
  - Meeting notice detail now includes related book information.

- Bug Fixes
  - Ensures correct notice-type handling: returns Not Found for mismatched tags.
  - Prevents deletion of meeting notices with a Forbidden response.

- Documentation
  - Improved API docs and operation/parameter descriptions for notice and meeting endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->