### PR TITLE
♻️ refactor: 마이페이지 - 내가 가입한 클럽 조회 - 커서 기반 페이징으로 수정

### DIFF
--- a/src/main/java/checkmo/domain/club/converter/ClubConverter.java
+++ b/src/main/java/checkmo/domain/club/converter/ClubConverter.java
@@ -52,6 +52,21 @@ public class ClubConverter {
     }
 
     /**
+     * ClubResponseDTO.ClubDetailResponseDTO -> ClubResponseDTO.MyPageClubListDTO 변환
+     */
+    public static ClubResponseDTO.MyPageClubListDTO toMyPageClubListDTO(
+            List<ClubResponseDTO.ClubDetailResponseDTO> clubList,
+            boolean hasNext,
+            Long nextCursor
+    ) {
+        return ClubResponseDTO.MyPageClubListDTO.builder()
+                .clubList(clubList)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
+                .build();
+    }
+
+    /**
      * Club 리스트 → ClubResponseDTO.ClubListDTO 변환
      */
     public static ClubResponseDTO.ClubListDTO toClubListDTO(

--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacade.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacade.java
@@ -30,7 +30,7 @@ public interface ClubQueryFacade {
      * @param memberId 회원 ID -> 로그인한 회원의 ID를 사용
      * @return 내가 가입한 독서 클럽 목록 DTO
      */
-    ClubResponseDTO.MyPageClubListDTO getMyPageClubList(String memberId);
+    ClubResponseDTO.MyPageClubListDTO getMyPageClubList(String memberId, Long cursorId, Integer size);
 
     /**
      * 특정 회원이 가입한 모임 목록을 조회합니다. (외부용)

--- a/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
+++ b/src/main/java/checkmo/domain/club/facade/ClubQueryFacadeImpl.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
     private final ClubQueryService clubQueryService;
     private final ClubBookRecommendQueryService clubBookRecommendQueryService;
     private final ClubCommunicationQueryService clubCommunicationQueryService;
+    private final ClubCategoryQueryService clubCategoryQueryService;
 
     /**
      * 특정 회원이 가입한 모임 목록을 조회합니다. (내부용)
@@ -82,16 +84,43 @@ public class ClubQueryFacadeImpl implements ClubQueryFacade {
      * @return 내가 가입한 독서 클럽 목록 DTO
      */
     @Override
-    public ClubResponseDTO.MyPageClubListDTO getMyPageClubList(String memberId) {
+    public ClubResponseDTO.MyPageClubListDTO getMyPageClubList(String memberId, Long cursorId, Integer size) {
 
-        // 1. 회원이 가입한 모임 목록 조회
-        List<ClubResponseDTO.ClubDetailResponseDTO> myClubs =
-                clubMemberQueryService.getMyPageClubList(memberId).getClubList();
+        // 1. 기본 사이즈 처리
+        if (size == null) size = DEFAULT_PAGE_SIZE;
 
-        // 2. MyPageClubListDTO로 감싸서 반환
-        return ClubResponseDTO.MyPageClubListDTO.builder()
-                .clubList(myClubs)
-                .build();
+        // 2. 서비스 호출 (size+1로 조회 → hasNext 판단)
+        List<ClubMember> clubMembers = clubMemberQueryService.getMyPageClubList(memberId, cursorId, size + 1);
+
+        // 3. 페이징 처리
+        boolean hasNext = clubMembers.size() > size;
+        if (hasNext) {
+            clubMembers = clubMembers.subList(0, size);
+        }
+        Long nextCursor = hasNext ? clubMembers.get(clubMembers.size() - 1).getId() : null;
+
+        // 4. 클럽 ID 수집
+        List<Long> clubIds = clubMembers.stream()
+                .map(cm -> cm.getClub().getId())
+                .toList();
+
+        // 5. 카테고리 배치 조회
+        Map<Long, List<String>> clubCategoryNamesMap =
+                ClubConverter.fromClubCategoriesToCategoryNamesMap(
+                        clubCategoryQueryService.findCategoriesByClubIds(clubIds)
+                );
+
+        // 6. DTO 변환
+        List<ClubResponseDTO.ClubDetailResponseDTO> dtoList = clubMembers.stream()
+                .map(cm -> ClubConverter.fromClubToResponseDTOWithCategoryNames(
+                        cm.getClub(),
+                        clubCategoryNamesMap.getOrDefault(cm.getClub().getId(), Collections.emptyList()),
+                        cm.isStaff()
+                ))
+                .toList();
+
+        // 7. DTO 감싸서 반환
+        return ClubConverter.toMyPageClubListDTO(dtoList, hasNext, nextCursor);
     }
 
     @Override

--- a/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
+++ b/src/main/java/checkmo/domain/club/repository/ClubMemberRepository.java
@@ -1,6 +1,6 @@
 package checkmo.domain.club.repository;
 
-import checkmo.domain.club.entity.Club;
+import org.springframework.data.domain.Pageable;
 import checkmo.domain.club.entity.ClubMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,4 +24,9 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long>, C
 
     @Query("SELECT cm FROM ClubMember cm WHERE cm.club.id = :clubId AND cm.memberId IN :memberIds")
     List<ClubMember> findClubMembersByClubIdAndMemberIdIn(Long clubId, List<String> memberIds);
+
+    @Query("SELECT cm FROM ClubMember cm JOIN FETCH cm.club c " +
+            "WHERE cm.memberId = :memberId " + "AND (:cursorId IS NULL OR cm.id > :cursorId) " +
+            "ORDER BY cm.id ASC")
+    List<ClubMember> findClubMembersByMemberIdOrderByIdAsc(@Param("memberId") String memberId, @Param("cursorId") Long cursorId, Pageable pageable);
 }

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryService.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryService.java
@@ -43,7 +43,7 @@ public interface ClubMemberQueryService {
      * @param memberId 회원 ID -> 로그인한 회원의 ID를 사용
      * @return 내가 가입한 독서 클럽 목록 DTO
      */
-    ClubResponseDTO.MyPageClubListDTO getMyPageClubList(String memberId);
+    List<ClubMember> getMyPageClubList(String memberId, Long cursorId, Integer size);
 
     /**
      * 특정 회원이 해당 클럽에서 어떤 상태(등급)인지 조회합니다.

--- a/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
+++ b/src/main/java/checkmo/domain/club/service/query/ClubMemberQueryServiceImpl.java
@@ -61,38 +61,8 @@ public class ClubMemberQueryServiceImpl implements ClubMemberQueryService {
      * @return 내가 가입한 독서 클럽 목록 DTO
      */
     @Override
-    public ClubResponseDTO.MyPageClubListDTO getMyPageClubList(String memberId) {
-
-        // 1. ClubMember와 Club 엔티티 fetch join으로 조회
-        List<ClubMember> clubMembers = clubMemberRepository.findByMemberIdWithClub(memberId);
-
-        // 2. 모든 클럽 ID 수집
-        List<Long> clubIds = clubMembers.stream()
-                .map(cm -> cm.getClub().getId())
-                .toList();
-
-        // 3. 모든 클럽의 카테고리 이름을 한 번에 조회
-        List<ClubCategory> allClubCategories = clubCategoryQueryService.findCategoriesByClubIds(clubIds);
-        Map<Long, List<String>> clubCategoryNamesMap = ClubConverter.fromClubCategoriesToCategoryNamesMap(allClubCategories);
-
-        // 4. DTO 변환
-        List<ClubResponseDTO.ClubDetailResponseDTO> responseList = clubMembers.stream()
-                .map(cm -> {
-                    Club c = cm.getClub();
-                    List<String> categoryNames = clubCategoryNamesMap.getOrDefault(c.getId(), Collections.emptyList());
-                    return ClubConverter.fromClubToResponseDTOWithCategoryNames(c, categoryNames, cm.isStaff());
-/*
-                    // 기존 방식: 카테고리 정보를 CategorySharedDTO로 변환, TODO : 팀원들과 상의 후 제거
-                    List<CategorySharedDTO.CategoryInfo> categories = clubCategoriesMap.getOrDefault(c.getId(), Collections.emptyList());
-                    return ClubConverter.fromClubToResponseDTO(c, categories, cm.isStaff());
-*/
-                })
-                .toList();
-
-        // 5. MyPageClubListDTO로 감싸서 반환
-        return ClubResponseDTO.MyPageClubListDTO.builder()
-                .clubList(responseList)
-                .build();
+    public List<ClubMember> getMyPageClubList(String memberId, Long cursorId, Integer size) {
+        return clubMemberRepository.findClubMembersByMemberIdOrderByIdAsc(memberId, cursorId, size);
     }
 
     /**

--- a/src/main/java/checkmo/domain/club/web/controller/ClubController.java
+++ b/src/main/java/checkmo/domain/club/web/controller/ClubController.java
@@ -211,9 +211,11 @@ public class ClubController {
     })
     @GetMapping("/myPage")
     public ApiResponse<ClubResponseDTO.MyPageClubListDTO> getMyPageClubs(
-            @CurrentId String memberId
+            @CurrentId String memberId,
+            @RequestParam(required = false) Long cursorId,
+            @RequestParam(required = false) Integer size
     ) {
-        return ApiResponse.onSuccess(clubQueryFacade.getMyPageClubList(memberId));
+        return ApiResponse.onSuccess(clubQueryFacade.getMyPageClubList(memberId, cursorId, size));
     }
 
     /**

--- a/src/main/java/checkmo/domain/club/web/dto/club/ClubResponseDTO.java
+++ b/src/main/java/checkmo/domain/club/web/dto/club/ClubResponseDTO.java
@@ -51,6 +51,8 @@ public class ClubResponseDTO {
     @Builder
     public static class MyPageClubListDTO {
         private List<ClubDetailResponseDTO> clubList; // 모임 목록
+        private boolean hasNext;
+        private Long nextCursor;
     }
 
     @Getter


### PR DESCRIPTION
## 🚀 변경사항
마이페이지 - 내가 가입한 클럽 조회 - 커서 기반 페이징으로 수정

## 🔗 관련 이슈
- Closes #116 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * My Page clubs list now supports cursor-based pagination via optional cursorId and size query parameters.
  * Responses include pagination metadata: hasNext and nextCursor to enable seamless infinite scrolling.
  * Club entries now display associated category names in the list view.
  * Improved list loading behavior for accounts with many clubs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->