### PR TITLE
[BUG] 미팅 Request DTO 검증 어노테이션 추가

### DIFF
--- a/src/main/java/checkmo/domain/club/entity/announcement/Notice.java
+++ b/src/main/java/checkmo/domain/club/entity/announcement/Notice.java
@@ -19,6 +19,7 @@ public class Notice extends BaseEntity {
 
     private String title;
 
+    @Column(length = 1000)
     private String content;
 
     private boolean important;

--- a/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
+++ b/src/main/java/checkmo/domain/club/entity/meeting/Meeting.java
@@ -29,6 +29,7 @@ public class Meeting extends BaseEntity {
 
     private String location;
 
+    @Column(length = 1000)
     private String content;
 
     @Column(nullable = false)

--- a/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/meeting/MeetingRequestDTO.java
@@ -16,15 +16,19 @@ public class MeetingRequestDTO {
     @NoArgsConstructor
     public static class MeetingCreateRequestDTO {
         @NotBlank(message = "독서모임 제목은 필수 입력입니다.")
+        @Size(max = 255, message = "독서모임 제목은 255자 이하로 입력해주세요.")
         private String title; // 독서모임 제목
         @NotNull(message = "미팅 날짜, 시간은 null이 될 수 없습니다.")
         private LocalDateTime meetingTime; // 미팅 날짜, 시간
         @NotBlank(message = "독서모임 장소는 필수 입력입니다.")
+        @Size(max = 255, message = "독서모임 장소는 255자 이하로 입력해주세요.")
         private String location; // 모임 장소
         @NotBlank(message = "독서모임 설명은 필수 입력입니다.")
+        @Size(max = 1000, message = "독서모임 설명은 1000자 이하로 입력해주세요.")
         private String content;  // 모임 내용 설명 (공지사항 내용)
+        @NotNull(message = "기수는 null이 될 수 없습니다.")
         @Min(value = 1, message = "기수는 1 이상의 정수여야 합니다.")
-        private int generation;  // 기수
+        private Integer generation;  // 기수
         @NotBlank(message = "독서모임 태그는 필수 입력입니다.")
         @Size(max = 6, message = "태그는 최대 6글자까지 입력 가능합니다.")
         private String tag; // 태그
@@ -37,15 +41,19 @@ public class MeetingRequestDTO {
     @NoArgsConstructor
     public static class MeetingUpdateRequestDTO {
         @NotBlank(message = "독서모임 제목은 필수 입력입니다.")
+        @Size(max = 255, message = "독서모임 제목은 255자 이하로 입력해주세요.")
         private String title; // 독서모임 제목
         @NotNull(message = "미팅 날짜, 시간은 null이 될 수 없습니다.")
         private LocalDateTime meetingTime; // 미팅 날짜, 시간
         @NotBlank(message = "독서모임 장소는 필수 입력입니다.")
+        @Size(max = 255, message = "독서모임 장소는 255자 이하로 입력해주세요.")
         private String location; // 모임 장소
         @NotBlank(message = "독서모임 설명은 필수 입력입니다.")
+        @Size(max = 1000, message = "독서모임 설명은 1000자 이하로 입력해주세요.")
         private String content;  // 모임 내용 설명 (공지사항 내용)
+        @NotNull(message = "기수는 null이 될 수 없습니다.")
         @Min(value = 1, message = "기수는 1 이상의 정수여야 합니다.")
-        private int generation;  // 기수
+        private Integer generation;  // 기수
         @NotBlank(message = "독서모임 태그는 필수 입력입니다.")
         @Size(max = 6, message = "태그는 최대 6글자까지 입력 가능합니다.")
         private String tag; // 태그


### PR DESCRIPTION
## 🚀 변경사항
<!-- 뭘 구현했는지/수정했는지 간단히 -->
- 미팅 Request DTO String의 사이즈 관련 어노테이션 추가

## 🔗 관련 이슈
- Closes #113 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support longer content (up to 1000 characters) for notices and meetings.

* **Bug Fixes**
  * Enforce field length limits on meeting create/update: title and location up to 255 characters; content up to 1000.
  * Require the generation field to be provided (non-null) and at least 1, improving input validation and error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->