### PR TITLE
[FEAT] 알림 설정 구현, 알림 종류 추가 및 알림 엔티티 필드 단순화

### DIFF
--- a/src/main/java/checkmo/bookStory/BookStoryEvent.java
+++ b/src/main/java/checkmo/bookStory/BookStoryEvent.java
@@ -11,4 +11,8 @@ public class BookStoryEvent {
     @Builder
     public record BookStoryLiked(Long eventId, String senderId, String receiverId, Long bookStoryId) {
     }
+
+    @Builder
+    public record BookStoryComment(Long eventId, String senderId, String receiverId, Long bookStoryId) {
+    }
 }

--- a/src/main/java/checkmo/bookStory/internal/entity/BookStory.java
+++ b/src/main/java/checkmo/bookStory/internal/entity/BookStory.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +40,7 @@ public class BookStory extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    @JoinColumn(name = "member_id", nullable = false)
+    @Column(name = "member_id", nullable = false)
     private String memberId;
 
     @Column(name = "book_id", nullable = false)

--- a/src/main/java/checkmo/clubManagement/ClubManagementAPI.java
+++ b/src/main/java/checkmo/clubManagement/ClubManagementAPI.java
@@ -18,6 +18,14 @@ public interface ClubManagementAPI {
     void validateClub(Long clubId) throws ClubManagementException;
 
     /**
+     * 특정 모임의 이름을 조회.
+     *
+     * @param clubId 모임 ID
+     * @return 모임 이름
+     */
+    String fetchClubName(Long clubId) throws ClubManagementException;
+
+    /**
      * 특정 회원이 가입한 모임 목록을 조회합니다. 마이페이지 등 다른 서비스에서 사용됩니다.
      *
      * @param memberId 회원 ID

--- a/src/main/java/checkmo/clubManagement/ClubManagementAPI.java
+++ b/src/main/java/checkmo/clubManagement/ClubManagementAPI.java
@@ -26,6 +26,14 @@ public interface ClubManagementAPI {
     String fetchClubName(Long clubId) throws ClubManagementException;
 
     /**
+     * 여러 모임의 이름을 배치 조회.
+     *
+     * @param clubIds 모임 ID 목록
+     * @return 모임 ID를 키로 하는 모임 이름 맵
+     */
+    Map<Long, String> fetchClubNamesByClubIds(List<Long> clubIds);
+
+    /**
      * 특정 회원이 가입한 모임 목록을 조회합니다. 마이페이지 등 다른 서비스에서 사용됩니다.
      *
      * @param memberId 회원 ID

--- a/src/main/java/checkmo/clubManagement/internal/ClubManagementAPIImpl.java
+++ b/src/main/java/checkmo/clubManagement/internal/ClubManagementAPIImpl.java
@@ -36,6 +36,14 @@ public class ClubManagementAPIImpl implements ClubManagementAPI {
     }
 
     @Override
+    public Map<Long, String> fetchClubNamesByClubIds(List<Long> clubIds) {
+        if (clubIds == null || clubIds.isEmpty()) {
+            return Map.of();
+        }
+        return clubManagementQueryService.retrieveClubNamesByIds(clubIds);
+    }
+
+    @Override
     public ClubList fetchMyClubs(String memberId) {
         return clubMemberQueryService.retrieveClubList(memberId);
     }

--- a/src/main/java/checkmo/clubManagement/internal/ClubManagementAPIImpl.java
+++ b/src/main/java/checkmo/clubManagement/internal/ClubManagementAPIImpl.java
@@ -31,6 +31,11 @@ public class ClubManagementAPIImpl implements ClubManagementAPI {
     }
 
     @Override
+    public String fetchClubName(Long clubId) throws ClubManagementException {
+        return clubManagementQueryService.validateClub(clubId).getName();
+    }
+
+    @Override
     public ClubList fetchMyClubs(String memberId) {
         return clubMemberQueryService.retrieveClubList(memberId);
     }

--- a/src/main/java/checkmo/clubManagement/internal/repository/ClubRepository.java
+++ b/src/main/java/checkmo/clubManagement/internal/repository/ClubRepository.java
@@ -1,9 +1,16 @@
 package checkmo.clubManagement.internal.repository;
 
 import checkmo.clubManagement.internal.entity.Club;
+import checkmo.clubManagement.internal.repository.projection.ClubIdAndNameProjection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ClubRepository extends JpaRepository<Club, Long>, ClubRepositoryCustom {
     boolean existsByName(String clubName);
+
+    @Query("select c.id as id, c.name as name from Club c where c.id in :clubIds")
+    List<ClubIdAndNameProjection> findIdAndNameByIdIn(@Param("clubIds") List<Long> clubIds);
 }
 

--- a/src/main/java/checkmo/clubManagement/internal/repository/projection/ClubIdAndNameProjection.java
+++ b/src/main/java/checkmo/clubManagement/internal/repository/projection/ClubIdAndNameProjection.java
@@ -1,0 +1,9 @@
+package checkmo.clubManagement.internal.repository.projection;
+
+/**
+ * 클럽 ID와 이름
+ */
+public interface ClubIdAndNameProjection {
+    Long getId();
+    String getName();
+}

--- a/src/main/java/checkmo/clubManagement/internal/service/query/ClubManagementQueryService.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/query/ClubManagementQueryService.java
@@ -4,8 +4,11 @@ import checkmo.clubManagement.internal.entity.Club;
 import checkmo.clubManagement.internal.excepetion.ClubManagementErrorStatus;
 import checkmo.clubManagement.internal.excepetion.ClubManagementException;
 import checkmo.clubManagement.internal.repository.ClubRepository;
+import checkmo.clubManagement.internal.repository.projection.ClubIdAndNameProjection;
 import checkmo.clubManagement.web.dto.ClubRequestDTO;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,5 +35,14 @@ public class ClubManagementQueryService {
     public Club validateClub(Long clubId) throws ClubManagementException {
         return clubRepository.findById(clubId)
                 .orElseThrow(() -> new ClubManagementException(ClubManagementErrorStatus.CLUB_NOT_FOUND));
+    }
+
+    public Map<Long, String> retrieveClubNamesByIds(List<Long> clubIds) {
+        List<ClubIdAndNameProjection> results = clubRepository.findIdAndNameByIdIn(clubIds);
+        return results.stream()
+                .collect(Collectors.toMap(
+                        ClubIdAndNameProjection::getId,
+                        ClubIdAndNameProjection::getName
+                ));
     }
 }

--- a/src/main/java/checkmo/clubMeeting/ClubMeetingEvent.java
+++ b/src/main/java/checkmo/clubMeeting/ClubMeetingEvent.java
@@ -3,8 +3,14 @@ package checkmo.clubMeeting;
 import lombok.Builder;
 
 public class ClubMeetingEvent {
+
+    //TODO : 아래 두개의 이벤트 이름 수정 필요!!
+
     @Builder
     public record ClubMeetingCreatedEvent(Long clubId, Long meetingId, Long version, String title, String content) {
     }
 
+    @Builder
+    public record ClubMeetingCreated(Long eventId, Long clubId, String clubName) {
+    }
 }

--- a/src/main/java/checkmo/clubMeeting/internal/service/command/ClubMeetingCommandService.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/command/ClubMeetingCommandService.java
@@ -2,6 +2,7 @@ package checkmo.clubMeeting.internal.service.command;
 
 import checkmo.book.BookAPI;
 import checkmo.clubManagement.ClubManagementAPI;
+import checkmo.clubMeeting.ClubMeetingEvent.ClubMeetingCreated;
 import checkmo.clubMeeting.ClubMeetingEvent.ClubMeetingCreatedEvent;
 import checkmo.clubMeeting.internal.converter.ClubMeetingConverter;
 import checkmo.clubMeeting.internal.entity.ClubMemberTeam;
@@ -52,6 +53,9 @@ public class ClubMeetingCommandService {
 
         // 미팅 기반 공지사항 생성 이벤트 발행
         publishMeetingCreatedEvent(meeting);
+
+        // 미팅 생성 알림 이벤트 발행
+        publishMeetingCreatedNotificationEvent(meeting, clubId);
 
         return meeting.getId();
     }
@@ -151,6 +155,17 @@ public class ClubMeetingCommandService {
                 .version(meeting.getVersion())
                 .title(meeting.getTitle())
                 .content(meeting.getContent())
+                .build();
+
+        applicationEventPublisher.publishEvent(event);
+    }
+
+    private void publishMeetingCreatedNotificationEvent(Meeting meeting, Long clubId) {
+        String clubName = clubManagementAPI.fetchClubName(clubId);
+        ClubMeetingCreated event = ClubMeetingCreated.builder()
+                .eventId(meeting.getId())
+                .clubId(clubId)
+                .clubName(clubName)
                 .build();
 
         applicationEventPublisher.publishEvent(event);

--- a/src/main/java/checkmo/clubNotice/ClubNoticeEvent.java
+++ b/src/main/java/checkmo/clubNotice/ClubNoticeEvent.java
@@ -1,0 +1,10 @@
+package checkmo.clubNotice;
+
+import lombok.Builder;
+
+public class ClubNoticeEvent {
+
+    @Builder
+    public record ClubNoticeCreated(Long eventId, Long clubId, String clubName) {
+    }
+}

--- a/src/main/java/checkmo/clubNotice/internal/service/command/ClubNoticeCommandService.java
+++ b/src/main/java/checkmo/clubNotice/internal/service/command/ClubNoticeCommandService.java
@@ -2,6 +2,7 @@ package checkmo.clubNotice.internal.service.command;
 
 import checkmo.clubManagement.ClubManagementAPI;
 import checkmo.clubMeeting.ClubMeetingEvent.ClubMeetingCreatedEvent;
+import checkmo.clubNotice.ClubNoticeEvent.ClubNoticeCreated;
 import checkmo.clubNotice.internal.converter.ClubNoticeConverter;
 import checkmo.clubNotice.internal.entity.ClubMemberVote;
 import checkmo.clubNotice.internal.entity.Notice;
@@ -17,6 +18,7 @@ import checkmo.clubNotice.web.dto.ClubNoticeRequestDTO.CreateClubVote;
 import checkmo.clubNotice.web.dto.ClubNoticeRequestDTO.VoteResult;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +36,8 @@ public class ClubNoticeCommandService {
     private final NoticeRepository noticeRepository;
     private final ClubMemberVoteRepository clubMemberVoteRepository;
 
+    private final ApplicationEventPublisher applicationEventPublisher;
+
     public Notice createPureNotice(Long clubId, String memberId, CreateClubNotice request) {
         clubManagementAPI.validateClub(clubId);
         clubManagementAPI.validateStaffClubMember(clubId, memberId);
@@ -41,7 +45,19 @@ public class ClubNoticeCommandService {
         Notice notice = ClubNoticeConverter.toNotice(request, clubId);
         noticeRepository.save(notice);
 
+        publishNoticeCreatedEvent(notice, clubId);
+
         return notice;
+    }
+
+    private void publishNoticeCreatedEvent(Notice notice, Long clubId) {
+        String clubName = clubManagementAPI.fetchClubName(clubId);
+        ClubNoticeCreated event = ClubNoticeCreated.builder()
+                .eventId(notice.getId())
+                .clubId(clubId)
+                .clubName(clubName)
+                .build();
+        applicationEventPublisher.publishEvent(event);
     }
 
     public void deletePureNotice(Long clubId, Long noticeId, String memberId) {

--- a/src/main/java/checkmo/member/MemberEvent.java
+++ b/src/main/java/checkmo/member/MemberEvent.java
@@ -11,4 +11,8 @@ public class MemberEvent {
     @Builder
     public record DeleteProfileImage(String imageUrl) {
     }
+
+    @Builder
+    public record MemberRegistrationCompleted(String memberId) {
+    }
 }

--- a/src/main/java/checkmo/member/internal/service/command/MemberCommandService.java
+++ b/src/main/java/checkmo/member/internal/service/command/MemberCommandService.java
@@ -56,8 +56,14 @@ public class MemberCommandService {
 
         member.updateInterestCategories(new HashSet<>(request.getCategories()));
 
-        // 프로필 완료 상태로 변경 이벤트 발행
+        // 프로필 완료 상태로 변경
         authenticationAPI.completeProfile(memberId);
+
+        // 회원 등록 완료 이벤트 발행
+        eventPublisher.publishEvent(
+                MemberEvent.MemberRegistrationCompleted.builder()
+                        .memberId(memberId)
+                        .build());
     }
 
     /**

--- a/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
+++ b/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
@@ -53,12 +53,12 @@ public class NotificationConverter {
     ) {
         // 클럽 알림: clubName 사용,
         // 사용자 알림: senderNickname 사용
-        String displayName = isClubNotification(notification.getNotificationType())
+        String displayName = notification.getNotificationType().isClubNotification()
                 ? clubNameMap.get(notification.getDomainId())
                 : senderNicknameMap.get(notification.getSenderId());
 
         // sourceId는 클럽 미팅/공지 알림에서만 필요
-        Long sourceId = needsSourceId(notification.getNotificationType())
+        Long sourceId = notification.getNotificationType().needsSourceId()
                 ? notification.getSourceId()
                 : null;
 
@@ -71,16 +71,5 @@ public class NotificationConverter {
                 .read(notification.isRead())
                 .createdAt(notification.getCreatedAt())
                 .build();
-    }
-
-    private static boolean isClubNotification(Notification.NotificationType type) {
-        return type == Notification.NotificationType.JOIN_CLUB
-                || type == Notification.NotificationType.CLUB_MEETING_CREATED
-                || type == Notification.NotificationType.CLUB_NOTICE_CREATED;
-    }
-
-    private static boolean needsSourceId(Notification.NotificationType type) {
-        return type == Notification.NotificationType.CLUB_MEETING_CREATED
-                || type == Notification.NotificationType.CLUB_NOTICE_CREATED;
     }
 }

--- a/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
+++ b/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
@@ -14,10 +14,11 @@ import lombok.NoArgsConstructor;
 public class NotificationConverter {
 
     public static String getRedirectPath(Notification.NotificationType notificationType, Long bookStoryId) {
-        if (Notification.NotificationType.LIKE == notificationType) {
+        if (Notification.NotificationType.LIKE == notificationType
+                || Notification.NotificationType.COMMENT == notificationType) {
             return "/bookstory/" + bookStoryId + "/detail"; // 프론트엔드 경로
         }
-        return null; // 지금은 LIKE 타입일 경우 무조건 bookStoryId를 사용하지만, 다른 타입이 추가될 경우를 대비하여 null 반환
+        return null;
     }
 
     public static String getRedirectPath(Notification.NotificationType notificationType, String Nickname) {

--- a/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
+++ b/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
@@ -54,8 +54,8 @@ public class NotificationConverter {
         // 클럽 알림: clubName 사용,
         // 사용자 알림: senderNickname 사용
         String displayName = notification.getNotificationType().isClubNotification()
-                ? clubNameMap.get(notification.getDomainId())
-                : senderNicknameMap.get(notification.getSenderId());
+                ? clubNameMap.getOrDefault(notification.getDomainId(), "삭제된 클럽")
+                : senderNicknameMap.getOrDefault(notification.getSenderId(), "탈퇴한 회원");
 
         // sourceId는 클럽 미팅/공지 알림에서만 필요
         Long sourceId = notification.getNotificationType().needsSourceId()

--- a/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
+++ b/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
@@ -13,46 +13,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NotificationConverter {
 
-    public static String getRedirectPath(Notification.NotificationType notificationType, Long bookStoryId) {
-        if (Notification.NotificationType.LIKE == notificationType
-                || Notification.NotificationType.COMMENT == notificationType) {
-            return "/bookstory/" + bookStoryId + "/detail"; // 프론트엔드 경로
-        }
-        return null;
-    }
-
-    public static String getRedirectPath(Notification.NotificationType notificationType, String Nickname) {
-        if (Notification.NotificationType.FOLLOW == notificationType) {
-            return "/info/others/" + Nickname; // 프론트엔드 경로
-        }
-        return null; // 지금은 FOLLOW 타입일 경우 무조건 Nickname을 사용하지만, 다른 타입이 추가될 경우를 대비하여 null 반환
-    }
-
-    public static String getRedirectPathForClub(Notification.NotificationType notificationType, Long clubId) {
-        if (Notification.NotificationType.JOIN_CLUB == notificationType) {
-            return "/bookclub/" + clubId + "/home";
-        }
-        return null;
-    }
-
-    public static String getRedirectPathForClubMeeting(Long clubId, Long meetingId) {
-        return "/bookclub/" + clubId + "/meeting/" + meetingId;
-    }
-
-    public static String getRedirectPathForClubNotice(Long clubId, Long noticeId) {
-        return "/bookclub/" + clubId + "/notice/" + noticeId;
-    }
-
     public static BasicInfoPreviewList convertToPreviewListDTO(
             List<Notification> notifications,
-            Map<String, String> senderNicknameMap
+            Map<String, String> senderNicknameMap,
+            Map<Long, String> clubNameMap
     ) {
-
         List<BasicInfo> previewList = notifications.stream()
-                .map(notification -> convertToPreviewDTO(
-                        notification,
-                        notification.getSenderId() != null ? senderNicknameMap.get(notification.getSenderId()) : null
-                ))
+                .map(notification -> convertToBasicInfo(notification, senderNicknameMap, clubNameMap))
                 .toList();
 
         return BasicInfoPreviewList.builder()
@@ -60,33 +27,15 @@ public class NotificationConverter {
                 .build();
     }
 
-    public static BasicInfo convertToPreviewDTO(
-            Notification notification,
-            String senderNickname
-    ) {
-        return BasicInfo.builder()
-                .notificationId(notification.getId())
-                .notificationType(notification.getNotificationType())
-                .senderNickname(senderNickname)
-                .targetName(notification.getTargetName())
-                .read(notification.isRead())
-                .createdAt(notification.getCreatedAt())
-                .redirectPath(notification.getRedirectPath())
-                .build();
-    }
-
     public static BasicInfoList convertToNotificationListDTO(
             List<Notification> notifications,
             Map<String, String> senderNicknameMap,
+            Map<Long, String> clubNameMap,
             CursorResult<Notification> cursorResult,
             int pageSize
     ) {
-
         var notificationList = notifications.stream()
-                .map(notification -> convertToPreviewDTO(
-                        notification,
-                        notification.getSenderId() != null ? senderNicknameMap.get(notification.getSenderId()) : null
-                ))
+                .map(notification -> convertToBasicInfo(notification, senderNicknameMap, clubNameMap))
                 .toList();
 
         return BasicInfoList.builder()
@@ -95,5 +44,43 @@ public class NotificationConverter {
                 .nextCursor(cursorResult.nextCursor())
                 .pageSize(pageSize)
                 .build();
+    }
+
+    private static BasicInfo convertToBasicInfo(
+            Notification notification,
+            Map<String, String> senderNicknameMap,
+            Map<Long, String> clubNameMap
+    ) {
+        // 클럽 알림: clubName 사용,
+        // 사용자 알림: senderNickname 사용
+        String displayName = isClubNotification(notification.getNotificationType())
+                ? clubNameMap.get(notification.getDomainId())
+                : senderNicknameMap.get(notification.getSenderId());
+
+        // sourceId는 클럽 미팅/공지 알림에서만 필요
+        Long sourceId = needsSourceId(notification.getNotificationType())
+                ? notification.getSourceId()
+                : null;
+
+        return BasicInfo.builder()
+                .notificationId(notification.getId())
+                .notificationType(notification.getNotificationType())
+                .domainId(notification.getDomainId())
+                .sourceId(sourceId)
+                .displayName(displayName)
+                .read(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+
+    private static boolean isClubNotification(Notification.NotificationType type) {
+        return type == Notification.NotificationType.JOIN_CLUB
+                || type == Notification.NotificationType.CLUB_MEETING_CREATED
+                || type == Notification.NotificationType.CLUB_NOTICE_CREATED;
+    }
+
+    private static boolean needsSourceId(Notification.NotificationType type) {
+        return type == Notification.NotificationType.CLUB_MEETING_CREATED
+                || type == Notification.NotificationType.CLUB_NOTICE_CREATED;
     }
 }

--- a/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
+++ b/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
@@ -30,9 +30,17 @@ public class NotificationConverter {
 
     public static String getRedirectPathForClub(Notification.NotificationType notificationType, Long clubId) {
         if (Notification.NotificationType.JOIN_CLUB == notificationType) {
-            return "/bookclub/" + clubId + "/home"; // 프론트엔드 경로
+            return "/bookclub/" + clubId + "/home";
         }
         return null;
+    }
+
+    public static String getRedirectPathForClubMeeting(Long clubId, Long meetingId) {
+        return "/bookclub/" + clubId + "/meeting/" + meetingId;
+    }
+
+    public static String getRedirectPathForClubNotice(Long clubId, Long noticeId) {
+        return "/bookclub/" + clubId + "/notice/" + noticeId;
     }
 
     public static BasicInfoPreviewList convertToPreviewListDTO(

--- a/src/main/java/checkmo/notification/internal/entity/Notification.java
+++ b/src/main/java/checkmo/notification/internal/entity/Notification.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"notification_type", "source_id"})
+        @UniqueConstraint(columnNames = {"notification_type", "source_id", "receiver_id"})
 })
 public class Notification extends BaseEntity {
 
@@ -59,6 +59,6 @@ public class Notification extends BaseEntity {
     }
 
     public enum NotificationType {
-        LIKE, COMMENT, FOLLOW, JOIN_CLUB
+        LIKE, COMMENT, FOLLOW, JOIN_CLUB, CLUB_MEETING_CREATED, CLUB_NOTICE_CREATED
     }
 }

--- a/src/main/java/checkmo/notification/internal/entity/Notification.java
+++ b/src/main/java/checkmo/notification/internal/entity/Notification.java
@@ -56,6 +56,17 @@ public class Notification extends BaseEntity {
     }
 
     public enum NotificationType {
-        LIKE, COMMENT, FOLLOW, JOIN_CLUB, CLUB_MEETING_CREATED, CLUB_NOTICE_CREATED
+        LIKE, COMMENT, FOLLOW, JOIN_CLUB, CLUB_MEETING_CREATED, CLUB_NOTICE_CREATED;
+
+        public boolean isClubNotification() {
+            return this == JOIN_CLUB
+                    || this == CLUB_MEETING_CREATED
+                    || this == CLUB_NOTICE_CREATED;
+        }
+
+        public boolean needsSourceId() {
+            return this == CLUB_MEETING_CREATED
+                    || this == CLUB_NOTICE_CREATED;
+        }
     }
 }

--- a/src/main/java/checkmo/notification/internal/entity/Notification.java
+++ b/src/main/java/checkmo/notification/internal/entity/Notification.java
@@ -42,11 +42,8 @@ public class Notification extends BaseEntity {
     @Column(nullable = false)
     private boolean isRead = false;
 
-    @Column(nullable = false)
-    private String redirectPath;
-
-    @Column
-    private String targetName; // 대상 엔티티의 이름 (클럽명, 사용자명 등)
+    @Column(name = "domain_id")
+    private Long domainId; // 알림 대상 도메인의 ID (bookStoryId, clubId 등). FOLLOW의 경우 null
 
     @Column(name = "receiver_id", nullable = false)
     private String receiverId;

--- a/src/main/java/checkmo/notification/internal/entity/Notification.java
+++ b/src/main/java/checkmo/notification/internal/entity/Notification.java
@@ -59,6 +59,6 @@ public class Notification extends BaseEntity {
     }
 
     public enum NotificationType {
-        LIKE, FOLLOW, JOIN_CLUB
+        LIKE, COMMENT, FOLLOW, JOIN_CLUB
     }
 }

--- a/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
+++ b/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
@@ -47,6 +47,10 @@ public class NotificationSetting extends BaseEntity {
     @Builder.Default
     private boolean clubMeetingCreated = true;
 
+    @Column(name = "new_follower", nullable = false)
+    @Builder.Default
+    private boolean newFollower = true;
+
     public void toggleBookStoryLiked() {
         this.bookStoryLiked = !this.bookStoryLiked;
     }
@@ -61,6 +65,10 @@ public class NotificationSetting extends BaseEntity {
 
     public void toggleClubMeetingCreated() {
         this.clubMeetingCreated = !this.clubMeetingCreated;
+    }
+
+    public void toggleNewFollower() {
+        this.newFollower = !this.newFollower;
     }
 
 }

--- a/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
+++ b/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
@@ -1,6 +1,7 @@
 package checkmo.notification.internal.entity;
 
 import checkmo.common.BaseEntity;
+import checkmo.notification.internal.entity.Notification.NotificationType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -79,4 +80,14 @@ public class NotificationSetting extends BaseEntity {
         this.joinClub = !this.joinClub;
     }
 
+    public boolean isEnabled(NotificationType type) {
+        return switch (type) {
+            case LIKE -> bookStoryLiked;
+            case COMMENT -> bookStoryComment;
+            case FOLLOW -> newFollower;
+            case JOIN_CLUB -> joinClub;
+            case CLUB_MEETING_CREATED -> clubMeetingCreated;
+            case CLUB_NOTICE_CREATED -> clubNoticeCreated;
+        };
+    }
 }

--- a/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
+++ b/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
@@ -1,0 +1,50 @@
+package checkmo.notification.internal.entity;
+
+import checkmo.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id"})
+})
+public class NotificationSetting extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private String memberId;
+
+    @Column(name = "book_story_liked", nullable = false)
+    @Builder.Default
+    private boolean bookStoryLiked = true;
+
+    @Column(name = "book_story_comment", nullable = false)
+    @Builder.Default
+    private boolean bookStoryComment = true;
+
+    @Column(name = "club_notice_created", nullable = false)
+    @Builder.Default
+    private boolean clubNoticeCreated = true;
+
+    @Column(name = "club_meeting_created", nullable = false)
+    @Builder.Default
+    private boolean clubMeetingCreated = true;
+
+}

--- a/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
+++ b/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
@@ -47,4 +47,20 @@ public class NotificationSetting extends BaseEntity {
     @Builder.Default
     private boolean clubMeetingCreated = true;
 
+    public void toggleBookStoryLiked() {
+        this.bookStoryLiked = !this.bookStoryLiked;
+    }
+
+    public void toggleBookStoryComment() {
+        this.bookStoryComment = !this.bookStoryComment;
+    }
+
+    public void toggleClubNoticeCreated() {
+        this.clubNoticeCreated = !this.clubNoticeCreated;
+    }
+
+    public void toggleClubMeetingCreated() {
+        this.clubMeetingCreated = !this.clubMeetingCreated;
+    }
+
 }

--- a/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
+++ b/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
@@ -51,6 +51,10 @@ public class NotificationSetting extends BaseEntity {
     @Builder.Default
     private boolean newFollower = true;
 
+    @Column(name = "join_club", nullable = false)
+    @Builder.Default
+    private boolean joinClub = true;
+
     public void toggleBookStoryLiked() {
         this.bookStoryLiked = !this.bookStoryLiked;
     }
@@ -69,6 +73,10 @@ public class NotificationSetting extends BaseEntity {
 
     public void toggleNewFollower() {
         this.newFollower = !this.newFollower;
+    }
+
+    public void toggleJoinClub() {
+        this.joinClub = !this.joinClub;
     }
 
 }

--- a/src/main/java/checkmo/notification/internal/exception/NotificationErrorStatus.java
+++ b/src/main/java/checkmo/notification/internal/exception/NotificationErrorStatus.java
@@ -12,6 +12,7 @@ public enum NotificationErrorStatus implements BaseErrorCode {
 
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_400", "알림을 찾을 수 없습니다."),
     NOTIFICATION_ALREADY_READ(HttpStatus.BAD_REQUEST, "NOTIFICATION_401", "이미 읽은 알림입니다."),
+    NOTIFICATION_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_402", "알림 설정을 찾을 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/checkmo/notification/internal/listener/NotificationEventListener.java
+++ b/src/main/java/checkmo/notification/internal/listener/NotificationEventListener.java
@@ -2,6 +2,8 @@ package checkmo.notification.internal.listener;
 
 import checkmo.bookStory.BookStoryEvent;
 import checkmo.clubManagement.ClubManagementEvent.JoinClubEvent;
+import checkmo.clubMeeting.ClubMeetingEvent.ClubMeetingCreated;
+import checkmo.clubNotice.ClubNoticeEvent.ClubNoticeCreated;
 import checkmo.member.MemberEvent;
 import checkmo.notification.internal.service.command.NotificationCommandService;
 import checkmo.notification.internal.service.command.NotificationSettingCommandService;
@@ -54,6 +56,26 @@ public class NotificationEventListener {
             notificationCommandService.createNotification(event);
         } catch (Exception e) {
             log.error("독서 클럽 가입 승인 알림 생성 실패, JoinClubEvent: {}", event, e);
+            throw e;
+        }
+    }
+
+    @ApplicationModuleListener
+    public void handleNotificationEvent(ClubMeetingCreated event) {
+        try {
+            notificationCommandService.createNotification(event);
+        } catch (Exception e) {
+            log.error("정기 모임 생성 알림 생성 실패, ClubMeetingCreated: {}", event, e);
+            throw e;
+        }
+    }
+
+    @ApplicationModuleListener
+    public void handleNotificationEvent(ClubNoticeCreated event) {
+        try {
+            notificationCommandService.createNotification(event);
+        } catch (Exception e) {
+            log.error("공지사항 생성 알림 생성 실패, ClubNoticeCreated: {}", event, e);
             throw e;
         }
     }

--- a/src/main/java/checkmo/notification/internal/listener/NotificationEventListener.java
+++ b/src/main/java/checkmo/notification/internal/listener/NotificationEventListener.java
@@ -29,6 +29,16 @@ public class NotificationEventListener {
     }
 
     @ApplicationModuleListener
+    public void handleNotificationEvent(BookStoryEvent.BookStoryComment event) {
+        try {
+            notificationCommandService.createNotification(event);
+        } catch (Exception e) {
+            log.error("책이야기 댓글 알림 생성 실패, CommentEvent: {}", event, e);
+            throw e;
+        }
+    }
+
+    @ApplicationModuleListener
     public void handleNotificationEvent(MemberEvent.Follow event) {
         try {
             notificationCommandService.createNotification(event);

--- a/src/main/java/checkmo/notification/internal/listener/NotificationEventListener.java
+++ b/src/main/java/checkmo/notification/internal/listener/NotificationEventListener.java
@@ -4,6 +4,7 @@ import checkmo.bookStory.BookStoryEvent;
 import checkmo.clubManagement.ClubManagementEvent.JoinClubEvent;
 import checkmo.member.MemberEvent;
 import checkmo.notification.internal.service.command.NotificationCommandService;
+import checkmo.notification.internal.service.command.NotificationSettingCommandService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.modulith.events.ApplicationModuleListener;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
 public class NotificationEventListener {
 
     private final NotificationCommandService notificationCommandService;
+    private final NotificationSettingCommandService notificationSettingCommandService;
 
     @ApplicationModuleListener
     public void handleNotificationEvent(BookStoryEvent.BookStoryLiked event) {
@@ -42,6 +44,16 @@ public class NotificationEventListener {
             notificationCommandService.createNotification(event);
         } catch (Exception e) {
             log.error("독서 클럽 가입 승인 알림 생성 실패, JoinClubEvent: {}", event, e);
+            throw e;
+        }
+    }
+
+    @ApplicationModuleListener
+    public void handleMemberRegistrationCompleted(MemberEvent.MemberRegistrationCompleted event) {
+        try {
+            notificationSettingCommandService.createNotificationSetting(event.memberId());
+        } catch (Exception e) {
+            log.error("알림 설정 생성 실패, MemberRegistrationCompleted: {}", event, e);
             throw e;
         }
     }

--- a/src/main/java/checkmo/notification/internal/repository/NotificationRepository.java
+++ b/src/main/java/checkmo/notification/internal/repository/NotificationRepository.java
@@ -1,13 +1,10 @@
 package checkmo.notification.internal.repository;
 
 import checkmo.notification.internal.entity.Notification;
-import checkmo.notification.internal.entity.Notification.NotificationType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
 
     Optional<Notification> findByIdAndReceiverId(Long notificationId, String receiverId);
-
-    boolean existsByNotificationTypeAndSourceId(NotificationType notificationType, Long sourceId);
 }

--- a/src/main/java/checkmo/notification/internal/repository/NotificationSettingRepository.java
+++ b/src/main/java/checkmo/notification/internal/repository/NotificationSettingRepository.java
@@ -1,0 +1,12 @@
+package checkmo.notification.internal.repository;
+
+import checkmo.notification.internal.entity.NotificationSetting;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+
+    Optional<NotificationSetting> findByMemberId(String memberId);
+
+    boolean existsByMemberId(String memberId);
+}

--- a/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
+++ b/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
@@ -69,7 +69,7 @@ public class NotificationQueryFacade {
 
     private Map<String, String> fetchSenderNicknameMap(List<Notification> notifications) {
         List<String> senderIds = notifications.stream()
-                .filter(n -> !isClubNotification(n.getNotificationType()))
+                .filter(n -> !n.getNotificationType().isClubNotification())
                 .map(Notification::getSenderId)
                 .distinct()
                 .toList();
@@ -78,16 +78,10 @@ public class NotificationQueryFacade {
 
     private Map<Long, String> fetchClubNameMap(List<Notification> notifications) {
         List<Long> clubIds = notifications.stream()
-                .filter(n -> isClubNotification(n.getNotificationType()))
+                .filter(n -> n.getNotificationType().isClubNotification())
                 .map(Notification::getDomainId)
                 .distinct()
                 .toList();
         return clubManagementAPI.fetchClubNamesByClubIds(clubIds);
-    }
-
-    private boolean isClubNotification(NotificationType type) {
-        return type == NotificationType.JOIN_CLUB
-                || type == NotificationType.CLUB_MEETING_CREATED
-                || type == NotificationType.CLUB_NOTICE_CREATED;
     }
 }

--- a/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
+++ b/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
@@ -6,8 +6,10 @@ import checkmo.member.MemberAPI;
 import checkmo.notification.internal.converter.NotificationConverter;
 import checkmo.notification.internal.entity.Notification;
 import checkmo.notification.internal.service.query.NotificationQueryService;
+import checkmo.notification.internal.service.query.NotificationSettingQueryService;
 import checkmo.notification.web.dto.NotificationResponseDTO.BasicInfoList;
 import checkmo.notification.web.dto.NotificationResponseDTO.BasicInfoPreviewList;
+import checkmo.notification.web.dto.NotificationResponseDTO.SettingInfo;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class NotificationQueryFacade {
     private final MemberAPI memberAPI;
 
     private final NotificationQueryService notificationQueryService;
+    private final NotificationSettingQueryService notificationSettingQueryService;
 
     @Cacheable(value = "notifications", key = "#memberId")
     public BasicInfoPreviewList retrieveNotificationPreviews(String memberId, int size) {
@@ -58,6 +61,10 @@ public class NotificationQueryFacade {
                 notificationCursorResult,
                 DEFAULT_PAGE_SIZE
         );
+    }
+
+    public SettingInfo retrieveNotificationSetting(String memberId) {
+        return notificationSettingQueryService.getNotificationSetting(memberId);
     }
 
     private List<String> extractSenderIds(List<Notification> notifications) {

--- a/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
+++ b/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
@@ -1,10 +1,12 @@
 package checkmo.notification.internal.service;
 
+import checkmo.clubManagement.ClubManagementAPI;
 import checkmo.common.template.CursorPagingHelper;
 import checkmo.common.template.CursorResult;
 import checkmo.member.MemberAPI;
 import checkmo.notification.internal.converter.NotificationConverter;
 import checkmo.notification.internal.entity.Notification;
+import checkmo.notification.internal.entity.Notification.NotificationType;
 import checkmo.notification.internal.service.query.NotificationQueryService;
 import checkmo.notification.internal.service.query.NotificationSettingQueryService;
 import checkmo.notification.web.dto.NotificationResponseDTO.BasicInfoList;
@@ -26,6 +28,7 @@ public class NotificationQueryFacade {
 
     // Domain level 2
     private final MemberAPI memberAPI;
+    private final ClubManagementAPI clubManagementAPI;
 
     private final NotificationQueryService notificationQueryService;
     private final NotificationSettingQueryService notificationSettingQueryService;
@@ -34,12 +37,10 @@ public class NotificationQueryFacade {
     public BasicInfoPreviewList retrieveNotificationPreviews(String memberId, int size) {
         List<Notification> notifications = notificationQueryService.retrieveUnreadNotifications(memberId, size);
 
-        List<String> senderIds = extractSenderIds(notifications);
+        Map<String, String> senderNicknameMap = fetchSenderNicknameMap(notifications);
+        Map<Long, String> clubNameMap = fetchClubNameMap(notifications);
 
-        // 발신자 닉네임 배치 조회로 처리
-        Map<String, String> senderNicknameMap = memberAPI.fetchNicknameByMemberIds(senderIds);
-
-        return NotificationConverter.convertToPreviewListDTO(notifications, senderNicknameMap);
+        return NotificationConverter.convertToPreviewListDTO(notifications, senderNicknameMap, clubNameMap);
     }
 
     public BasicInfoList retrieveNotifications(String memberId, Long cursorId) {
@@ -50,14 +51,13 @@ public class NotificationQueryFacade {
         );
         List<Notification> notifications = notificationCursorResult.content();
 
-        List<String> senderIds = extractSenderIds(notifications);
-
-        // 알림 보낸 사람 닉네임 배치 조회
-        Map<String, String> senderNicknameMap = memberAPI.fetchNicknameByMemberIds(senderIds);
+        Map<String, String> senderNicknameMap = fetchSenderNicknameMap(notifications);
+        Map<Long, String> clubNameMap = fetchClubNameMap(notifications);
 
         return NotificationConverter.convertToNotificationListDTO(
                 notifications,
                 senderNicknameMap,
+                clubNameMap,
                 notificationCursorResult,
                 DEFAULT_PAGE_SIZE
         );
@@ -67,10 +67,27 @@ public class NotificationQueryFacade {
         return notificationSettingQueryService.getNotificationSetting(memberId);
     }
 
-    private List<String> extractSenderIds(List<Notification> notifications) {
-        return notifications.stream()
+    private Map<String, String> fetchSenderNicknameMap(List<Notification> notifications) {
+        List<String> senderIds = notifications.stream()
+                .filter(n -> !isClubNotification(n.getNotificationType()))
                 .map(Notification::getSenderId)
                 .distinct()
                 .toList();
+        return memberAPI.fetchNicknameByMemberIds(senderIds);
+    }
+
+    private Map<Long, String> fetchClubNameMap(List<Notification> notifications) {
+        List<Long> clubIds = notifications.stream()
+                .filter(n -> isClubNotification(n.getNotificationType()))
+                .map(Notification::getDomainId)
+                .distinct()
+                .toList();
+        return clubManagementAPI.fetchClubNamesByClubIds(clubIds);
+    }
+
+    private boolean isClubNotification(NotificationType type) {
+        return type == NotificationType.JOIN_CLUB
+                || type == NotificationType.CLUB_MEETING_CREATED
+                || type == NotificationType.CLUB_NOTICE_CREATED;
     }
 }

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
@@ -57,6 +57,36 @@ public class NotificationCommandService {
     }
 
     /**
+     * 댓글 알림 생성
+     *
+     * @param event 댓글 알림 정보 DTO
+     */
+    @CacheEvict(value = "notifications", key = "#event.receiverId()")
+    public void createNotification(BookStoryEvent.BookStoryComment event) {
+        NotificationType type = NotificationType.COMMENT;
+        Long sourceId = event.eventId();
+        if (notificationRepository.existsByNotificationTypeAndSourceId(type, sourceId)) {
+            return;
+        }
+
+        String redirectPath = NotificationConverter.getRedirectPath(type, event.bookStoryId());
+
+        Notification notification = Notification.builder()
+                .notificationType(type)
+                .sourceId(sourceId)
+                .redirectPath(redirectPath)
+                .targetName(null)
+                .senderId(event.senderId())
+                .receiverId(event.receiverId())
+                .build();
+        try {
+            notificationRepository.save(notification);
+        } catch (DataIntegrityViolationException e) {
+            // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
+        }
+    }
+
+    /**
      * 팔로우(구독) 알림 생성
      *
      * @param event 팔로우 알림 정보 DTO

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
@@ -44,14 +44,9 @@ public class NotificationCommandService {
             return;
         }
 
-        Long sourceId = event.eventId();
-        if (notificationRepository.existsByNotificationTypeAndSourceId(type, sourceId)) {
-            return;
-        }
-
         Notification notification = Notification.builder()
                 .notificationType(type)
-                .sourceId(sourceId)
+                .sourceId(event.eventId())
                 .domainId(event.bookStoryId())
                 .senderId(event.senderId())
                 .receiverId(event.receiverId())
@@ -75,14 +70,9 @@ public class NotificationCommandService {
             return;
         }
 
-        Long sourceId = event.eventId();
-        if (notificationRepository.existsByNotificationTypeAndSourceId(type, sourceId)) {
-            return;
-        }
-
         Notification notification = Notification.builder()
                 .notificationType(type)
-                .sourceId(sourceId)
+                .sourceId(event.eventId())
                 .domainId(event.bookStoryId())
                 .senderId(event.senderId())
                 .receiverId(event.receiverId())
@@ -106,15 +96,10 @@ public class NotificationCommandService {
             return;
         }
 
-        Long sourceId = event.eventId();
-        if (notificationRepository.existsByNotificationTypeAndSourceId(type, sourceId)) {
-            return;
-        }
-
         // domainId = null, 프론트에서 displayName(닉네임)으로 프로필 페이지 접근
         Notification notification = Notification.builder()
                 .notificationType(type)
-                .sourceId(sourceId)
+                .sourceId(event.eventId())
                 .domainId(null)
                 .senderId(event.followerId())
                 .receiverId(event.followingId())
@@ -138,14 +123,9 @@ public class NotificationCommandService {
             return;
         }
 
-        Long sourceId = event.eventId();
-        if (notificationRepository.existsByNotificationTypeAndSourceId(type, sourceId)) {
-            return;
-        }
-
         Notification notification = Notification.builder()
                 .notificationType(type)
-                .sourceId(sourceId)
+                .sourceId(event.eventId())
                 .domainId(event.clubId())
                 .senderId("SYSTEM")
                 .receiverId(event.memberId())

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
@@ -1,9 +1,13 @@
 package checkmo.notification.internal.service.command;
 
 import checkmo.bookStory.BookStoryEvent;
+import checkmo.clubManagement.ClubManagementAPI;
 import checkmo.clubManagement.ClubManagementEvent.JoinClubEvent;
+import checkmo.clubMeeting.ClubMeetingEvent.ClubMeetingCreated;
+import checkmo.clubNotice.ClubNoticeEvent.ClubNoticeCreated;
 import checkmo.member.MemberAPI;
 import checkmo.member.MemberEvent;
+import java.util.List;
 import checkmo.notification.internal.converter.NotificationConverter;
 import checkmo.notification.internal.entity.Notification;
 import checkmo.notification.internal.entity.Notification.NotificationType;
@@ -11,6 +15,8 @@ import checkmo.notification.internal.exception.NotificationErrorStatus;
 import checkmo.notification.internal.exception.NotificationException;
 import checkmo.notification.internal.repository.NotificationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -22,8 +28,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationCommandService {
 
     private final MemberAPI memberAPI;
+    private final ClubManagementAPI clubManagementAPI;
 
     private final NotificationRepository notificationRepository;
+
+    private final CacheManager cacheManager;
+
 
     /**
      * 좋아요 알림 생성
@@ -149,6 +159,63 @@ public class NotificationCommandService {
             notificationRepository.save(notification);
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
+        }
+    }
+
+    /**
+     * 정기 모임 생성 알림 생성
+     *
+     * @param event 정기 모임 생성 알림 정보 DTO
+     */
+    public void createNotification(ClubMeetingCreated event) {
+        NotificationType type = NotificationType.CLUB_MEETING_CREATED;
+        Long sourceId = event.eventId();
+        String redirectPath = NotificationConverter.getRedirectPathForClubMeeting(event.clubId(), event.eventId());
+
+        List<String> memberIds = clubManagementAPI.fetchActiveMemberIds(event.clubId());
+        for (String memberId : memberIds) {
+            createClubNotification(type, sourceId, redirectPath, event.clubName(), memberId);
+        }
+    }
+
+    /**
+     * 공지사항 생성 알림 생성
+     *
+     * @param event 공지사항 생성 알림 정보 DTO
+     */
+    public void createNotification(ClubNoticeCreated event) {
+        NotificationType type = NotificationType.CLUB_NOTICE_CREATED;
+        Long sourceId = event.eventId();
+        String redirectPath = NotificationConverter.getRedirectPathForClubNotice(event.clubId(), event.eventId());
+
+        List<String> memberIds = clubManagementAPI.fetchActiveMemberIds(event.clubId());
+        for (String memberId : memberIds) {
+            createClubNotification(type, sourceId, redirectPath, event.clubName(), memberId);
+        }
+    }
+
+    private void createClubNotification(NotificationType type, Long sourceId, String redirectPath,
+                                        String clubName, String receiverId) {
+        Notification notification = Notification.builder()
+                .notificationType(type)
+                .sourceId(sourceId)
+                .redirectPath(redirectPath)
+                .targetName(clubName)
+                .senderId("SYSTEM")
+                .receiverId(receiverId)
+                .build();
+        try {
+            notificationRepository.save(notification);
+            evictNotificationCache(receiverId);
+        } catch (DataIntegrityViolationException e) {
+            // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
+        }
+    }
+
+    private void evictNotificationCache(String memberId) {
+        Cache cache = cacheManager.getCache("notifications");
+        if (cache != null) {
+            cache.evict(memberId);
         }
     }
 

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
@@ -5,10 +5,8 @@ import checkmo.clubManagement.ClubManagementAPI;
 import checkmo.clubManagement.ClubManagementEvent.JoinClubEvent;
 import checkmo.clubMeeting.ClubMeetingEvent.ClubMeetingCreated;
 import checkmo.clubNotice.ClubNoticeEvent.ClubNoticeCreated;
-import checkmo.member.MemberAPI;
 import checkmo.member.MemberEvent;
 import java.util.List;
-import checkmo.notification.internal.converter.NotificationConverter;
 import checkmo.notification.internal.entity.Notification;
 import checkmo.notification.internal.entity.Notification.NotificationType;
 import checkmo.notification.internal.exception.NotificationErrorStatus;
@@ -28,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class NotificationCommandService {
 
-    private final MemberAPI memberAPI;
     private final ClubManagementAPI clubManagementAPI;
 
     private final NotificationRepository notificationRepository;
@@ -52,14 +49,10 @@ public class NotificationCommandService {
             return;
         }
 
-        String redirectPath = NotificationConverter.getRedirectPath(type, event.bookStoryId());
-
-        // Notification 객체를 생성하고 저장 (targetName = null)
         Notification notification = Notification.builder()
                 .notificationType(type)
                 .sourceId(sourceId)
-                .redirectPath(redirectPath)
-                .targetName(null)
+                .domainId(event.bookStoryId())
                 .senderId(event.senderId())
                 .receiverId(event.receiverId())
                 .build();
@@ -87,13 +80,10 @@ public class NotificationCommandService {
             return;
         }
 
-        String redirectPath = NotificationConverter.getRedirectPath(type, event.bookStoryId());
-
         Notification notification = Notification.builder()
                 .notificationType(type)
                 .sourceId(sourceId)
-                .redirectPath(redirectPath)
-                .targetName(null)
+                .domainId(event.bookStoryId())
                 .senderId(event.senderId())
                 .receiverId(event.receiverId())
                 .build();
@@ -121,17 +111,11 @@ public class NotificationCommandService {
             return;
         }
 
-        // 팔로우 누른 사람의 닉네임을 가져옴
-        String FollowerNickname = memberAPI.fetchNickname(event.followerId());
-
-        String redirectPath = NotificationConverter.getRedirectPath(type, FollowerNickname);
-
-        // Notification 객체를 생성하고 저장 (targetName = followerNickname)
+        // domainId = null, 프론트에서 displayName(닉네임)으로 프로필 페이지 접근
         Notification notification = Notification.builder()
                 .notificationType(type)
                 .sourceId(sourceId)
-                .redirectPath(redirectPath)
-                .targetName(FollowerNickname)
+                .domainId(null)
                 .senderId(event.followerId())
                 .receiverId(event.followingId())
                 .build();
@@ -159,15 +143,10 @@ public class NotificationCommandService {
             return;
         }
 
-        String redirectPath
-                = NotificationConverter.getRedirectPathForClub(Notification.NotificationType.JOIN_CLUB, event.clubId());
-
-        // Notification 객체를 생성하고 저장 (sender 없이, targetName 포함)
         Notification notification = Notification.builder()
                 .notificationType(type)
                 .sourceId(sourceId)
-                .redirectPath(redirectPath)
-                .targetName(event.clubName())
+                .domainId(event.clubId())
                 .senderId("SYSTEM")
                 .receiverId(event.memberId())
                 .build();
@@ -187,11 +166,10 @@ public class NotificationCommandService {
     public void createNotification(ClubMeetingCreated event) {
         NotificationType type = NotificationType.CLUB_MEETING_CREATED;
         Long sourceId = event.eventId();
-        String redirectPath = NotificationConverter.getRedirectPathForClubMeeting(event.clubId(), event.eventId());
 
         List<String> memberIds = clubManagementAPI.fetchActiveMemberIds(event.clubId());
         for (String memberId : memberIds) {
-            createClubNotification(type, sourceId, redirectPath, event.clubName(), memberId);
+            createClubNotification(type, sourceId, event.clubId(), memberId);
         }
     }
 
@@ -203,16 +181,15 @@ public class NotificationCommandService {
     public void createNotification(ClubNoticeCreated event) {
         NotificationType type = NotificationType.CLUB_NOTICE_CREATED;
         Long sourceId = event.eventId();
-        String redirectPath = NotificationConverter.getRedirectPathForClubNotice(event.clubId(), event.eventId());
 
         List<String> memberIds = clubManagementAPI.fetchActiveMemberIds(event.clubId());
         for (String memberId : memberIds) {
-            createClubNotification(type, sourceId, redirectPath, event.clubName(), memberId);
+            createClubNotification(type, sourceId, event.clubId(), memberId);
         }
     }
 
-    private void createClubNotification(NotificationType type, Long sourceId, String redirectPath,
-                                        String clubName, String receiverId) {
+    private void createClubNotification(NotificationType type, Long sourceId, Long clubId,
+                                        String receiverId) {
         if (!isNotificationEnabled(receiverId, type)) {
             return;
         }
@@ -220,8 +197,7 @@ public class NotificationCommandService {
         Notification notification = Notification.builder()
                 .notificationType(type)
                 .sourceId(sourceId)
-                .redirectPath(redirectPath)
-                .targetName(clubName)
+                .domainId(clubId)
                 .senderId("SYSTEM")
                 .receiverId(receiverId)
                 .build();

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
@@ -14,6 +14,7 @@ import checkmo.notification.internal.entity.Notification.NotificationType;
 import checkmo.notification.internal.exception.NotificationErrorStatus;
 import checkmo.notification.internal.exception.NotificationException;
 import checkmo.notification.internal.repository.NotificationRepository;
+import checkmo.notification.internal.repository.NotificationSettingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
@@ -31,18 +32,21 @@ public class NotificationCommandService {
     private final ClubManagementAPI clubManagementAPI;
 
     private final NotificationRepository notificationRepository;
+    private final NotificationSettingRepository notificationSettingRepository;
 
     private final CacheManager cacheManager;
-
 
     /**
      * 좋아요 알림 생성
      *
      * @param event 좋아요 알림 정보 DTO
      */
-    @CacheEvict(value = "notifications", key = "#event.receiverId()")
     public void createNotification(BookStoryEvent.BookStoryLiked event) {
         NotificationType type = NotificationType.LIKE;
+        if (!isNotificationEnabled(event.receiverId(), type)) {
+            return;
+        }
+
         Long sourceId = event.eventId();
         if (notificationRepository.existsByNotificationTypeAndSourceId(type, sourceId)) {
             return;
@@ -61,6 +65,7 @@ public class NotificationCommandService {
                 .build();
         try {
             notificationRepository.save(notification);
+            evictNotificationCache(event.receiverId());
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
         }
@@ -71,9 +76,12 @@ public class NotificationCommandService {
      *
      * @param event 댓글 알림 정보 DTO
      */
-    @CacheEvict(value = "notifications", key = "#event.receiverId()")
     public void createNotification(BookStoryEvent.BookStoryComment event) {
         NotificationType type = NotificationType.COMMENT;
+        if (!isNotificationEnabled(event.receiverId(), type)) {
+            return;
+        }
+
         Long sourceId = event.eventId();
         if (notificationRepository.existsByNotificationTypeAndSourceId(type, sourceId)) {
             return;
@@ -91,6 +99,7 @@ public class NotificationCommandService {
                 .build();
         try {
             notificationRepository.save(notification);
+            evictNotificationCache(event.receiverId());
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
         }
@@ -101,9 +110,12 @@ public class NotificationCommandService {
      *
      * @param event 팔로우 알림 정보 DTO
      */
-    @CacheEvict(value = "notifications", key = "#event.followingId()")
     public void createNotification(MemberEvent.Follow event) {
         Notification.NotificationType type = Notification.NotificationType.FOLLOW;
+        if (!isNotificationEnabled(event.followingId(), type)) {
+            return;
+        }
+
         Long sourceId = event.eventId();
         if (notificationRepository.existsByNotificationTypeAndSourceId(type, sourceId)) {
             return;
@@ -125,6 +137,7 @@ public class NotificationCommandService {
                 .build();
         try {
             notificationRepository.save(notification);
+            evictNotificationCache(event.followingId());
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
         }
@@ -135,9 +148,12 @@ public class NotificationCommandService {
      *
      * @param event 독서 클럽 가입 승인 알림 정보 DTO
      */
-    @CacheEvict(value = "notifications", key = "#event.memberId()")
     public void createNotification(JoinClubEvent event) {
         Notification.NotificationType type = Notification.NotificationType.JOIN_CLUB;
+        if (!isNotificationEnabled(event.memberId(), type)) {
+            return;
+        }
+
         Long sourceId = event.eventId();
         if (notificationRepository.existsByNotificationTypeAndSourceId(type, sourceId)) {
             return;
@@ -157,6 +173,7 @@ public class NotificationCommandService {
                 .build();
         try {
             notificationRepository.save(notification);
+            evictNotificationCache(event.memberId());
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
         }
@@ -196,6 +213,10 @@ public class NotificationCommandService {
 
     private void createClubNotification(NotificationType type, Long sourceId, String redirectPath,
                                         String clubName, String receiverId) {
+        if (!isNotificationEnabled(receiverId, type)) {
+            return;
+        }
+
         Notification notification = Notification.builder()
                 .notificationType(type)
                 .sourceId(sourceId)
@@ -217,6 +238,12 @@ public class NotificationCommandService {
         if (cache != null) {
             cache.evict(memberId);
         }
+    }
+
+    private boolean isNotificationEnabled(String receiverId, NotificationType type) {
+        return notificationSettingRepository.findByMemberId(receiverId)
+                .map(setting -> setting.isEnabled(type))
+                .orElse(true);
     }
 
     /**

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationSettingCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationSettingCommandService.java
@@ -37,6 +37,7 @@ public class NotificationSettingCommandService {
             case BOOK_STORY_COMMENT -> setting.toggleBookStoryComment();
             case CLUB_NOTICE_CREATED -> setting.toggleClubNoticeCreated();
             case CLUB_MEETING_CREATED -> setting.toggleClubMeetingCreated();
+            case NEW_FOLLOWER -> setting.toggleNewFollower();
         }
     }
 }

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationSettingCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationSettingCommandService.java
@@ -1,6 +1,9 @@
 package checkmo.notification.internal.service.command;
 
 import checkmo.notification.internal.entity.NotificationSetting;
+import checkmo.notification.web.dto.NotificationSettingType;
+import checkmo.notification.internal.exception.NotificationErrorStatus;
+import checkmo.notification.internal.exception.NotificationException;
 import checkmo.notification.internal.repository.NotificationSettingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,5 +26,17 @@ public class NotificationSettingCommandService {
                 .build();
 
         notificationSettingRepository.save(notificationSetting);
+    }
+
+    public void toggleNotificationSetting(String memberId, NotificationSettingType settingType) {
+        NotificationSetting setting = notificationSettingRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new NotificationException(NotificationErrorStatus.NOTIFICATION_SETTING_NOT_FOUND));
+
+        switch (settingType) {
+            case BOOK_STORY_LIKED -> setting.toggleBookStoryLiked();
+            case BOOK_STORY_COMMENT -> setting.toggleBookStoryComment();
+            case CLUB_NOTICE_CREATED -> setting.toggleClubNoticeCreated();
+            case CLUB_MEETING_CREATED -> setting.toggleClubMeetingCreated();
+        }
     }
 }

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationSettingCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationSettingCommandService.java
@@ -38,6 +38,7 @@ public class NotificationSettingCommandService {
             case CLUB_NOTICE_CREATED -> setting.toggleClubNoticeCreated();
             case CLUB_MEETING_CREATED -> setting.toggleClubMeetingCreated();
             case NEW_FOLLOWER -> setting.toggleNewFollower();
+            case JOIN_CLUB -> setting.toggleJoinClub();
         }
     }
 }

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationSettingCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationSettingCommandService.java
@@ -1,0 +1,27 @@
+package checkmo.notification.internal.service.command;
+
+import checkmo.notification.internal.entity.NotificationSetting;
+import checkmo.notification.internal.repository.NotificationSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationSettingCommandService {
+
+    private final NotificationSettingRepository notificationSettingRepository;
+
+    public void createNotificationSetting(String memberId) {
+        if (notificationSettingRepository.existsByMemberId(memberId)) {
+            return;
+        }
+
+        NotificationSetting notificationSetting = NotificationSetting.builder()
+                .memberId(memberId)
+                .build();
+
+        notificationSettingRepository.save(notificationSetting);
+    }
+}

--- a/src/main/java/checkmo/notification/internal/service/query/NotificationSettingQueryService.java
+++ b/src/main/java/checkmo/notification/internal/service/query/NotificationSettingQueryService.java
@@ -25,6 +25,7 @@ public class NotificationSettingQueryService {
                 .bookStoryComment(setting.isBookStoryComment())
                 .clubNoticeCreated(setting.isClubNoticeCreated())
                 .clubMeetingCreated(setting.isClubMeetingCreated())
+                .newFollower(setting.isNewFollower())
                 .build();
     }
 }

--- a/src/main/java/checkmo/notification/internal/service/query/NotificationSettingQueryService.java
+++ b/src/main/java/checkmo/notification/internal/service/query/NotificationSettingQueryService.java
@@ -1,0 +1,30 @@
+package checkmo.notification.internal.service.query;
+
+import checkmo.notification.internal.entity.NotificationSetting;
+import checkmo.notification.internal.exception.NotificationErrorStatus;
+import checkmo.notification.internal.exception.NotificationException;
+import checkmo.notification.internal.repository.NotificationSettingRepository;
+import checkmo.notification.web.dto.NotificationResponseDTO.SettingInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationSettingQueryService {
+
+    private final NotificationSettingRepository notificationSettingRepository;
+
+    public SettingInfo getNotificationSetting(String memberId) {
+        NotificationSetting setting = notificationSettingRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new NotificationException(NotificationErrorStatus.NOTIFICATION_SETTING_NOT_FOUND));
+
+        return SettingInfo.builder()
+                .bookStoryLiked(setting.isBookStoryLiked())
+                .bookStoryComment(setting.isBookStoryComment())
+                .clubNoticeCreated(setting.isClubNoticeCreated())
+                .clubMeetingCreated(setting.isClubMeetingCreated())
+                .build();
+    }
+}

--- a/src/main/java/checkmo/notification/internal/service/query/NotificationSettingQueryService.java
+++ b/src/main/java/checkmo/notification/internal/service/query/NotificationSettingQueryService.java
@@ -26,6 +26,7 @@ public class NotificationSettingQueryService {
                 .clubNoticeCreated(setting.isClubNoticeCreated())
                 .clubMeetingCreated(setting.isClubMeetingCreated())
                 .newFollower(setting.isNewFollower())
+                .joinClub(setting.isJoinClub())
                 .build();
     }
 }

--- a/src/main/java/checkmo/notification/web/controller/NotificationController.java
+++ b/src/main/java/checkmo/notification/web/controller/NotificationController.java
@@ -2,10 +2,13 @@ package checkmo.notification.web.controller;
 
 import checkmo.authentication.CurrentId;
 import checkmo.common.apiPayload.ApiResponse;
+import checkmo.notification.web.dto.NotificationSettingType;
 import checkmo.notification.internal.service.NotificationQueryFacade;
 import checkmo.notification.internal.service.command.NotificationCommandService;
+import checkmo.notification.internal.service.command.NotificationSettingCommandService;
 import checkmo.notification.web.dto.NotificationResponseDTO.BasicInfoList;
 import checkmo.notification.web.dto.NotificationResponseDTO.BasicInfoPreviewList;
+import checkmo.notification.web.dto.NotificationResponseDTO.SettingInfo;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -26,6 +29,7 @@ public class NotificationController {
 
     private final NotificationQueryFacade notificationQueryFacade;
     private final NotificationCommandService notificationCommandService;
+    private final NotificationSettingCommandService notificationSettingCommandService;
 
     @Operation(summary = "알림 전체 조회", description = "특정 회원의 전체 알림을 조회합니다.")
     @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "10")
@@ -77,5 +81,35 @@ public class NotificationController {
     ) {
         notificationCommandService.markNotificationAsRead(notificationId, memberId);
         return ApiResponse.onSuccess(notificationId);
+    }
+
+    @Operation(summary = "알림 설정 조회", description = "회원의 알림 설정을 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "알림 설정을 찾을 수 없음")
+    })
+    @GetMapping("/settings")
+    public ApiResponse<SettingInfo> getNotificationSetting(
+            @CurrentId String memberId
+    ) {
+        var setting = notificationQueryFacade.retrieveNotificationSetting(memberId);
+        return ApiResponse.onSuccess(setting);
+    }
+
+    @Operation(summary = "알림 설정 토글", description = "특정 알림 설정을 토글합니다. (켜짐 <-> 꺼짐)")
+    @Parameter(name = "settingType", description = "알림 설정 타입", required = true, example = "BOOK_STORY_LIKED")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "알림 설정을 찾을 수 없음")
+    })
+    @PatchMapping("/settings/{settingType}")
+    public ApiResponse<Void> toggleNotificationSetting(
+            @CurrentId String memberId,
+            @PathVariable NotificationSettingType settingType
+    ) {
+        notificationSettingCommandService.toggleNotificationSetting(memberId, settingType);
+        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/checkmo/notification/web/dto/NotificationResponseDTO.java
+++ b/src/main/java/checkmo/notification/web/dto/NotificationResponseDTO.java
@@ -62,5 +62,6 @@ public class NotificationResponseDTO {
         private boolean clubNoticeCreated;
         private boolean clubMeetingCreated;
         private boolean newFollower;
+        private boolean joinClub;
     }
 }

--- a/src/main/java/checkmo/notification/web/dto/NotificationResponseDTO.java
+++ b/src/main/java/checkmo/notification/web/dto/NotificationResponseDTO.java
@@ -61,5 +61,6 @@ public class NotificationResponseDTO {
         private boolean bookStoryComment;
         private boolean clubNoticeCreated;
         private boolean clubMeetingCreated;
+        private boolean newFollower;
     }
 }

--- a/src/main/java/checkmo/notification/web/dto/NotificationResponseDTO.java
+++ b/src/main/java/checkmo/notification/web/dto/NotificationResponseDTO.java
@@ -43,13 +43,13 @@ public class NotificationResponseDTO {
     public static class BasicInfo {
         private Long notificationId;
         private Notification.NotificationType notificationType;
-        private String senderNickname;
-        private String targetName; // 대상 이름 (클럽명, 사용자명 등)
+        private Long domainId; // 알림 대상 도메인의 ID. FOLLOW의 경우 null
+        private Long sourceId; // 알림 출처 엔티티의 ID (meetingId, noticeId 등)
+        private String displayName; // 사람 알림: 닉네임, 시스템 알림: 클럽명
         private boolean read;
 
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
         private LocalDateTime createdAt;
-        private String redirectPath;
     }
 
     @Getter

--- a/src/main/java/checkmo/notification/web/dto/NotificationResponseDTO.java
+++ b/src/main/java/checkmo/notification/web/dto/NotificationResponseDTO.java
@@ -51,4 +51,15 @@ public class NotificationResponseDTO {
         private LocalDateTime createdAt;
         private String redirectPath;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SettingInfo {
+        private boolean bookStoryLiked;
+        private boolean bookStoryComment;
+        private boolean clubNoticeCreated;
+        private boolean clubMeetingCreated;
+    }
 }

--- a/src/main/java/checkmo/notification/web/dto/NotificationSettingType.java
+++ b/src/main/java/checkmo/notification/web/dto/NotificationSettingType.java
@@ -4,5 +4,6 @@ public enum NotificationSettingType {
     BOOK_STORY_LIKED,
     BOOK_STORY_COMMENT,
     CLUB_NOTICE_CREATED,
-    CLUB_MEETING_CREATED
+    CLUB_MEETING_CREATED,
+    NEW_FOLLOWER
 }

--- a/src/main/java/checkmo/notification/web/dto/NotificationSettingType.java
+++ b/src/main/java/checkmo/notification/web/dto/NotificationSettingType.java
@@ -1,0 +1,8 @@
+package checkmo.notification.web.dto;
+
+public enum NotificationSettingType {
+    BOOK_STORY_LIKED,
+    BOOK_STORY_COMMENT,
+    CLUB_NOTICE_CREATED,
+    CLUB_MEETING_CREATED
+}

--- a/src/main/java/checkmo/notification/web/dto/NotificationSettingType.java
+++ b/src/main/java/checkmo/notification/web/dto/NotificationSettingType.java
@@ -5,5 +5,6 @@ public enum NotificationSettingType {
     BOOK_STORY_COMMENT,
     CLUB_NOTICE_CREATED,
     CLUB_MEETING_CREATED,
-    NEW_FOLLOWER
+    NEW_FOLLOWER,
+    JOIN_CLUB
 }

--- a/src/main/resources/db/migration/V20260119_1__alter_notification_table.sql
+++ b/src/main/resources/db/migration/V20260119_1__alter_notification_table.sql
@@ -1,0 +1,12 @@
+-- 기존 유니크 제약조건 변경
+ALTER TABLE notification
+    DROP INDEX UK_notification_type_source;
+
+ALTER TABLE notification
+    ADD CONSTRAINT UK_notification_type_source_receiver UNIQUE (notification_type, source_id, receiver_id);
+
+-- redirect_path, target_name 컬럼 삭제 및 domain_id 컬럼 추가
+ALTER TABLE notification DROP COLUMN redirect_path;
+ALTER TABLE notification DROP COLUMN target_name;
+
+ALTER TABLE notification ADD COLUMN domain_id BIGINT NULL;

--- a/src/main/resources/db/migration/V20260119_2__create_notification_setting.sql
+++ b/src/main/resources/db/migration/V20260119_2__create_notification_setting.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS notification_setting (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    member_id VARCHAR(255) NOT NULL,
+    book_story_liked BIT NOT NULL DEFAULT 1,
+    book_story_comment BIT NOT NULL DEFAULT 1,
+    club_notice_created BIT NOT NULL DEFAULT 1,
+    club_meeting_created BIT NOT NULL DEFAULT 1,
+    new_follower BIT NOT NULL DEFAULT 1,
+    join_club BIT NOT NULL DEFAULT 1,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
+
+ALTER TABLE notification_setting
+    ADD CONSTRAINT UK_notification_setting_member UNIQUE (member_id);

--- a/src/main/resources/db/migration/V20260119_3__insert_notification_setting_for_existing_members.sql
+++ b/src/main/resources/db/migration/V20260119_3__insert_notification_setting_for_existing_members.sql
@@ -1,0 +1,4 @@
+-- 기존 회원들에 대해 NotificationSetting 생성
+INSERT INTO notification_setting (member_id, book_story_liked, book_story_comment, club_notice_created, club_meeting_created, new_follower, join_club, created_at, updated_at)
+SELECT id, 1, 1, 1, 1, 1, 1, NOW(), NOW()
+FROM member;


### PR DESCRIPTION
## 🚀 변경사항
1. Notification 엔티티의 필드 정리해서 더 명확하고 단순하게 변경
2. NotificationSetting 엔티티 추가해서 사용자가 원하는 알림만 수신할 수 있게 변경

## 🔗 관련 이슈
- Closes #140 

## ✅ 체크리스트
- [ ] 로컬에서 테스트 완료
- [ ] 코드 리뷰 준비 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User notification preferences with toggle controls and API endpoints to view/toggle settings.
  * Notifications for book story comments, club meeting creation, and club notice publication.
  * Automatic creation of notification settings for new and existing members.

* **Improvements**
  * Broader notification coverage (club-wide broadcasts) and improved notification payloads for clearer targets.
  * Enhanced notification retrieval to include club names and sender info.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->