### PR TITLE
🐛  [BUG] 사용자는 하나의 미팅에 열리는 여러 팀에 속할 수 없다

### DIFF
--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -619,7 +620,7 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
         Map<String, MemberSharedDTO.BasicInfoDTO> memberBasicInfoMap = memberQueryFacade.getMemberBasicInfoMapForShare(memberIds);
 
         // 4. 미팅에 존재하는 모든 팀 조회
-        List<Team> teams = clubMeetingQueryService.findTeamsByMeeting(meetingId); // TODO: 독서모임 상세조회 PR에 존재하는데 충돌날지도?!
+        List<Team> teams = clubMeetingQueryService.findTeamsByMeeting(meetingId);
         List<Long> teamIds = extractTeamIds(teams);
         Map<Long, Integer> teamIdToTeamNumberMap = mapTeamIdToTeamNumberMap(teams);
 
@@ -650,14 +651,15 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
         if (memberIdToTeamIdMap == null || memberIdToTeamIdMap.isEmpty()) {
             return Map.of();
         }
-        return memberIdToTeamIdMap.entrySet().stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,                                        // key: memberId
-                        e -> {
-                            Long teamId = e.getValue();                           // value: 팀ID (nullable)
-                            return (teamId == null) ? null : teamIdToTeamNumberMap.get(teamId);
-                        }
-                ));
+        if (teamIdToTeamNumberMap == null || teamIdToTeamNumberMap.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Integer> memberIdToTeamNumber = new HashMap<>();
+        memberIdToTeamIdMap.forEach((memberId, teamId) -> {
+            Integer teamNumber = (teamId == null) ? null : teamIdToTeamNumberMap.get(teamId);
+            memberIdToTeamNumber.put(memberId, teamNumber);
+        });
+        return memberIdToTeamNumber;
     }
 
     private Map<Long, Integer> mapTeamIdToTeamNumberMap(List<Team> teams) {

--- a/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubMeetingCommandServiceImpl.java
@@ -200,21 +200,16 @@ public class ClubMeetingCommandServiceImpl implements ClubMeetingCommandService 
         }
 
         // 2. 요청 teamNumber와 nicknameList 검증 및 정리
-        Map<Integer, List<String>> requestTeamNumberToNicknameList = new HashMap<>();
-        Set<Integer> requestTeamNumbers = new HashSet<>();
-        Set<String> requestNicknames = new LinkedHashSet<>();
-
-        for (MeetingRequestDTO.TeamMemberDTO dto : request.getTeamMemberDTOList()) {
-            Integer num = dto.getTeamNumber();
-
-            if (!requestTeamNumbers.add(num)) { // 요청 teamNumber 중 teamNumber가 이미 존재하면 예외 발생
-                throw new GeneralException(ErrorStatus.TEAM_NUMBER_DUPLICATED_REQUEST, num.toString()); //TODO: 팀 넘버 포함 예외 메시지
-            }
-
-            List<String> names = new ArrayList<>(new LinkedHashSet<>(dto.getNicknameList())); // 닉네임 리스트의 중복 제거
-            requestTeamNumberToNicknameList.put(num, names);
-            requestNicknames.addAll(names);
-        }
+        Map<Integer, List<String>> requestTeamNumberToNicknameList =
+                request.getTeamMemberDTOList().stream()
+                        .collect(Collectors.toMap(
+                                MeetingRequestDTO.TeamMemberDTO::getTeamNumber,
+                                dto -> dto.getNicknameList().stream().distinct().toList()
+                        ));
+        Set<Integer> requestTeamNumbers = requestTeamNumberToNicknameList.keySet();
+        Set<String> requestNicknames = requestTeamNumberToNicknameList.values().stream()
+                .flatMap(List::stream)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         // 3. 해당 미팅의 기존 팀들 조회 후 teamNumber -> Team Map (TeamTopic이 유지되도록 Team은 유지)
         List<Team> existingTeams = teamRepository.findAllByMeetingIdOrderByTeamNumberAsc(meetingId);
@@ -222,25 +217,23 @@ public class ClubMeetingCommandServiceImpl implements ClubMeetingCommandService 
                 .collect(Collectors.toMap(Team::getTeamNumber, t -> t));
 
         // 4. 요청에 있는데 아직 없는 teamNumber는 Team 생성
-        for (Integer teamNumber : requestTeamNumbers) {
-            if (!existingTeamNumberToTeam.containsKey(teamNumber)) {
-                Team team = Team.builder()
-                        .teamNumber(teamNumber)
-                        .build();
-                meeting.addTeam(team);
-                existingTeams.add(team);
-                existingTeamNumberToTeam.put(teamNumber, team);
-            }
-        }
+        requestTeamNumbers.stream()
+                .filter(teamNumber -> !existingTeamNumberToTeam.containsKey(teamNumber))
+                .forEach(teamNumber -> {
+                    Team team = Team.builder()
+                            .teamNumber(teamNumber)
+                            .build();
+                    meeting.addTeam(team);
+                    existingTeams.add(team);
+                    existingTeamNumberToTeam.put(teamNumber, team);
+                });
 
         // 5. 요청에는 없는데 존재하는 teamNumber는 Team 삭제
         List<Team> toDeleteTeams = existingTeams.stream()
                 .filter(t -> !requestTeamNumbers.contains(t.getTeamNumber()))
                 .toList();
-
         // 미팅과의 양방향 연관 끊기 -> orphanRemoval이 true이므로 미팅이 flush될 때 Team도 삭제됨
         toDeleteTeams.forEach(meeting::removeTeam);
-
         // 기존 팀, 기존 teamNumber -> Team Map 메모리 컬렉션/맵 동기화
         existingTeams.removeAll(toDeleteTeams);
         existingTeamNumberToTeam.keySet().removeAll(toDeleteTeams.stream()

--- a/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMeetingQueryServiceImpl.java
@@ -109,6 +109,7 @@ public class ClubMeetingQueryServiceImpl implements ClubMeetingQueryService {
                 .collect(Collectors.toMap(
                         mt -> mt.getClubMember().getMemberId(), // key: 멤버 ID
                         MemberTeam::getTeamId // value: 팀 id
+                        // 하나의 멤버는 하나의 미팅의 여러 팀에 속할 수 없으므로 병합 조건 존재하지 않아도 됨
                 ));
     }
 

--- a/src/main/java/checkmo/domain/club/validation/validTeamManage/TeamManageValidator.java
+++ b/src/main/java/checkmo/domain/club/validation/validTeamManage/TeamManageValidator.java
@@ -22,6 +22,7 @@ public class TeamManageValidator implements ConstraintValidator<ValidTeamManage,
         if (teamMemberDTOList == null) return true; // @NotNull로 따로 처리
 
         boolean success = true;
+        context.disableDefaultConstraintViolation();
 
         Set<Integer> seenTeamNumbers = new HashSet<>(); // 팀 번호 중복 체크용
         Set<String> seenNicknames = new HashSet<>();
@@ -37,6 +38,14 @@ public class TeamManageValidator implements ConstraintValidator<ValidTeamManage,
                 addViolation(context,
                         String.format("요청 teamNumber'%d'가 중복되었습니다.", teamNum),
                         "teamMemberDTOList[" + i + "].teamNumber");
+                /*
+                // TODO: ConstraintViolationException의 PropertyPath를 포함해서 에러를 응답하도록 Handler 수정 필요
+                context.buildConstraintViolationWithTemplate(
+                            String.format("팀 번호 '%d'가 중복되었습니다.", teamNum))
+                    .addPropertyNode("teamMemberDTOList").inIterable().atIndex(i)
+                    .addPropertyNode("teamNumber")
+                    .addConstraintViolation();
+                */
             }
 
             List<String> nicknameList = dto.getNicknameList();
@@ -50,6 +59,13 @@ public class TeamManageValidator implements ConstraintValidator<ValidTeamManage,
                                 String.format("닉네임 '%s'이 여러 개 포함되었습니다.", nick),
                                 "teamMemberDTOList[" + i + "].nicknameList[" + j + "]"
                         );
+                        /*
+                        context.buildConstraintViolationWithTemplate(
+                                        String.format("닉네임 '%s'이 여러 개 포함되었습니다.", nick))
+                                .addPropertyNode("teamMemberDTOList").inIterable().atIndex(i)
+                                .addPropertyNode("nicknameList").inIterable().atIndex(j)
+                                .addConstraintViolation();
+                         */
                     }
                 }
             }

--- a/src/main/java/checkmo/domain/club/validation/validTeamManage/TeamManageValidator.java
+++ b/src/main/java/checkmo/domain/club/validation/validTeamManage/TeamManageValidator.java
@@ -1,0 +1,66 @@
+package checkmo.domain.club.validation.validTeamManage;
+
+import checkmo.domain.club.web.dto.meeting.MeetingRequestDTO;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class TeamManageValidator implements ConstraintValidator<ValidTeamManage, MeetingRequestDTO.TeamManageDTO> {
+    @Override
+    public void initialize(ValidTeamManage constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(MeetingRequestDTO.TeamManageDTO value, ConstraintValidatorContext context) {
+        if (value == null) return true; // @NotNull로 따로 처리
+
+        List<MeetingRequestDTO.TeamMemberDTO> teamMemberDTOList = value.getTeamMemberDTOList();
+        if (teamMemberDTOList == null) return true; // @NotNull로 따로 처리
+
+        boolean success = true;
+
+        Set<Integer> seenTeamNumbers = new HashSet<>(); // 팀 번호 중복 체크용
+        Set<String> seenNicknames = new HashSet<>();
+
+        for (int i = 0; i < teamMemberDTOList.size(); i++) {
+            MeetingRequestDTO.TeamMemberDTO dto = teamMemberDTOList.get(i);
+            if (dto == null) continue;
+
+            Integer teamNum = dto.getTeamNumber();
+
+            if (teamNum != null && !seenTeamNumbers.add(teamNum)) {
+                success = false;
+                addViolation(context,
+                        String.format("요청 teamNumber'%d'가 중복되었습니다.", teamNum),
+                        "teamMemberDTOList[" + i + "].teamNumber");
+            }
+
+            List<String> nicknameList = dto.getNicknameList();
+            if (nicknameList != null) {
+                for (int j = 0; j < nicknameList.size(); j++) {
+                    String nick = (nicknameList.get(j) == null) ? null : nicknameList.get(j).trim(); // 필드 레벨 @NotBlank/@Pattern로 1차 검증됨
+                    if (nick != null && !seenNicknames.add(nick)) {
+                        success = false;
+                        addViolation(
+                                context,
+                                String.format("닉네임 '%s'이 여러 개 포함되었습니다.", nick),
+                                "teamMemberDTOList[" + i + "].nicknameList[" + j + "]"
+                        );
+                    }
+                }
+            }
+        }
+        return success;
+    }
+
+    private void addViolation(ConstraintValidatorContext context, String message, String propertyPath) {
+        context.buildConstraintViolationWithTemplate(message)
+                .addPropertyNode(propertyPath)
+                .addConstraintViolation();
+    }
+}
+

--- a/src/main/java/checkmo/domain/club/validation/validTeamManage/ValidTeamManage.java
+++ b/src/main/java/checkmo/domain/club/validation/validTeamManage/ValidTeamManage.java
@@ -1,0 +1,18 @@
+package checkmo.domain.club.validation.validTeamManage;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = TeamManageValidator.class)
+public @interface ValidTeamManage {
+    String message() default "잘못된 팀 배정 요청입니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
@@ -1,11 +1,10 @@
 package checkmo.domain.club.web.dto.meeting;
 
+import checkmo.domain.club.validation.validTeamManage.ValidTeamManage;
 import checkmo.global.dto.BookSharedDTO;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -64,6 +63,7 @@ public class MeetingRequestDTO {
 
     @Getter
     @NoArgsConstructor
+    @ValidTeamManage
     public static class TeamManageDTO {
         @Valid
         @NotNull(message = "팀 멤버 정보는 null이 될 수 없습니다.")


### PR DESCRIPTION
## 🚀 변경사항
- 사용자는 하나의 미팅에 열리는 여러 팀에 속할 수 없다
- 팀 PUT API의 요청 DTO 중복값 검증 및 적용
- 서비스 레이어의 중복값 검증 코드 삭제
- Collectors.toMap()에 null을 넣음으로써 발생하는 NPE 문제 해결

## 🔗 관련 이슈
- Closes #103 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added class-level validation for team management requests to detect duplicate team numbers and duplicate nicknames with clear, field-specific error messages.
- Bug Fixes
  - Prevented potential errors when mapping members to team numbers if auxiliary data is missing, improving stability during team assignment.
- Refactor
  - Streamlined team management processing: deduplicates nicknames per team, derives requested team numbers from input, and simplifies creation/removal of teams while preserving behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->