### PR TITLE
♻️ [REFACTOR] 클럽 관련 API에서 클럽 멤버 상태 응답 

### DIFF
--- a/src/main/java/checkmo/domain/club/converter/ClubConverter.java
+++ b/src/main/java/checkmo/domain/club/converter/ClubConverter.java
@@ -8,6 +8,7 @@ import checkmo.domain.club.entity.announcement.MemberVote;
 import checkmo.domain.club.entity.announcement.Notice;
 import checkmo.domain.club.entity.announcement.Vote;
 import checkmo.domain.club.entity.meeting.*;
+import checkmo.domain.club.web.dto.MembershipResponseDTO;
 import checkmo.domain.club.web.dto.bookshelf.BookShelfRequestDTO;
 import checkmo.domain.club.web.dto.bookshelf.BookShelfResponseDTO;
 import checkmo.domain.club.web.dto.club.ClubRequestDTO;
@@ -36,6 +37,17 @@ public class ClubConverter {
     // =====================================================
     // Entity ↔ DTO 변환
     // =====================================================
+
+    /**
+     * ClubMember 엔티티 -> MembershipResponseDTO.MembershipDTO 변환
+     */
+    public static MembershipResponseDTO.MembershipDTO fromClubMembertoMembershipDTO(ClubMember clubMember) {
+        return MembershipResponseDTO.MembershipDTO.builder()
+                .clubMemberId(clubMember.getId())
+                .clubMemberStatus(clubMember.getClubMemberStatus().name())
+                .updatedAt(clubMember.getUpdatedAt())
+                .build();
+    }
 
     /**
      * Club 리스트 → ClubResponseDTO.ClubListDTO 변환
@@ -557,12 +569,14 @@ public class ClubConverter {
     public static BookShelfResponseDTO.BookShelfDetailDTO fromBookShelfDTOToBookShelfDetailDTO(
             Meeting meeting,
             BookSharedDTO.DetailInfoDTO bookSharedDTO,
-            BookShelfResponseDTO.TopicListDTO topicListDTO
+            BookShelfResponseDTO.TopicListDTO topicListDTO,
+            MembershipResponseDTO.MembershipDTO membershipDTO
     ) {
         return BookShelfResponseDTO.BookShelfDetailDTO.builder()
                 .meetingInfo(fromMeetingToBookshelfMeetingInfoDTO(meeting))
                 .bookDetailInfo(bookSharedDTO)
                 .topicList(topicListDTO)
+                .membership(membershipDTO)
                 .build();
     }
 
@@ -588,12 +602,16 @@ public class ClubConverter {
     /**
      * List<Meeting> -> List<MeetingResponseDTO.MeetingInfoDTO> 변환
      */
-    public static List<MeetingResponseDTO.MeetingInfoDTO> fromMeetingListToMeetingInfoDTOList(
-            List<Meeting> meetings
+    public static MeetingResponseDTO.CalendarMeetingDTO fromMeetingListToMCalendarMeetingDTO(
+            List<Meeting> meetings,
+            MembershipResponseDTO.MembershipDTO membershipDTO
     ) {
-        return meetings.stream()
-                .map(meeting -> fromMeetingAndBookSharedDTOToMeetingInfoDTO(meeting, null))
-                .toList();
+        return MeetingResponseDTO.CalendarMeetingDTO.builder()
+                .meetingInfoList(meetings.stream()
+                        .map(meeting -> fromMeetingAndBookSharedDTOToMeetingInfoDTO(meeting, null))
+                        .toList())
+                .membership(membershipDTO)
+                .build();
     }
 
     /**
@@ -622,7 +640,8 @@ public class ClubConverter {
             Map<Long, List<Integer>> teamTopicsWithTeamByTopicIds,
             List<Team> teams,
             Map<Integer, List<TeamTopic>> teamTopicsGroupingByTeamNumber,
-            Map<String, MemberSharedDTO.BasicInfoDTO> authorInfoMap
+            Map<String, MemberSharedDTO.BasicInfoDTO> authorInfoMap,
+            MembershipResponseDTO.MembershipDTO membershipDTO
     ) {
         MeetingResponseDTO.MeetingInfoDTO meetingInfoDTO = ClubConverter.fromMeetingAndBookSharedDTOToMeetingInfoDTO(meeting, bookSharedDTO);
 
@@ -642,13 +661,14 @@ public class ClubConverter {
                             ))
                             .toList();
 
-                    return fromTopicDTOListToTeamTopicDTO(team.getTeamNumber(), teamTopicDTOs);
+                    return fromTopicDTOListToTeamTopicDTO(team.getTeamNumber(), teamTopicDTOs, null);
                 })
                 .toList();
         return fromMeetingInfoDTOAndTopicDTOListAndTeamTopicDTOListToTopicDTO(
                 meetingInfoDTO,
                 topicDTOList,
-                teamTopicDTOList
+                teamTopicDTOList,
+                membershipDTO
         );
     }
 
@@ -698,12 +718,14 @@ public class ClubConverter {
     public static BookShelfResponseDTO.BookReviewListDTO fromBookReviewDTOListToBookReviewListDTO(
             List<BookShelfResponseDTO.BookReviewDTO> bookReviewList,
             boolean hasNext,
-            Long nextCursor
+            Long nextCursor,
+            MembershipResponseDTO.MembershipDTO membershipDTO
     ) {
         return BookShelfResponseDTO.BookReviewListDTO.builder()
                 .bookReviewList(bookReviewList)
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
+                .membership(membershipDTO)
                 .build();
     }
 
@@ -713,12 +735,14 @@ public class ClubConverter {
     public static BookShelfResponseDTO.TopicListDTO fromTopicDTOListToTopicListDTOForBookshelf(
             List<BookShelfResponseDTO.TopicDTO> topicListDTOs,
             boolean hasNext,
-            Long nextCursor
+            Long nextCursor,
+            MembershipResponseDTO.MembershipDTO membershipDTO
     ) {
         return BookShelfResponseDTO.TopicListDTO.builder()
                 .topics(topicListDTOs)
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
+                .membership(membershipDTO)
                 .build();
     }
 
@@ -728,12 +752,14 @@ public class ClubConverter {
     public static BookShelfResponseDTO.BookShelfListDTO fromBookShelfInfoDTOListToBookShelfListDTO(
             List<BookShelfResponseDTO.BookShelfInfoDTO> bookShelfInfoDTOs,
             boolean hasNext,
-            Long nextCursor
+            Long nextCursor,
+            MembershipResponseDTO.MembershipDTO membershipDTO
     ) {
         return BookShelfResponseDTO.BookShelfListDTO.builder()
                 .bookShelfInfoList(bookShelfInfoDTOs)
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
+                .membership(membershipDTO)
                 .build();
     }
 
@@ -754,12 +780,14 @@ public class ClubConverter {
     public static MeetingResponseDTO.MeetingListDTO fromMeetingInfoDTOListToMeetingListDTO(
             List<MeetingResponseDTO.MeetingInfoDTO> meetingInfoDTOList,
             boolean hasNext,
-            Long nextCursor
+            Long nextCursor,
+            MembershipResponseDTO.MembershipDTO membershipDTO
     ) {
         return MeetingResponseDTO.MeetingListDTO.builder()
                 .meetingInfoList(meetingInfoDTOList)
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
+                .membership(membershipDTO)
                 .build();
     }
 
@@ -781,10 +809,15 @@ public class ClubConverter {
     /**
      * List<MeetingResponseDTO.TopicDTO> -> MeetingResponseDTO.TeamTopicDTO 변환
      */
-    public static MeetingResponseDTO.TeamTopicDTO fromTopicDTOListToTeamTopicDTO(Integer teamNumber, List<MeetingResponseDTO.TopicDTO> topicList) {
+    public static MeetingResponseDTO.TeamTopicDTO fromTopicDTOListToTeamTopicDTO(
+            Integer teamNumber,
+            List<MeetingResponseDTO.TopicDTO> topicList,
+            MembershipResponseDTO.MembershipDTO membershipDTO
+    ) {
         return MeetingResponseDTO.TeamTopicDTO.builder()
                 .teamNumber(teamNumber)
                 .topics(topicList)
+                .membership(membershipDTO)
                 .build();
     }
 
@@ -794,12 +827,24 @@ public class ClubConverter {
     public static MeetingResponseDTO.MeetingDetailDTO fromMeetingInfoDTOAndTopicDTOListAndTeamTopicDTOListToTopicDTO(
             MeetingResponseDTO.MeetingInfoDTO meetingInfoDTO,
             List<MeetingResponseDTO.TopicDTO> topicDTOList,
-            List<MeetingResponseDTO.TeamTopicDTO> teamTopicDTOList
+            List<MeetingResponseDTO.TeamTopicDTO> teamTopicDTOList,
+            MembershipResponseDTO.MembershipDTO membershipDTO
     ) {
         return MeetingResponseDTO.MeetingDetailDTO.builder()
                 .meetingInfo(meetingInfoDTO)
                 .topics(topicDTOList)
                 .teams(teamTopicDTOList)
+                .membership(membershipDTO)
+                .build();
+    }
+
+    public static MeetingResponseDTO.TopicDTOList fromTopicDTOListAndMembershipDTOToTopicListDTO(
+            List<MeetingResponseDTO.TopicDTO> topicDTOs,
+            MembershipResponseDTO.MembershipDTO membershipDTO
+    ) {
+        return MeetingResponseDTO.TopicDTOList.builder()
+                .topics(topicDTOs)
+                .membership(membershipDTO)
                 .build();
     }
 

--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacade.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacade.java
@@ -217,7 +217,7 @@ public interface ClubQueryFacade {
      * @param memberId 요청자 회원 ID
      * @return 미팅 발제 목록 DTO
      */
-    List<MeetingResponseDTO.TopicDTO> findMeetingTopicsWithTeam(Long meetingId, String memberId);
+    MeetingResponseDTO.TopicDTOList findMeetingTopicsWithTeam(Long meetingId, String memberId);
 
     /**
      * ClubMeetingQueryService
@@ -262,7 +262,7 @@ public interface ClubQueryFacade {
      * @param memberId 요청자 회원 ID
      * @return 미팅 리스트 DTO
      */
-    List<MeetingResponseDTO.MeetingInfoDTO> getClubMeetingCalendar(Long clubId, int year, int month, String memberId);
+    MeetingResponseDTO.CalendarMeetingDTO getClubMeetingCalendar(Long clubId, int year, int month, String memberId);
 
     /**
      * 다른 도메인에서 관계 설정을 위해 엔티티의 프록시(참조)를 조회합니다. (외부용)

--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
@@ -7,6 +7,7 @@ import checkmo.domain.club.entity.ClubMember;
 import checkmo.domain.club.entity.meeting.*;
 import checkmo.domain.club.repository.ClubRepository;
 import checkmo.domain.club.service.query.*;
+import checkmo.domain.club.web.dto.MembershipResponseDTO;
 import checkmo.domain.club.web.dto.bookshelf.BookShelfResponseDTO;
 import checkmo.domain.club.web.dto.club.ClubResponseDTO;
 import checkmo.domain.club.web.dto.meeting.MeetingResponseDTO;
@@ -334,6 +335,9 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
 
     @Override
     public BookShelfResponseDTO.BookShelfListDTO getBookShelfList(Long clubId, Long cursorId, Integer size, Integer generation, String memberId) {
+        clubQueryService.validateClub(clubId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
+
         List<Meeting> meetings = clubMeetingQueryService.getBookShelfList(clubId, generation, cursorId, size + 1, memberId);
         boolean hasNext = meetings.size() > size;
         if (hasNext) {
@@ -350,7 +354,8 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
                 )
                 .toList();
 
-        return ClubConverter.fromBookShelfInfoDTOListToBookShelfListDTO(bookShelfInfoDTOS, hasNext, nextCursor);
+        MembershipResponseDTO.MembershipDTO membershipDTO = ClubConverter.fromClubMembertoMembershipDTO(clubMember);
+        return ClubConverter.fromBookShelfInfoDTOListToBookShelfListDTO(bookShelfInfoDTOS, hasNext, nextCursor, membershipDTO);
     }
 
     @Override
@@ -359,7 +364,7 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
         final Integer TOPIC_SIZE = 3;
 
         Meeting meeting = clubMeetingQueryService.validateMeeting(meetingId);
-        clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
 
         List<Topic> topics = clubMeetingQueryService.findTopicsWithClubMemberByMeeting(meetingId, null, TOPIC_SIZE + 1);
 
@@ -377,17 +382,19 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
                 ))
                 .toList();
 
+        MembershipResponseDTO.MembershipDTO membershipDTO = ClubConverter.fromClubMembertoMembershipDTO(clubMember);
         return ClubConverter.fromBookShelfDTOToBookShelfDetailDTO(
                 meeting,
                 bookQueryFacade.getBookDetailInfoForShare(meeting.getBookId()),
-                ClubConverter.fromTopicDTOListToTopicListDTOForBookshelf(topicListDTOs, hasNext, nextCursor)
+                ClubConverter.fromTopicDTOListToTopicListDTOForBookshelf(topicListDTOs, hasNext, nextCursor, null),
+                membershipDTO
         );
     }
 
     @Override
     public BookShelfResponseDTO.TopicListDTO findTopicsByMeeting(Long meetingId, Long cursorId, Integer size, String memberId) {
         Meeting meeting = clubMeetingQueryService.validateMeeting(meetingId);
-        clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
 
         List<Topic> topics = clubMeetingQueryService.findTopicsWithClubMemberByMeeting(meetingId, cursorId, size + 1);
 
@@ -413,13 +420,14 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
                 ))
                 .toList();
 
-        return ClubConverter.fromTopicDTOListToTopicListDTOForBookshelf(topicListDTOs, hasNext, nextCursor);
+        MembershipResponseDTO.MembershipDTO membershipDTO = ClubConverter.fromClubMembertoMembershipDTO(clubMember);
+        return ClubConverter.fromTopicDTOListToTopicListDTOForBookshelf(topicListDTOs, hasNext, nextCursor, membershipDTO);
     }
 
     @Override
     public BookShelfResponseDTO.BookReviewListDTO getBookReviewList(Long meetingId, Long lastReviewId, int size, String memberId) {
         Meeting meeting = clubMeetingQueryService.validateMeeting(meetingId);
-        clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
 
         List<BookReview> bookReviews = clubMeetingQueryService.findBookReviewsByMeeting(meetingId, lastReviewId, size);
 
@@ -436,13 +444,14 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
                 ))
                 .toList();
 
-        return ClubConverter.fromBookReviewDTOListToBookReviewListDTO(bookReviewDTOs, hasNext, nextCursor);
+        MembershipResponseDTO.MembershipDTO membershipDTO = ClubConverter.fromClubMembertoMembershipDTO(clubMember);
+        return ClubConverter.fromBookReviewDTOListToBookReviewListDTO(bookReviewDTOs, hasNext, nextCursor, membershipDTO);
     }
 
     @Override
     public MeetingResponseDTO.MeetingListDTO getMeetingsByClub(Long clubId, Long cursorId, Integer size, String memberId) {
         clubQueryService.validateClub(clubId);
-        clubMemberQueryService.validateClubMember(clubId, memberId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
 
         List<Meeting> meetings = clubMeetingQueryService.findMeetingsByClubAndCursor(clubId, cursorId, size + 1);
         boolean hasNext = meetings.size() > size;
@@ -457,14 +466,16 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
                         bookQueryFacade.getBookBasicInfoForShare(meeting.getBookId())
                 ))
                 .toList();
-        return ClubConverter.fromMeetingInfoDTOListToMeetingListDTO(meetingInfoDTOList, hasNext, nextCursor);
+
+        MembershipResponseDTO.MembershipDTO membershipDTO = ClubConverter.fromClubMembertoMembershipDTO(clubMember);
+        return ClubConverter.fromMeetingInfoDTOListToMeetingListDTO(meetingInfoDTOList, hasNext, nextCursor, membershipDTO);
     }
 
     @Override
     public MeetingResponseDTO.MeetingDetailDTO findMeetingDetailById(Long meetingId, String memberId) {
         // 1. 미팅과 클럽 멤버 검증
         Meeting meeting = clubMeetingQueryService.validateMeeting(meetingId);
-        clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
 
         // 2. [발제 전체보기 - 미리보기] 발제 최신순 상위 4개 토픽 리스트 조회
         List<Topic> topics = clubMeetingQueryService.findTopicsWithClubMemberByMeeting(meetingId, null, 4);
@@ -500,20 +511,23 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
         Map<String, MemberSharedDTO.BasicInfoDTO> authorInfoMap =
                 memberQueryFacade.getMemberBasicInfoMapForShare(authorIds);
 
+        MembershipResponseDTO.MembershipDTO membershipDTO = ClubConverter.fromClubMembertoMembershipDTO(clubMember);
+
         // 7. DTO 변환
         return ClubConverter.fromMeetingAndBookSharedDTOEtcToMeetingDetailDTO(
                 meeting, bookQueryFacade.getBookBasicInfoForShare(meeting.getBookId()), // -> MeetingInfoDTO
                 topics, teamTopicsWithTeamByTopicIds, // -> List<TopicDTO>
                 teams, teamTopicsGroupingByTeamNumber, // -> List<TeamTopicDTO>
-                authorInfoMap // -> List<TopicDTO>, List<TeamTopicDTO> 작성자 정보
+                authorInfoMap, // -> List<TopicDTO>, List<TeamTopicDTO> 작성자 정보
+                membershipDTO // -> MembershipDTO
         );
     }
 
     @Override
-    public List<MeetingResponseDTO.TopicDTO> findMeetingTopicsWithTeam(Long meetingId, String memberId) {
+    public MeetingResponseDTO.TopicDTOList findMeetingTopicsWithTeam(Long meetingId, String memberId) {
         // 1. 미팅과 클럽 멤버 검증
         Meeting meeting = clubMeetingQueryService.validateMeeting(meetingId);
-        clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
 
         // 2. 토픽 리스트 조회
         List<Topic> topics = clubMeetingQueryService.findTopicsWithClubMemberByMeeting(meetingId, null, null);
@@ -532,18 +546,25 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
                 .toList();
         Map<Long, List<Integer>> teamTopicsWithTeamByTopicIds = clubMeetingQueryService.findTeamTopicsWithTeamByTopicIds(topicIds);
 
+        MembershipResponseDTO.MembershipDTO membershipDTO = ClubConverter.fromClubMembertoMembershipDTO(clubMember);
+
         // 5. MeetingResponseDTO.TopicListDTO 변환
-        return ClubConverter.fromTopicListAndTopicSelectionAndMemberSharedDTOToTopicDTOList(
+        List<MeetingResponseDTO.TopicDTO> topicDTOList = ClubConverter.fromTopicListAndTopicSelectionAndMemberSharedDTOToTopicDTOList(
                 topics,
                 authorInfoMap,
                 teamTopicsWithTeamByTopicIds
+        );
+
+        return ClubConverter.fromTopicDTOListAndMembershipDTOToTopicListDTO(
+                topicDTOList,
+                membershipDTO
         );
     }
 
     public MeetingResponseDTO.TeamTopicDTO findMeetingTopicsByTeam(Long meetingId, Integer teamNumber, String memberId) {
         // 1. 미팅과 클럽 멤버, 팀 검증
         Meeting meeting = clubMeetingQueryService.validateMeeting(meetingId);
-        clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(meeting.getClubId(), memberId);
         Team team = clubMeetingQueryService.validateTeam(meetingId, teamNumber);
 
         // 2. 팀 토픽 > 토픽 > 클럽 멤버 정보 전체 조회
@@ -568,11 +589,13 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
                 ))
                 .toList();
 
-        return ClubConverter.fromTopicDTOListToTeamTopicDTO(teamNumber, topicDTOList);
+        MembershipResponseDTO.MembershipDTO membershipDTO = ClubConverter.fromClubMembertoMembershipDTO(clubMember);
+
+        return ClubConverter.fromTopicDTOListToTeamTopicDTO(teamNumber, topicDTOList, membershipDTO);
     }
 
     @Override
-    public List<MeetingResponseDTO.MeetingInfoDTO> getClubMeetingCalendar(Long clubId, int year, int month, String memberId) {
+    public MeetingResponseDTO.CalendarMeetingDTO getClubMeetingCalendar(Long clubId, int year, int month, String memberId) {
         return clubMeetingQueryService.getClubMeetingByYearAndMonth(clubId, year, month, memberId);
     }
 

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryService.java
@@ -79,7 +79,7 @@ public interface ClubMeetingQueryService {
      * @param memberId 요청자 회원 ID
      * @return 독서모임의 모임 정보 리스트
      */
-    List<MeetingResponseDTO.MeetingInfoDTO> getClubMeetingByYearAndMonth(Long clubId, int year, int month, String memberId);
+    MeetingResponseDTO.CalendarMeetingDTO getClubMeetingByYearAndMonth(Long clubId, int year, int month, String memberId);
 
     /**
      * 모임을 책장 리스트로 조회

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
@@ -4,8 +4,10 @@ import checkmo.apiPayload.code.status.ErrorStatus;
 import checkmo.apiPayload.exception.GeneralException;
 import checkmo.domain.club.converter.ClubConverter;
 import checkmo.domain.club.entity.Club;
+import checkmo.domain.club.entity.ClubMember;
 import checkmo.domain.club.entity.meeting.*;
 import checkmo.domain.club.repository.meeting.*;
+import checkmo.domain.club.web.dto.MembershipResponseDTO;
 import checkmo.domain.club.web.dto.meeting.MeetingResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -67,23 +69,22 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
 
     @Override
     public List<Meeting> getBookShelfList(Long clubId, Integer generation, Long cursorId, Integer size, String memberId) {
-        clubQueryService.validateClub(clubId);
-        clubMemberQueryService.validateClubMember(clubId, memberId);
-
         return meetingRepository.findAllByClubIdAndGenerationAndCursorDesc(clubId, generation, cursorId, size);
     }
 
     @Override
-    public List<MeetingResponseDTO.MeetingInfoDTO> getClubMeetingByYearAndMonth(Long clubId, int year, int month, String memberId) {
+    public MeetingResponseDTO.CalendarMeetingDTO getClubMeetingByYearAndMonth(Long clubId, int year, int month, String memberId) {
         Club club = clubQueryService.validateClub(clubId);
-        clubMemberQueryService.validateClubMember(clubId, memberId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
 
         LocalDateTime startDateTime = LocalDateTime.of(year, month, 1, 0, 0, 0);
         LocalDateTime endDateTime = startDateTime.plusMonths(1); //12월의 경우 다음 해 1월로 넘어감
 
         List<Meeting> meetings = meetingRepository.findAllByClubIdBetweenMeetingTimeAsc(clubId, startDateTime, endDateTime);
 
-        return ClubConverter.fromMeetingListToMeetingInfoDTOList(meetings);
+        MembershipResponseDTO.MembershipDTO membershipDTO = ClubConverter.fromClubMembertoMembershipDTO(clubMember);
+
+        return ClubConverter.fromMeetingListToMCalendarMeetingDTO(meetings, membershipDTO);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubMeetingController.java
@@ -20,8 +20,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping()
 @RequiredArgsConstructor
@@ -124,7 +122,7 @@ public class ClubMeetingController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "독서클럽을 찾을 수 없습니다."),
     })
     @GetMapping("/api/clubs/{clubId}/calendar")
-    public ApiResponse<List<MeetingResponseDTO.MeetingInfoDTO>> getClubCalendar(
+    public ApiResponse<MeetingResponseDTO.CalendarMeetingDTO> getClubCalendar(
             @PathVariable Long clubId,
             @RequestParam @Min(2000) @Max(2050) int year,
             @RequestParam @Min(1) @Max(12) int month,
@@ -166,11 +164,11 @@ public class ClubMeetingController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 독서모임을 찾을 수 없습니다."),
     })
     @GetMapping("/api/meetings/{meetingId}/team-topics")
-    public ApiResponse<List<MeetingResponseDTO.TopicDTO>> getTopics(
+    public ApiResponse<MeetingResponseDTO.TopicDTOList> getTopics(
             @PathVariable Long meetingId,
             @CurrentId String memberId
     ) {
-        List<MeetingResponseDTO.TopicDTO> topics = clubQueryFacade.findMeetingTopicsWithTeam(meetingId, memberId);
+        MeetingResponseDTO.TopicDTOList topics = clubQueryFacade.findMeetingTopicsWithTeam(meetingId, memberId);
         return ApiResponse.onSuccess(topics);
     }
 

--- a/src/main/java/checkmo/domain/club/web/dto/MembershipResponseDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/MembershipResponseDTO.java
@@ -1,0 +1,20 @@
+package checkmo.domain.club.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class MembershipResponseDTO {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MembershipDTO {
+        private Long clubMemberId; // 모임 회원 ID
+        private String clubMemberStatus; // 모임 회원 상태
+        private LocalDateTime updatedAt; // 모임 회원 정보 수정 시간
+    }
+}

--- a/src/main/java/checkmo/domain/club/web/dto/bookshelf/BookShelfResponseDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/bookshelf/BookShelfResponseDTO.java
@@ -1,7 +1,9 @@
 package checkmo.domain.club.web.dto.bookshelf;
 
+import checkmo.domain.club.web.dto.MembershipResponseDTO;
 import checkmo.global.dto.BookSharedDTO;
 import checkmo.global.dto.MemberSharedDTO;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +19,7 @@ public class BookShelfResponseDTO {
     @Builder
     public static class BookShelfListDTO {
         List<BookShelfInfoDTO> bookShelfInfoList;
+        MembershipResponseDTO.MembershipDTO membership;
         private boolean hasNext; // 다음 페이지 존재 여부
         private Long nextCursor; // 다음 페이지 커서 (마지막 항목의 ID)
     }
@@ -46,6 +49,7 @@ public class BookShelfResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class BookShelfDetailDTO {
+        MembershipResponseDTO.MembershipDTO membership;
         private MeetingInfoDTO meetingInfo; // Meeting 기본 정보
         private BookSharedDTO.DetailInfoDTO bookDetailInfo; // 책 상세 정보 - 공용 DTO 사용
         private TopicListDTO topicList; // 발제 리스트(등록순 3개 미리보기)
@@ -57,6 +61,7 @@ public class BookShelfResponseDTO {
     @Builder
     public static class BookReviewListDTO {
         List<BookReviewDTO> bookReviewList; // 한줄평 리스트
+        MembershipResponseDTO.MembershipDTO membership;
         private boolean hasNext; // 다음 페이지 존재 여부
         private Long nextCursor; // 다음 페이지 커서 (마지막 항목의 ID)
     }
@@ -77,6 +82,8 @@ public class BookShelfResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class TopicListDTO {
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        MembershipResponseDTO.MembershipDTO membership;
         private List<TopicDTO> topics; // 토픽 목록
         private boolean hasNext; // 다음 페이지 존재 여부
         private Long nextCursor; // 다음 페이지 커서

--- a/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingResponseDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingResponseDTO.java
@@ -1,7 +1,9 @@
 package checkmo.domain.club.web.dto.meeting;
 
+import checkmo.domain.club.web.dto.MembershipResponseDTO;
 import checkmo.global.dto.BookSharedDTO;
 import checkmo.global.dto.MemberSharedDTO;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +22,7 @@ public class MeetingResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class MeetingDetailDTO {
+        MembershipResponseDTO.MembershipDTO membership;
         private MeetingInfoDTO meetingInfo;
         private List<TopicDTO> topics; // 모임의 토픽 목록 -> 발제 등록순 4개 담기
         private List<TeamTopicDTO> teams; // 모임의 팀 별 토픽 목록 -> 발제 등록순 4개 담기
@@ -30,6 +33,7 @@ public class MeetingResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class MeetingListDTO {
+        MembershipResponseDTO.MembershipDTO membership;
         private List<MeetingInfoDTO> meetingInfoList; // 모임 정보 목록
         private boolean hasNext; // 다음 페이지 존재 여부
         private Long nextCursor; // 다음 페이지 커서
@@ -50,8 +54,19 @@ public class MeetingResponseDTO {
         private String location; // 모임 장소
         private int generation; // 기수
         private String tag;
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         private String content; // 모임 내용, ClubNoticeDetailDTO-MeetingNoticeDTO-MeetingInfoDTO 에서만 이 필드에 값 넣고 나머지에선 다 NULL
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         private BookSharedDTO.BasicInfoDTO bookInfo; // 책 정보 - 공용 DTO 사용
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CalendarMeetingDTO {
+        List<MeetingResponseDTO.MeetingInfoDTO> meetingInfoList;
+        MembershipResponseDTO.MembershipDTO membership;
     }
 
     @Getter
@@ -72,6 +87,7 @@ public class MeetingResponseDTO {
         private Long topicId; // 토픽 ID
         private String content; // 토픽 내용
         private MemberSharedDTO.BasicInfoDTO authorInfo; // 작성자 정보
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         private List<Integer> teamNumbers; // 해당 토픽에 참여한 팀 번호 목록 | TeamTopicDTO-TopicDTO에서는 이 필드 NULL
     }
 
@@ -79,7 +95,18 @@ public class MeetingResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    public static class TopicDTOList {
+        List<MeetingResponseDTO.TopicDTO> topics;
+        MembershipResponseDTO.MembershipDTO membership;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     public static class TeamTopicDTO {
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        MembershipResponseDTO.MembershipDTO membership;
         private Integer teamNumber; // 팀 번호
         private List<TopicDTO> topics; // 해당 팀이 선택한 토픽 목록
     }


### PR DESCRIPTION
## 🚀 변경사항
<!-- 뭘 구현했는지/수정했는지 간단히 -->
- 책장, 미팅 관련 API에서 클럽 멤버 상태 응답 
- DTO 재사용에 따라 null일수도 있는 필드들 null이면 Json 포함 X

## 🔗 관련 이슈
- Closes #99 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Responses now include membership info across meetings, topics, and bookshelf data.
  - Calendar endpoint returns a single object combining meeting list and membership.
  - Topic endpoints return an object combining topics and membership.
  - Cleaner payloads with non-null-only fields in select properties.

- Refactor
  - Calendar and topic APIs return wrapper objects instead of raw lists.
  - Calendar requests now use the signed-in member context automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->