### PR TITLE
✨ [Feat] 독서 클럽 상세 조회, 독서 클럽 업데이트

### DIFF
--- a/src/main/java/checkmo/domain/club/entity/Club.java
+++ b/src/main/java/checkmo/domain/club/entity/Club.java
@@ -3,6 +3,7 @@ package checkmo.domain.club.entity;
 import checkmo.domain.category.entity.ClubCategory;
 import checkmo.domain.club.entity.announcement.Vote;
 import checkmo.domain.club.entity.meeting.Meeting;
+import checkmo.domain.club.web.dto.club.ClubRequestDTO;
 import checkmo.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -86,6 +87,34 @@ public class Club extends BaseEntity {
     public void addClubMember(ClubMember clubMember) {
         this.clubMembers.add(clubMember);
         clubMember.setClub(this);
+    }
+
+    public void updateFromDetailDTO(ClubRequestDTO.ClubDetailDTO dto) {
+        if (dto.getName() != null) {
+            this.name = dto.getName();
+        }
+        if (dto.getDescription() != null) {
+            this.description = dto.getDescription();
+        }
+        if (dto.getProfileImageUrl() != null) {
+            this.profileImgUrl = dto.getProfileImageUrl();
+        }
+
+        // open 필드는 수정 불가 → 반영하지 않음
+
+        if (dto.getParticipantTypes() != null) {
+            this.participantTypes.clear();
+            this.participantTypes.addAll(dto.getParticipantTypes());
+        }
+        if (dto.getRegion() != null) {
+            this.region = dto.getRegion();
+        }
+        if (dto.getInsta() != null) {
+            this.insta = dto.getInsta();
+        }
+        if (dto.getKakao() != null) {
+            this.kakao = dto.getKakao();
+        }
     }
 
 }

--- a/src/main/java/checkmo/domain/club/facade/ClubCommandFacade.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubCommandFacade.java
@@ -24,6 +24,16 @@ public interface ClubCommandFacade {
     Long createClub(String memberId, ClubRequestDTO.ClubDetailDTO request); //
 
     /**
+     * ClubManagementCommandService
+     * 기존 독서 모임 정보를 수정합니다. (내부용)
+     *
+     * @param clubId   수정할 모임 ID
+     * @param memberId 수정 요청한 회원 ID
+     * @param request  모임 수정 요청 정보 DTO
+     */
+    void updateClub(Long clubId, String memberId, ClubRequestDTO.ClubDetailDTO request);
+
+    /**
      * ClubMembershipCommandService
      * 독서 모임에 가입을 신청합니다. (내부용)
      *

--- a/src/main/java/checkmo/domain/club/facade/ClubCommandFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubCommandFacadeImpl.java
@@ -43,6 +43,19 @@ public class ClubCommandFacadeImpl implements ClubCommandFacade {
     }
 
     /**
+     * ClubManagementCommandService
+     * 기존 독서 모임 정보를 수정합니다. (내부용)
+     *
+     * @param clubId   수정할 모임 ID
+     * @param memberId 수정 요청한 회원 ID
+     * @param request  모임 수정 요청 정보 DTO
+     */
+    @Override
+    public void updateClub(Long clubId, String memberId, ClubRequestDTO.ClubDetailDTO request) {
+        clubManagementCommandService.updateClub(clubId, memberId, request);
+    }
+
+    /**
      * ClubMembershipCommandService
      * 독서 모임에 가입을 신청합니다. (내부용)
      *

--- a/src/main/java/checkmo/domain/club/service/command/ClubManagementCommandService.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubManagementCommandService.java
@@ -18,4 +18,13 @@ public interface ClubManagementCommandService {
      */
     Long createClub(String memberId, ClubRequestDTO.ClubDetailDTO request);
 
+    /**
+     * ClubManagementCommandService
+     * 기존 독서 모임 정보를 수정합니다.
+     *
+     * @param clubId   수정할 모임 ID
+     * @param memberId 수정 요청한 회원 ID
+     * @param request  모임 수정 요청 정보 DTO
+     */
+    void updateClub(Long clubId, String memberId, ClubRequestDTO.ClubDetailDTO request);
 }

--- a/src/main/java/checkmo/domain/club/service/command/ClubManagementCommandServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/command/ClubManagementCommandServiceImpl.java
@@ -7,6 +7,7 @@ import checkmo.domain.club.converter.ClubConverter;
 import checkmo.domain.club.entity.Club;
 import checkmo.domain.club.entity.ClubMember;
 import checkmo.domain.club.repository.ClubRepository;
+import checkmo.domain.club.service.query.ClubMemberQueryService;
 import checkmo.domain.club.service.query.ClubQueryService;
 import checkmo.domain.club.web.dto.club.ClubRequestDTO;
 import checkmo.domain.member.entity.Member;
@@ -21,6 +22,7 @@ public class ClubManagementCommandServiceImpl implements ClubManagementCommandSe
 
     private final ClubRepository clubRepository;
     private final ClubQueryService clubQueryService;
+    private final ClubMemberQueryService clubMemberQueryService;
     private final MemberQueryFacade memberQueryFacade;
     private final CategoryCommandFacade categoryCommandFacade;
 
@@ -63,6 +65,43 @@ public class ClubManagementCommandServiceImpl implements ClubManagementCommandSe
 
         // 6. 생성된 클럽의 ID 반환
         return club.getId();
+    }
+
+    /**
+     * 독서모임 정보를 수정합니다.
+     *
+     * 피그마 참고 페이지 : #독서모임 - 모임 수정 화면
+     *
+     * @param clubId   수정할 독서모임 ID
+     * @param memberId 수정 요청 회원 ID
+     * @param request  수정할 모임 정보 DTO
+     */
+    @Override
+    @Transactional
+    public void updateClub(Long clubId, String memberId, ClubRequestDTO.ClubDetailDTO request) {
+
+        // 1. 클럽 유효성 검증
+        Club club = clubQueryService.validateClub(clubId);
+
+        // 2. 운영진 권한 확인
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
+        boolean isStaff = clubMember.isStaff();
+        if (!isStaff) {
+            throw new GeneralException(ErrorStatus.CLUB_STAFF_ONLY);
+        }
+
+        // 3. 클럽 이름 중복 검사 (단, 기존 이름과 다를 때만)
+        if (!club.getName().equals(request.getName()) &&
+                clubQueryService.isDuplicateClubName(request.getName())) {
+            throw new GeneralException(ErrorStatus.CLUB_DUPLICATED_NAME);
+        }
+
+        // 4. 엔티티 필드 수정
+        club.updateFromDetailDTO(request);
+
+        // 5. 카테고리 연관관계 수정
+        categoryCommandFacade.modifyClubCategories(clubId, ClubConverter.toCategoryListRequestDTO(request));
+
     }
 
 }

--- a/src/main/java/checkmo/domain/club/web/controller/ClubController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubController.java
@@ -112,6 +112,52 @@ public class ClubController {
     }
 
     /**
+     * 독서 모임 업데이트 API
+     *
+     * @param clubId   수정할 클럽 ID
+     * @param memberId 현재 로그인한 회원 ID
+     * @param request  수정할 클럽 정보(name, description, profileImageUrl, isOpen, category 등)
+     * @return 수정된 클럽 상세 정보
+     */
+    @Operation(
+            summary = "독서 모임 정보 수정",
+            description = """
+            지정한 클럽의 정보를 수정합니다.
+            
+            수정 가능 필드:
+              - name (모임 이름)
+              - description (모임 설명)
+              - profileImageUrl (프로필 이미지 URL)
+              - participantTypes (참여자 유형 목록)
+              - region (지역)
+              - insta (인스타그램 주소)
+              - kakao (카카오 오픈채팅 주소)
+            
+            수정 불가 필드:
+              - open (공개 여부)
+                - 요청 DTO에는 포함되지만, 서버에서는 해당 값을 무시하며 DB에 반영하지 않습니다.
+                - open 값 변경은 모임 생성 시에만 가능합니다.
+                - 피그마에 적힌 요구 사항을 참고한 것으로, 수정이 필요하면 말씀해주세요!
+            """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "입력 값이 유효하지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "수정 권한 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "클럽을 찾을 수 없음")
+    })
+    @PutMapping("/{clubId}")
+    public ApiResponse<ClubResponseDTO.ClubDetailDTO> updateClub(
+            @PathVariable Long clubId,
+            @CurrentId String memberId,
+            @RequestBody @Valid ClubRequestDTO.ClubDetailDTO request
+    ) {
+        clubCommandFacade.updateClub(clubId, memberId, request);
+        ClubResponseDTO.ClubDetailDTO result = clubQueryFacade.getClubInfo(clubId, memberId);
+        return ApiResponse.onSuccess(result);
+    }
+
+    /**
      * 독서 모임 검색 API
      *
      * @param keyword 검색할 키워드

--- a/src/main/java/checkmo/domain/club/web/controller/ClubController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubController.java
@@ -90,6 +90,28 @@ public class ClubController {
     }
 
     /**
+     * 독서 모임 상세 조회 API
+     *
+     * @param clubId   조회할 클럽 ID
+     * @param memberId 현재 로그인한 회원 ID
+     * @return 클럽 상세 정보
+     */
+    @Operation(summary = "독서 모임 상세 조회", description = "지정한 클럽의 상세 정보를 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "클럽을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "조회 권한 없음")
+    })
+    @GetMapping("/{clubId}")
+    public ApiResponse<ClubResponseDTO.ClubDetailDTO> getClubDetail(
+            @PathVariable Long clubId,
+            @CurrentId String memberId
+    ) {
+        ClubResponseDTO.ClubDetailDTO result = clubQueryFacade.getClubInfo(clubId, memberId);
+        return ApiResponse.onSuccess(result);
+    }
+
+    /**
      * 독서 모임 검색 API
      *
      * @param keyword 검색할 키워드


### PR DESCRIPTION
## 🚀 변경사항
독서 클럽 상세 조회, 독서 클럽 업데이트

## 🔗 관련 이슈
- Closes #108 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GET /api/clubs/{clubId} to view detailed club information.
  - Added PUT /api/clubs/{clubId} to update club details: name, description, profile image, participant types, categories, region, Instagram, and Kakao. “Open” status remains non-editable.
- Permissions & Validation
  - Updates restricted to club staff; meaningful errors returned for unauthorized access.
  - Prevents saving duplicate club names; validation on input with clear error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->