### PR TITLE
[FEAT] 책이야기 조회 수 추가, 삭제, 검색 및 부가 기능 구현

### DIFF
--- a/src/main/java/checkmo/CheckmoApplication.java
+++ b/src/main/java/checkmo/CheckmoApplication.java
@@ -6,10 +6,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 
+@EnableAsync
 @EnableRetry
 @EnableScheduling
 @EnableJpaAuditing

--- a/src/main/java/checkmo/bookStory/internal/converter/BookStoryConverter.java
+++ b/src/main/java/checkmo/bookStory/internal/converter/BookStoryConverter.java
@@ -3,6 +3,7 @@ package checkmo.bookStory.internal.converter;
 import checkmo.book.BookExternalDTO;
 import checkmo.bookStory.internal.entity.BookStory;
 import checkmo.bookStory.internal.entity.Comment;
+import checkmo.bookStory.internal.repository.projection.BookStoryPrevNextProjection;
 import checkmo.bookStory.web.dto.BookStoryRequestDTO;
 import checkmo.bookStory.web.dto.BookStoryResponseDTO;
 import checkmo.member.MemberExternalDTO;
@@ -55,7 +56,8 @@ public class BookStoryConverter {
             BookExternalDTO.BasicInfo bookInfo,
             BasicInfoWithFollow authorInfo,
             boolean isLiked,
-            List<BookStoryResponseDTO.CommentInfo> commentList
+            List<BookStoryResponseDTO.CommentInfo> commentList,
+            BookStoryPrevNextProjection bookStoryPrevNextProjection
     ) {
         return BookStoryResponseDTO.DetailInfo.builder()
                 .bookStoryId(bookStory.getId())
@@ -70,6 +72,8 @@ public class BookStoryConverter {
                 .viewCount(bookStory.getViewCount())
                 .commentCount(bookStory.getCommentsCount())
                 .comments(commentList)
+                .prevBookStoryId(bookStoryPrevNextProjection.getPrevId())
+                .nextBookStoryId(bookStoryPrevNextProjection.getNextId())
                 .build();
     }
 

--- a/src/main/java/checkmo/bookStory/internal/converter/BookStoryConverter.java
+++ b/src/main/java/checkmo/bookStory/internal/converter/BookStoryConverter.java
@@ -32,8 +32,7 @@ public class BookStoryConverter {
             String currentMemberId,
             BookExternalDTO.BasicInfo bookInfo,
             BasicInfoWithFollow authorInfo,
-            boolean isLiked,
-            int commentCount
+            boolean isLiked
     ) {
         return BookStoryResponseDTO.BasicInfo.builder()
                 .bookStoryId(bookStory.getId())
@@ -45,7 +44,8 @@ public class BookStoryConverter {
                 .likedByMe(isLiked)
                 .createdAt(bookStory.getCreatedAt())
                 .writtenByMe(bookStory.getMemberId().equals(currentMemberId))
-                .commentCount(commentCount)
+                .viewCount(bookStory.getViewCount())
+                .commentCount(bookStory.getCommentsCount())
                 .build();
     }
 
@@ -67,6 +67,7 @@ public class BookStoryConverter {
                 .likedByMe(isLiked)
                 .createdAt(bookStory.getCreatedAt())
                 .writtenByMe(bookStory.getMemberId().equals(currentMemberId))
+                .viewCount(bookStory.getViewCount())
                 .commentCount(bookStory.getCommentsCount())
                 .comments(commentList)
                 .build();

--- a/src/main/java/checkmo/bookStory/internal/converter/BookStoryConverter.java
+++ b/src/main/java/checkmo/bookStory/internal/converter/BookStoryConverter.java
@@ -105,12 +105,25 @@ public class BookStoryConverter {
             MemberExternalDTO.BasicInfo authorInfo,
             List<BookStoryResponseDTO.CommentInfo> replies
     ) {
+        if (comment.isDeleted()) {
+            return BookStoryResponseDTO.CommentInfo.builder()
+                    .commentId(comment.getId())
+                    .content(null)
+                    .authorInfo(null)
+                    .createdAt(comment.getCreatedAt())
+                    .writtenByMe(false)
+                    .deleted(true)
+                    .replies(replies)
+                    .build();
+        }
+
         return BookStoryResponseDTO.CommentInfo.builder()
                 .commentId(comment.getId())
                 .content(comment.getContent())
                 .authorInfo(authorInfo)
                 .createdAt(comment.getCreatedAt())
                 .writtenByMe(comment.getMemberId().equals(currentMemberId))
+                .deleted(false)
                 .replies(replies)
                 .build();
     }

--- a/src/main/java/checkmo/bookStory/internal/entity/BookStory.java
+++ b/src/main/java/checkmo/bookStory/internal/entity/BookStory.java
@@ -35,6 +35,10 @@ public class BookStory extends BaseEntity {
     @Builder.Default
     private int commentsCount = 0;
 
+    @Column(nullable = false)
+    @Builder.Default
+    private int viewCount = 0;
+
     private String title;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/checkmo/bookStory/internal/entity/BookStory.java
+++ b/src/main/java/checkmo/bookStory/internal/entity/BookStory.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -39,6 +40,11 @@ public class BookStory extends BaseEntity {
     @Builder.Default
     private int viewCount = 0;
 
+    @Builder.Default
+    private boolean deleted = false;
+
+    private LocalDateTime deletedAt;
+
     private String title;
 
     @Column(columnDefinition = "TEXT")
@@ -66,13 +72,6 @@ public class BookStory extends BaseEntity {
     public void addCommentToList(Comment comment) {
         this.comments.add(comment);
         this.commentsCount++;
-    }
-
-    public void removeCommentFromList(Comment comment) {
-        this.comments.remove(comment);
-        if (this.commentsCount > 0) {
-            this.commentsCount--;
-        }
     }
 
     public void addBookStoryLiked(BookStoryLiked bookStoryLiked) {

--- a/src/main/java/checkmo/bookStory/internal/entity/Comment.java
+++ b/src/main/java/checkmo/bookStory/internal/entity/Comment.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -49,6 +50,11 @@ public class Comment extends BaseEntity {
     @OrderBy("createdAt ASC")
     private List<Comment> childrenComment = new ArrayList<>(); // 대댓글 리스트들
 
+    @Builder.Default
+    private boolean deleted = false;
+
+    private LocalDateTime deletedAt;
+
     public void addChildComment(Comment childComment) {
         childrenComment.add(childComment);
     }
@@ -73,5 +79,10 @@ public class Comment extends BaseEntity {
 
     public void updateContent(String content) {
         this.content = content;
+    }
+
+    public void softDelete() {
+        this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/checkmo/bookStory/internal/entity/Comment.java
+++ b/src/main/java/checkmo/bookStory/internal/entity/Comment.java
@@ -64,4 +64,14 @@ public class Comment extends BaseEntity {
             throw new BookStoryException(BookStoryErrorStatus.COMMENT_DEPTH_LIMIT_EXCEEDED);
         }
     }
+
+    public void verifyOwner(String memberId) {
+        if (!this.memberId.equals(memberId)) {
+            throw new BookStoryException(BookStoryErrorStatus.COMMENT_NOT_AUTHORIZED);
+        }
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/checkmo/bookStory/internal/exception/BookStoryErrorStatus.java
+++ b/src/main/java/checkmo/bookStory/internal/exception/BookStoryErrorStatus.java
@@ -15,6 +15,7 @@ public enum BookStoryErrorStatus implements BaseErrorCode {
 
     // 책 이야기 댓글
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_404", "댓글을 찾을 수 없습니다."),
+    COMMENT_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "COMMENT_403", "댓글 수정/삭제 권한이 없습니다."),
     INVALID_PARENT_COMMENT(HttpStatus.BAD_REQUEST, "COMMENT_401", "부모 댓글이 해당 책 이야기에 속하지 않습니다."),
     COMMENT_DEPTH_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "COMMENT_402", "댓글은 2단계까지만 허용됩니다."),
 

--- a/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepository.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepository.java
@@ -13,4 +13,10 @@ public interface BookStoryQueryRepository {
             Long cursorId,
             int pageSize
     );
+
+    List<BookStory> searchBookStories(
+            String bookId,
+            Long cursorId,
+            int pageSize
+    );
 }

--- a/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepositoryImpl.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepositoryImpl.java
@@ -43,6 +43,7 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
         return queryFactory
                 .selectFrom(bookStory)
                 .where(
+                        notDeleted(),
                         createCursorExp(cursorId),
                         bookStory.bookId.eq(bookId)
                 )
@@ -54,7 +55,10 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
     private List<BookStory> findAllBookStories(Long cursorId, int pageSize) {
         return queryFactory
                 .selectFrom(bookStory)
-                .where(createCursorExp(cursorId))
+                .where(
+                        notDeleted(),
+                        createCursorExp(cursorId)
+                )
                 .orderBy(bookStory.id.desc())
                 .limit(pageSize)
                 .fetch();
@@ -70,6 +74,7 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
         return queryFactory
                 .selectFrom(bookStory)
                 .where(
+                        notDeleted(),
                         createCursorExp(cursorId),
                         bookStory.memberId.in(followingMemberIds)
                 )
@@ -82,6 +87,7 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
         return queryFactory
                 .selectFrom(bookStory)
                 .where(
+                        notDeleted(),
                         createCursorExp(cursorId),
                         bookStory.memberId.eq(memberId)
                 )
@@ -105,6 +111,7 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
         return queryFactory
                 .selectFrom(bookStory)
                 .where(
+                        notDeleted(),
                         createCursorExp(cursorId),
                         bookStory.memberId.in(clubMemberIds)
                 )
@@ -121,12 +128,17 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
         return queryFactory
                 .selectFrom(bookStory)
                 .where(
+                        notDeleted(),
                         createCursorExp(cursorId),
                         bookStory.memberId.eq(targetMemberId)
                 )
                 .orderBy(bookStory.id.desc())
                 .limit(pageSize)
                 .fetch();
+    }
+
+    private BooleanExpression notDeleted() {
+        return bookStory.deleted.eq(false);
     }
 
     private BooleanExpression createCursorExp(Long cursorId) {

--- a/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepositoryImpl.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepositoryImpl.java
@@ -38,6 +38,19 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
         };
     }
 
+    @Override
+    public List<BookStory> searchBookStories(String bookId, Long cursorId, int pageSize) {
+        return queryFactory
+                .selectFrom(bookStory)
+                .where(
+                        createCursorExp(cursorId),
+                        bookStory.bookId.eq(bookId)
+                )
+                .orderBy(bookStory.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
     private List<BookStory> findAllBookStories(Long cursorId, int pageSize) {
         return queryFactory
                 .selectFrom(bookStory)

--- a/src/main/java/checkmo/bookStory/internal/repository/BookStoryRepository.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/BookStoryRepository.java
@@ -1,6 +1,7 @@
 package checkmo.bookStory.internal.repository;
 
 import checkmo.bookStory.internal.entity.BookStory;
+import checkmo.bookStory.internal.repository.projection.BookStoryPrevNextProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +12,13 @@ public interface BookStoryRepository extends JpaRepository<BookStory, Long>, Boo
     @Modifying
     @Query("UPDATE BookStory b SET b.viewCount = b.viewCount + :viewCount WHERE b.id = :id")
     void incrementViewCount(@Param("id") Long bookStoryId, @Param("viewCount") int viewCount);
+
+    @Query("""
+                SELECT
+                    (SELECT MAX(b1.id) FROM BookStory b1 WHERE b1.memberId = :memberId AND b1.id < :id) AS prevId,
+                    (SELECT MIN(b2.id) FROM BookStory b2 WHERE b2.memberId = :memberId AND b2.id > :id) AS nextId
+                FROM BookStory b
+                WHERE b.id = :id
+            """)
+    BookStoryPrevNextProjection findPrevNextBookStoryId(@Param("memberId") String memberId, @Param("id") Long bookStoryId);
 }

--- a/src/main/java/checkmo/bookStory/internal/repository/BookStoryRepository.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/BookStoryRepository.java
@@ -2,6 +2,7 @@ package checkmo.bookStory.internal.repository;
 
 import checkmo.bookStory.internal.entity.BookStory;
 import checkmo.bookStory.internal.repository.projection.BookStoryPrevNextProjection;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,16 +10,22 @@ import org.springframework.data.repository.query.Param;
 
 public interface BookStoryRepository extends JpaRepository<BookStory, Long>, BookStoryQueryRepository {
 
+    Optional<BookStory> findByIdAndDeletedFalse(Long id);
+
     @Modifying
     @Query("UPDATE BookStory b SET b.viewCount = b.viewCount + :viewCount WHERE b.id = :id")
     void incrementViewCount(@Param("id") Long bookStoryId, @Param("viewCount") int viewCount);
 
     @Query("""
                 SELECT
-                    (SELECT MAX(b1.id) FROM BookStory b1 WHERE b1.memberId = :memberId AND b1.id < :id) AS prevId,
-                    (SELECT MIN(b2.id) FROM BookStory b2 WHERE b2.memberId = :memberId AND b2.id > :id) AS nextId
+                    (SELECT MAX(b1.id) FROM BookStory b1 WHERE b1.memberId = :memberId AND b1.id < :id AND b1.deleted = false) AS prevId,
+                    (SELECT MIN(b2.id) FROM BookStory b2 WHERE b2.memberId = :memberId AND b2.id > :id AND b2.deleted = false) AS nextId
                 FROM BookStory b
                 WHERE b.id = :id
             """)
     BookStoryPrevNextProjection findPrevNextBookStoryId(@Param("memberId") String memberId, @Param("id") Long bookStoryId);
+
+    @Modifying
+    @Query("UPDATE BookStory b SET b.deleted = true, b.deletedAt = CURRENT_TIMESTAMP WHERE b.memberId = :memberId AND b.deleted = false")
+    void softDeleteAllByMemberId(@Param("memberId") String memberId);
 }

--- a/src/main/java/checkmo/bookStory/internal/repository/BookStoryRepository.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/BookStoryRepository.java
@@ -2,6 +2,13 @@ package checkmo.bookStory.internal.repository;
 
 import checkmo.bookStory.internal.entity.BookStory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BookStoryRepository extends JpaRepository<BookStory, Long>, BookStoryQueryRepository {
+
+    @Modifying
+    @Query("UPDATE BookStory b SET b.viewCount = b.viewCount + :viewCount WHERE b.id = :id")
+    void incrementViewCount(@Param("id") Long bookStoryId, @Param("viewCount") int viewCount);
 }

--- a/src/main/java/checkmo/bookStory/internal/repository/CommentRepository.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/CommentRepository.java
@@ -3,6 +3,7 @@ package checkmo.bookStory.internal.repository;
 import checkmo.bookStory.internal.entity.Comment;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,4 +15,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             "AND c.parentComment IS NULL " +
             "ORDER BY c.createdAt ASC")
     List<Comment> findParentComments(@Param("bookStoryId") Long bookStoryId);
+
+    @Modifying
+    @Query("UPDATE Comment c SET c.deleted = true, c.deletedAt = CURRENT_TIMESTAMP WHERE c.memberId = :memberId AND c.deleted = false")
+    void softDeleteAllByMemberId(@Param("memberId") String memberId);
 }

--- a/src/main/java/checkmo/bookStory/internal/repository/projection/BookStoryPrevNextProjection.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/projection/BookStoryPrevNextProjection.java
@@ -1,0 +1,6 @@
+package checkmo.bookStory.internal.repository.projection;
+
+public interface BookStoryPrevNextProjection {
+    Long getPrevId();
+    Long getNextId();
+}

--- a/src/main/java/checkmo/bookStory/internal/scheduler/BookStoryViewScheduler.java
+++ b/src/main/java/checkmo/bookStory/internal/scheduler/BookStoryViewScheduler.java
@@ -1,0 +1,38 @@
+package checkmo.bookStory.internal.scheduler;
+
+import checkmo.bookStory.internal.repository.BookStoryRepository;
+import checkmo.bookStory.internal.service.query.BookStoryViewCacheService;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookStoryViewScheduler {
+
+    private final BookStoryViewCacheService viewCacheService;
+    private final BookStoryRepository bookStoryRepository;
+
+    @Scheduled(fixedDelay = 60000)
+    @Transactional
+    public void syncViewCounts() {
+        Set<String> keys = viewCacheService.getViewCountKeys();
+
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+
+        for (String key : keys) {
+            Long bookStoryId = viewCacheService.parseBookStoryId(key);
+            int viewCount = viewCacheService.getViewCountAndDelete(key);
+
+            if (viewCount > 0) {
+                bookStoryRepository.incrementViewCount(bookStoryId, viewCount);
+            }
+        }
+    }
+}

--- a/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
+++ b/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -93,14 +92,19 @@ public class BookStoryQueryFacade {
         List<CommentInfo> commentDTOList =
                 BookStoryConverter.toCommentDetailList(comments, memberId, commentMemberInfoMap);
 
-        // 9. DTO 변환
+        // 9. 책이야기 작성자의 이전, 다음 책이야기 아이디 조회
+        var bookStoryPrevNextProjection
+                = bookStoryQueryService.retrievePrevNextBookStoryId(bookStory.getMemberId(), bookStoryId);
+
+        // 10. DTO 변환
         return BookStoryConverter.toBookStoryDetailWithComment(
                 bookStory,
                 memberId,
                 bookInfo,
                 authorInfo,
                 isLiked,
-                commentDTOList
+                commentDTOList,
+                bookStoryPrevNextProjection
         );
     }
 

--- a/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
+++ b/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
@@ -118,7 +118,7 @@ public class BookStoryQueryFacade {
      * @param cursorId             페이지 번호 (1부터 시작)
      * @return scope에 따른 책 이야기 목록 DTO
      */
-    public BookStoryResponseDTO.BookStoryList retrieveBookStories(
+    public BookStoryResponseDTO.BookStoryList fetchBookStories(
             String memberId,
             BookStoryRequestDTO.BookStoryScope scope,
             Long clubId, String targetMemberNickname,
@@ -248,5 +248,50 @@ public class BookStoryQueryFacade {
                     .orElseThrow(() -> new BookStoryException(BookStoryErrorStatus.CLUB_ACCESS_DENIED));
         }
         return null;
+    }
+
+    /**
+     * 특정 책으로 작성된 책 이야기 목록을 조회합니다.
+     *
+     * @param memberId 조회하는 회원의 ID
+     * @param bookId   책 ID
+     * @param cursorId 무한 스크롤을 위한 커서 ID
+     * @return bookId에 따른 책 이야기 목록 DTO
+     */
+    public BookStoryResponseDTO.BookStoryList fetchBookStoriesByBook(
+            String memberId,
+            String bookId,
+            Long cursorId
+    ) {
+
+        // 1. BookStory 리스트 조회
+        CursorResult<BookStory> bookStoryCursorResult = CursorPagingHelper.getPage(
+                (pageSize) -> bookStoryQueryService.retrieveBookStories(
+                        bookId, cursorId, pageSize
+                ),
+                BookStory::getId,
+                DEFAULT_PAGE_SIZE
+        );
+        List<BookStory> bookStories = bookStoryCursorResult.content();
+
+        // 좋아요 여부 조회
+        Map<Long, Boolean> isLikedMap = fetchLikedInfo(memberId, bookStories);
+
+        // 책 정보 조회
+        Map<String, BookExternalDTO.BasicInfo> bookInfoMap = fetchBookInfo(bookStories);
+
+        // 작성자 정보 조회
+        Map<String, BasicInfoWithFollow> authorInfoMap = fetchAuthorInfo(memberId, bookStories);
+
+        // DTO 변환
+        List<BookStoryResponseDTO.BasicInfo> basicInfoList = convertToBookStoryResponses(memberId,
+                bookStories, isLikedMap, bookInfoMap, authorInfoMap);
+
+        return BookStoryResponseDTO.BookStoryList.builder()
+                .basicInfoList(basicInfoList)
+                .hasNext(bookStoryCursorResult.hasNext())
+                .nextCursor(bookStoryCursorResult.nextCursor())
+                .pageSize(DEFAULT_PAGE_SIZE)
+                .build();
     }
 }

--- a/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
+++ b/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
@@ -225,8 +225,7 @@ public class BookStoryQueryFacade {
                         memberId,
                         bookInfoMap.get(bookStory.getBookId()),
                         authorInfoMap.get(bookStory.getMemberId()),
-                        isLikedMap.getOrDefault(bookStory.getId(), false),
-                        bookStory.getCommentsCount()
+                        isLikedMap.getOrDefault(bookStory.getId(), false)
                 )).toList();
     }
 

--- a/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
+++ b/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
@@ -10,6 +10,7 @@ import checkmo.bookStory.internal.entity.BookStory;
 import checkmo.bookStory.internal.entity.Comment;
 import checkmo.bookStory.internal.exception.BookStoryErrorStatus;
 import checkmo.bookStory.internal.exception.BookStoryException;
+import checkmo.bookStory.internal.service.query.BookStoryViewCacheService;
 import checkmo.bookStory.internal.service.query.BookStoryQueryService;
 import checkmo.bookStory.web.dto.BookStoryRequestDTO;
 import checkmo.bookStory.web.dto.BookStoryResponseDTO;
@@ -28,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +45,7 @@ public class BookStoryQueryFacade {
     private final BookAPI bookAPI;
 
     private final BookStoryQueryService bookStoryQueryService;
+    private final BookStoryViewCacheService viewCacheService;
 
     /**
      * 특정 책 이야기의 상세 정보를 조회합니다.
@@ -55,22 +58,25 @@ public class BookStoryQueryFacade {
         // 1. Service에서 BookStory 엔티티 조회
         BookStory bookStory = bookStoryQueryService.retrieveBookStory(bookStoryId);
 
-        // 2. 책 정보 조회
+        // 2. 레디스에 조회 수 카운트 증가
+        viewCacheService.incrementViewCount(bookStoryId, memberId);
+
+        // 3. 책 정보 조회
         BookExternalDTO.BasicInfo bookInfo = bookAPI.fetchBookBasicInfo(bookStory.getBookId());
 
-        // 3. 작성자 정보 조회
+        // 4. 작성자 정보 조회
         BasicInfoWithFollow authorInfo = memberAPI.fetchMemberBasicInfoWithFollow(
                 bookStory.getMemberId(), memberId);
 
-        // 4. 좋아요 여부 조회
+        // 5. 좋아요 여부 조회
         Boolean isLiked = bookStoryQueryService.checkBookStoryLikeByMemberId(memberId, List.of(bookStory))
                 .getOrDefault(bookStory.getId(), false);
 
-        // 5. 댓글 조회 (부모 댓글만, 대댓글은 컨버터에서 DTO 변환 시 자동 포함)
+        // 6. 댓글 조회 (부모 댓글만, 대댓글은 컨버터에서 DTO 변환 시 자동 포함)
         List<Comment> comments = bookStoryQueryService.retrieveBookStoryComments(bookStoryId);
 
-        // 6. 댓글 작성자들 정보 조회
-        // 6-1. 댓글 작성자들 Id 목록 조회 (Set으로 중복 제거)
+        // 7. 댓글 작성자들 정보 조회
+        // 7-1. 댓글 작성자들 Id 목록 조회 (Set으로 중복 제거)
         Set<String> commentMemberIds = comments.stream()
                 .flatMap(comment -> Stream.concat(
                         Stream.of(comment.getMemberId()),
@@ -78,16 +84,16 @@ public class BookStoryQueryFacade {
                 ))
                 .collect(Collectors.toSet());
 
-        // 6-2. 댓글 작성자들 정보를 배치 조회 (6-1에서 조회된 정보를 리스트로 변환 후 한번에 조회)
+        // 7-2. 댓글 작성자들 정보를 배치 조회 (6-1에서 조회된 정보를 리스트로 변환 후 한번에 조회)
         Map<String, MemberExternalDTO.BasicInfo> commentMemberInfoMap =
                 commentMemberIds.isEmpty() ? Map.of() :
                         memberAPI.fetchMemberBasicInfoByMemberIds(new ArrayList<>(commentMemberIds));
 
-        // 7. 댓글 DTO 변환
+        // 8. 댓글 DTO 변환
         List<CommentInfo> commentDTOList =
                 BookStoryConverter.toCommentDetailList(comments, memberId, commentMemberInfoMap);
 
-        // 8. DTO 변환
+        // 9. DTO 변환
         return BookStoryConverter.toBookStoryDetailWithComment(
                 bookStory,
                 memberId,

--- a/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommandService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommandService.java
@@ -70,4 +70,13 @@ public class BookStoryCommandService {
 
         bookStoryRepository.delete(bookStory);
     }
+
+    /**
+     * 회원 탈퇴 시 해당 회원의 모든 책이야기를 삭제(완전 삭제 아님)
+     *
+     * @param memberId 탈퇴하는 회원의 ID
+     */
+    public void softDeleteAllByMemberId(String memberId) {
+        bookStoryRepository.softDeleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommentCommandService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommentCommandService.java
@@ -140,4 +140,13 @@ public class BookStoryCommentCommandService {
         // 6. 삭제된 댓글 ID 반환
         return commentId;
     }
+
+    /**
+     * 회원 탈퇴 시 해당 회원의 모든 댓글을 삭제(완전 삭제 아님)
+     *
+     * @param memberId 탈퇴하는 회원의 ID
+     */
+    public void softDeleteAllByMemberId(String memberId) {
+        commentRepository.softDeleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommentCommandService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommentCommandService.java
@@ -107,4 +107,37 @@ public class BookStoryCommentCommandService {
         // 6. 수정된 댓글 ID 반환
         return commentId;
     }
+
+    /**
+     * 댓글 삭제 (소프트 삭제)
+     *
+     * @param memberId    삭제 요청자 ID
+     * @param bookStoryId 책이야기 ID
+     * @param commentId   삭제할 댓글 ID
+     * @return 삭제된 댓글 ID
+     */
+    public Long deleteComment(
+            String memberId,
+            Long bookStoryId,
+            Long commentId
+    ) {
+        // 1. 책이야기 존재 여부 확인
+        bookStoryQueryService.retrieveBookStory(bookStoryId);
+
+        // 2. 댓글 조회
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BookStoryException(BookStoryErrorStatus.COMMENT_NOT_FOUND));
+
+        // 3. 댓글이 해당 책이야기에 속하는지 확인
+        comment.verifyBookStory(bookStoryId);
+
+        // 4. 댓글 작성자 검증
+        comment.verifyOwner(memberId);
+
+        // 5. 소프트 삭제 처리
+        comment.softDelete();
+
+        // 6. 삭제된 댓글 ID 반환
+        return commentId;
+    }
 }

--- a/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommentCommandService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommentCommandService.java
@@ -72,4 +72,39 @@ public class BookStoryCommentCommandService {
         // 7. 댓글 작성된 책이야기 ID 반환
         return bookStoryId;
     }
+
+    /**
+     * 댓글 수정
+     *
+     * @param memberId    수정 요청자 ID
+     * @param bookStoryId 책이야기 ID
+     * @param commentId   수정할 댓글 ID
+     * @param request     수정할 댓글 내용
+     * @return 수정된 댓글 ID
+     */
+    public Long updateComment(
+            String memberId,
+            Long bookStoryId,
+            Long commentId,
+            BookStoryRequestDTO.CommentUpdate request
+    ) {
+        // 1. 책이야기 존재 여부 확인
+        bookStoryQueryService.retrieveBookStory(bookStoryId);
+
+        // 2. 댓글 조회
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BookStoryException(BookStoryErrorStatus.COMMENT_NOT_FOUND));
+
+        // 3. 댓글이 해당 책이야기에 속하는지 확인
+        comment.verifyBookStory(bookStoryId);
+
+        // 4. 댓글 작성자 검증
+        comment.verifyOwner(memberId);
+
+        // 5. 댓글 내용 수정
+        comment.updateContent(request.getContent());
+
+        // 6. 수정된 댓글 ID 반환
+        return commentId;
+    }
 }

--- a/src/main/java/checkmo/bookStory/internal/service/query/BookStoryQueryService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/query/BookStoryQueryService.java
@@ -7,6 +7,7 @@ import checkmo.bookStory.internal.exception.BookStoryException;
 import checkmo.bookStory.internal.repository.BookStoryLikedRepository;
 import checkmo.bookStory.internal.repository.BookStoryRepository;
 import checkmo.bookStory.internal.repository.CommentRepository;
+import checkmo.bookStory.internal.repository.projection.BookStoryPrevNextProjection;
 import checkmo.bookStory.web.dto.BookStoryRequestDTO;
 import java.util.HashSet;
 import java.util.List;
@@ -99,5 +100,9 @@ public class BookStoryQueryService {
                         bookStoryId -> bookStoryId,
                         likedIdSet::contains
                 ));
+    }
+
+    public BookStoryPrevNextProjection retrievePrevNextBookStoryId(String memberId, Long bookStoryId) {
+        return bookStoryRepository.findPrevNextBookStoryId(memberId, bookStoryId);
     }
 }

--- a/src/main/java/checkmo/bookStory/internal/service/query/BookStoryQueryService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/query/BookStoryQueryService.java
@@ -60,13 +60,13 @@ public class BookStoryQueryService {
     }
 
     /**
-     * 책 이야기 엔티티 조회
+     * 책 이야기 엔티티 조회 (삭제되지 않은 것만)
      *
      * @param bookStoryId 조회할 책 이야기의 ID
      * @return 조회된 책 이야기 엔티티
      */
     public BookStory retrieveBookStory(Long bookStoryId) {
-        return bookStoryRepository.findById(bookStoryId)
+        return bookStoryRepository.findByIdAndDeletedFalse(bookStoryId)
                 .orElseThrow(() -> new BookStoryException(BookStoryErrorStatus.BOOK_STORY_NOT_FOUND));
     }
 

--- a/src/main/java/checkmo/bookStory/internal/service/query/BookStoryQueryService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/query/BookStoryQueryService.java
@@ -51,6 +51,14 @@ public class BookStoryQueryService {
         return bookStoryRepository.searchBookStories(memberId, scope, clubId, targetMemberId, cursorId, pageSize);
     }
 
+    public List<BookStory> retrieveBookStories(
+            String bookId,
+            Long cursorId,
+            int pageSize
+    ) {
+        return bookStoryRepository.searchBookStories(bookId, cursorId, pageSize);
+    }
+
     /**
      * 책 이야기 엔티티 조회
      *

--- a/src/main/java/checkmo/bookStory/internal/service/query/BookStoryViewCacheService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/query/BookStoryViewCacheService.java
@@ -15,7 +15,7 @@ public class BookStoryViewCacheService {
 
     // 조회수 저장 (bookStory:viewCount:{bookStoryId})
     private static final String VIEW_COUNT_KEY = "bookStory:viewCount:";
-    // 중복 조회를 막기 위한 유저 저장 (bookStory:viewLog:{memberId})
+    // 중복 조회를 막기 위한 유저 저장 (bookStory:viewLog:{bookStoryId}:{memberId})
     private static final String VIEW_USER_LOG_KEY = "bookStory:viewLog:";
 
     /**

--- a/src/main/java/checkmo/bookStory/internal/service/query/BookStoryViewCacheService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/query/BookStoryViewCacheService.java
@@ -1,0 +1,58 @@
+package checkmo.bookStory.internal.service.query;
+
+import java.time.Duration;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookStoryViewCacheService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    // 조회수 저장 (bookStory:viewCount:{bookStoryId})
+    private static final String VIEW_COUNT_KEY = "bookStory:viewCount:";
+    // 중복 조회를 막기 위한 유저 저장 (bookStory:viewLog:{memberId})
+    private static final String VIEW_USER_LOG_KEY = "bookStory:viewLog:";
+
+    /**
+     * 조회수 증가 로직
+     * @param bookStoryId 게시글 ID
+     * @param memberId 조회한 유저 ID
+     */
+    @Async
+    public void incrementViewCount(Long bookStoryId, String memberId) {
+        String userLogKey = VIEW_USER_LOG_KEY + bookStoryId + ":" + memberId;
+        String viewCountKey = VIEW_COUNT_KEY + bookStoryId;
+
+        Boolean alreadyViewed = redisTemplate.hasKey(userLogKey);
+
+        if (!alreadyViewed) {
+            redisTemplate.opsForValue().increment(viewCountKey);
+
+            redisTemplate.opsForValue().set(userLogKey, "1", Duration.ofMinutes(10));
+        }
+    }
+
+    // TODO : SCAN 명령어로 구현하는게 더 좋지만 지금은 키 개수가 많지 않을 거라서 keys로 구현
+    public Set<String> getViewCountKeys() {
+        return redisTemplate.keys(VIEW_COUNT_KEY + "*");
+    }
+
+    public Long parseBookStoryId(String key) {
+        return Long.parseLong(key.replace(VIEW_COUNT_KEY, ""));
+    }
+
+    public int getViewCountAndDelete(String key) {
+        String value = redisTemplate.opsForValue().getAndDelete(key);
+
+        if (value == null) {
+            return 0;
+        }
+
+        return Integer.parseInt(value);
+    }
+}

--- a/src/main/java/checkmo/bookStory/web/controller/BookStoryController.java
+++ b/src/main/java/checkmo/bookStory/web/controller/BookStoryController.java
@@ -216,4 +216,26 @@ public class BookStoryController {
         Long resultCommentId = bookStoryCommentCommandService.updateComment(memberId, bookStoryId, commentId, request);
         return ApiResponse.onSuccess(resultCommentId);
     }
+
+    @Operation(summary = "책 이야기 댓글 삭제 API", description = "책 이야기에 작성한 댓글을 삭제합니다. (대댓글이 있는 경우 '삭제된 댓글입니다'로 표시)")
+    @Parameters({
+            @Parameter(name = "bookStoryId", description = "댓글이 속한 책 이야기 ID", required = true, example = "1"),
+            @Parameter(name = "commentId", description = "삭제할 댓글 ID", required = true, example = "10")
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "댓글 삭제 권한이 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책 이야기 또는 댓글을 찾을 수 없음")
+    })
+    @DeleteMapping("/{bookStoryId}/comments/{commentId}")
+    public ApiResponse<Long> deleteComment(
+            @CurrentId String memberId,
+            @PathVariable Long bookStoryId,
+            @PathVariable Long commentId
+    ) {
+        Long resultCommentId = bookStoryCommentCommandService.deleteComment(memberId, bookStoryId, commentId);
+        return ApiResponse.onSuccess(resultCommentId);
+    }
 }

--- a/src/main/java/checkmo/bookStory/web/controller/BookStoryController.java
+++ b/src/main/java/checkmo/bookStory/web/controller/BookStoryController.java
@@ -90,7 +90,7 @@ public class BookStoryController {
             throw new IllegalArgumentException("scope가 TARGET일 때는 targetMemberNickname 파라미터가 필수입니다.");
         }
 
-        var bookStoriesByScope = bookStoryQueryFacade.retrieveBookStories(memberId, scope, clubId, targetMemberNickname,
+        var bookStoriesByScope = bookStoryQueryFacade.fetchBookStories(memberId, scope, clubId, targetMemberNickname,
                 cursorId);
         return ApiResponse.onSuccess(bookStoriesByScope);
     }
@@ -237,5 +237,25 @@ public class BookStoryController {
     ) {
         Long resultCommentId = bookStoryCommentCommandService.deleteComment(memberId, bookStoryId, commentId);
         return ApiResponse.onSuccess(resultCommentId);
+    }
+
+    @Operation(summary = "특정 책으로 쓰여진 책이야기 조회 API", description = "특정 책으로 작성된 모든 책이야기를 조회합니다.")
+    @Parameters({
+            @Parameter(name = "bookId", description = "책이야기를 작성한 책 ID", required = true, example = "9791192005317"),
+            @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "1")
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @GetMapping("/search/{bookId}")
+    public ApiResponse<BookStoryResponseDTO.BookStoryList> getBookStoriesByBook(
+            @CurrentId String memberId,
+            @PathVariable String bookId,
+            @RequestParam(required = false) Long cursorId
+    ) {
+        var bookStoriesByBook = bookStoryQueryFacade.fetchBookStoriesByBook(memberId, bookId, cursorId);
+        return ApiResponse.onSuccess(bookStoriesByBook);
     }
 }

--- a/src/main/java/checkmo/bookStory/web/controller/BookStoryController.java
+++ b/src/main/java/checkmo/bookStory/web/controller/BookStoryController.java
@@ -193,4 +193,27 @@ public class BookStoryController {
                 request);
         return ApiResponse.onSuccess(resultBookStoryId);
     }
+
+    @Operation(summary = "책 이야기 댓글 수정 API", description = "책 이야기에 작성한 댓글을 수정합니다.")
+    @Parameters({
+            @Parameter(name = "bookStoryId", description = "댓글이 속한 책 이야기 ID", required = true, example = "1"),
+            @Parameter(name = "commentId", description = "수정할 댓글 ID", required = true, example = "10")
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "댓글 수정 권한이 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책 이야기 또는 댓글을 찾을 수 없음")
+    })
+    @PatchMapping("/{bookStoryId}/comments/{commentId}")
+    public ApiResponse<Long> updateComment(
+            @CurrentId String memberId,
+            @PathVariable Long bookStoryId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody BookStoryRequestDTO.CommentUpdate request
+    ) {
+        Long resultCommentId = bookStoryCommentCommandService.updateComment(memberId, bookStoryId, commentId, request);
+        return ApiResponse.onSuccess(resultCommentId);
+    }
 }

--- a/src/main/java/checkmo/bookStory/web/dto/BookStoryRequestDTO.java
+++ b/src/main/java/checkmo/bookStory/web/dto/BookStoryRequestDTO.java
@@ -36,4 +36,11 @@ public class BookStoryRequestDTO {
         @NotBlank(message = "댓글 내용을 입력해주세요.")
         private String content;
     }
+
+    @Getter
+    @NoArgsConstructor
+    public static class CommentUpdate {
+        @NotBlank(message = "수정할 댓글 내용을 입력해주세요.")
+        private String content;
+    }
 }

--- a/src/main/java/checkmo/bookStory/web/dto/BookStoryResponseDTO.java
+++ b/src/main/java/checkmo/bookStory/web/dto/BookStoryResponseDTO.java
@@ -97,6 +97,7 @@ public class BookStoryResponseDTO {
         private LocalDateTime createdAt;
 
         private boolean writtenByMe; // 작성자가 본인인지 여부
+        private boolean deleted; // 삭제된 댓글인지 여부
         private List<CommentInfo> replies; // 대댓글 목록
     }
 }

--- a/src/main/java/checkmo/bookStory/web/dto/BookStoryResponseDTO.java
+++ b/src/main/java/checkmo/bookStory/web/dto/BookStoryResponseDTO.java
@@ -82,6 +82,9 @@ public class BookStoryResponseDTO {
         private int commentCount; // 댓글 전체 개수 (대댓글 포함)
 
         private List<CommentInfo> comments;
+
+        private Long prevBookStoryId;
+        private Long nextBookStoryId;
     }
 
     @Getter

--- a/src/main/java/checkmo/bookStory/web/dto/BookStoryResponseDTO.java
+++ b/src/main/java/checkmo/bookStory/web/dto/BookStoryResponseDTO.java
@@ -57,6 +57,7 @@ public class BookStoryResponseDTO {
 
         private boolean writtenByMe; // 작성자가 본인인지 여부 (true: 본인, false: 타인)
         private int commentCount;
+        private int viewCount;
     }
 
     @Getter
@@ -77,6 +78,7 @@ public class BookStoryResponseDTO {
         private LocalDateTime createdAt;
 
         private boolean writtenByMe; // 작성자가 본인인지 여부 (true: 본인, false: 타인)
+        private int viewCount;
         private int commentCount; // 댓글 전체 개수 (대댓글 포함)
 
         private List<CommentInfo> comments;

--- a/src/main/resources/db/migration/V20260122_1__add_views_to_book_story.sql
+++ b/src/main/resources/db/migration/V20260122_1__add_views_to_book_story.sql
@@ -1,0 +1,4 @@
+ALTER TABLE book_story
+    ADD COLUMN view_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN deleted BIT(1) NOT NULL DEFAULT b'0',
+    ADD COLUMN deleted_at DATETIME NULL;

--- a/src/main/resources/db/migration/V20260122_2__add_deleted_fields_to_comment.sql
+++ b/src/main/resources/db/migration/V20260122_2__add_deleted_fields_to_comment.sql
@@ -1,0 +1,3 @@
+ALTER TABLE comment
+    ADD COLUMN deleted BIT(1) NOT NULL DEFAULT b'0',
+    ADD COLUMN deleted_at DATETIME(6) NULL;

--- a/src/main/resources/db/seed/local/V20260122_3__insert_local_seed.sql
+++ b/src/main/resources/db/seed/local/V20260122_3__insert_local_seed.sql
@@ -17,11 +17,11 @@ VALUES
 -- =========================
 -- 2) member
 -- =========================
-INSERT INTO member (id, email, nick_name, description, img_url, created_at, updated_at)
+INSERT INTO member (id, email, name, phone_number, nick_name, description, img_url, created_at, updated_at)
 VALUES
-    ('mem-001', 'test1@checkmo.local', '테스터1', '로컬 시드 유저1', NULL, @now, @now),
-    ('mem-002', 'test2@checkmo.local', '테스터2', '로컬 시드 유저2', NULL, @now, @now),
-    ('mem-003', 'admin@checkmo.local',  '어드민1','어드민 시드 유저1',  NULL, @now, @now);
+    ('mem-001', 'test1@checkmo.local', '홍길동', '010-1234-5678', '테스터1', '로컬 시드 유저1', NULL, @now, @now),
+    ('mem-002', 'test2@checkmo.local', '김철수', '010-2345-6789', '테스터2', '로컬 시드 유저2', NULL, @now, @now),
+    ('mem-003', 'admin@checkmo.local', '박영희', '010-3456-7890', '어드민1', '어드민 시드 유저1', NULL, @now, @now);
 
 -- =========================
 -- 3) member_interest_categories
@@ -190,15 +190,17 @@ VALUES
 -- =========================
 -- 13) book_story
 -- =========================
-INSERT INTO book_story (id, member_id, book_id, title, description, likes, comments_count, created_at, updated_at)
+INSERT INTO book_story (id, member_id, book_id, title, description, likes, comments_count, view_count, deleted, deleted_at, created_at, updated_at)
 VALUES
-    (1, 'mem-001', '9791193324530', '마지막 기도 감상', '복수와 신앙 사이의 갈등이 인상적', 2, 1, @now, @now),
-    (2, 'mem-001', '9791192128610', '녹색 자본론 정리', '억압/배제의 구조를 인류학적으로 읽다', 1, 0, @now, @now),
-    (3, 'mem-002', '9791192005317', '살인자ㅇ난감 메모', '장면 전환 템포가 좋았던 포인트', 0, 0, @now, @now),
-    (4, 'mem-002', '9791192625133', '거인의 어깨 요약', '투자 대가들의 공통점/차이점 정리', 0, 2, @now, @now),
-    (5, 'mem-003', '9791193528723', '인생의 태도 한 문장', '태도가 결국 선택을 바꾼다', 1, 0, @now, @now),
-    (6, 'mem-003', '9791193790403', '해리포터 1권 재독', '초반 세계관 소개가 완벽한 입문서', 0, 1, @now, @now),
-    (7, 'mem-003', '9791193790496', '불의 잔 4권 포인트', '전개의 밀도와 복선 회수 메모', 2, 0, @now, @now);
+    (1, 'mem-001', '9791193324530', '마지막 기도 감상', '복수와 신앙 사이의 갈등이 인상적', 2, 1, 15, b'0', NULL, @now, @now),
+    (2, 'mem-001', '9791192128610', '녹색 자본론 정리', '억압/배제의 구조를 인류학적으로 읽다', 1, 0, 8, b'0', NULL, @now, @now),
+    (3, 'mem-002', '9791192005317', '살인자ㅇ난감 메모', '장면 전환 템포가 좋았던 포인트', 0, 0, 3, b'0', NULL, @now, @now),
+    (4, 'mem-002', '9791192625133', '거인의 어깨 요약', '투자 대가들의 공통점/차이점 정리', 0, 2, 12, b'0', NULL, @now, @now),
+    (5, 'mem-003', '9791193528723', '인생의 태도 한 문장', '태도가 결국 선택을 바꾼다', 1, 0, 5, b'0', NULL, @now, @now),
+    (6, 'mem-003', '9791193790403', '해리포터 1권 재독', '초반 세계관 소개가 완벽한 입문서', 0, 1, 20, b'0', NULL, @now, @now),
+    (7, 'mem-003', '9791193790496', '불의 잔 4권 포인트', '전개의 밀도와 복선 회수 메모', 2, 0, 10, b'0', NULL, @now, @now),
+    (8, 'mem-003', '9791192005317', '드라마 먼저 보고 본 살인자ㅇ난감 후기', '영화보다 확실히 내용도 더 자세하게 뭔가 깊이가 있어서 많은 생각을 할 수 있었어요', 0, 0, 0, b'0', NULL, @now, @now),
+    (9, 'mem-002', '9791193394564', '트럼프 정책 정리', '미국 우선주의 정책의 핵심 요약', 0, 0, 2, b'1', @now, @now, @now);
 
 -- =========================
 -- 14) book_story_liked
@@ -218,14 +220,15 @@ VALUES
 -- =========================
 -- 15) comment
 -- =========================
-INSERT INTO comment (id, book_story_id, parent_comment_id, member_id, content, created_at, updated_at)
+INSERT INTO comment (id, book_story_id, parent_comment_id, member_id, content, deleted, deleted_at, created_at, updated_at)
 VALUES
-    (1, 1, NULL, 'mem-002', '저도 이 지점에서 주인공이 급격히 흔들리는 게 인상적이었어요.', @now, @now),
+    (1, 1, NULL, 'mem-001', '저도 이 지점에서 주인공이 급격히 흔들리는 게 인상적이었어요.', b'1', @now, @now, @now),
+    (2, 1, NULL, 'mem-002', '주인공의 위기 상황 때 정말 심장이 철렁했어요...', b'0', NULL, @now, @now),
 
-    (2, 4, NULL, 'mem-003', '세 사람(그레이엄/버핏/린치) 관점 정리 너무 좋네요. 저는 리스크 관리 파트가 기억에 남았어요.', @now, @now),
-    (3, 4, 2,    'mem-002', '맞아요. 특히 “잃지 않는 것”을 우선으로 보는 관점이 현실적이더라고요.', @now, @now),
+    (3, 4, NULL, 'mem-003', '세 사람(그레이엄/버핏/린치) 관점 정리 너무 좋네요. 저는 리스크 관리 파트가 기억에 남았어요.', b'0', NULL, @now, @now),
+    (4, 4, 2,    'mem-002', '맞아요. 특히 "잃지 않는 것"을 우선으로 보는 관점이 현실적이더라고요.', b'0', NULL, @now, @now),
 
-    (4, 6, NULL, 'mem-001', '입문서로서 완성도가 진짜 높죠. 세계관 소개가 과하지 않으면서도 몰입되더라구요.', @now, @now);
+    (5, 6, NULL, 'mem-001', '입문서로서 완성도가 진짜 높죠. 세계관 소개가 과하지 않으면서도 몰입되더라구요.', b'0', NULL, @now, @now);
 
 -- =========================
 -- 16) follow
@@ -268,38 +271,48 @@ VALUES
 
 -- =========================
 -- 20) notification
--- 알림 타입: LIKE / FOLLOW / JOIN_CLUB
+-- 알림 타입: LIKE / COMMENT / FOLLOW / JOIN_CLUB / CLUB_MEETING_CREATED / CLUB_NOTICE_CREATED
+-- source_id: 알림 출처 엔티티 ID, domain_id: 대상 도메인 ID (FOLLOW는 null)
 -- =========================
 INSERT INTO notification (
-    id, receiver_id, sender_id, source_id, target_name, notification_type, redirect_path,
+    id, receiver_id, sender_id, source_id, domain_id, notification_type,
     is_read, created_at, updated_at
 )
 VALUES
-    -- ===== LIKE 알림 (book_story_liked 기반) =====
-    (1, 'mem-001', 'mem-002', 101, '마지막 기도 감상', 'LIKE', '/book-stories/1', b'0', @now, @now),
+    -- ===== LIKE 알림 (source_id = book_story_liked.id, domain_id = book_story_id) =====
+    (1, 'mem-001', 'mem-002', 101, 1, 'LIKE', b'0', @now, @now),
+    (2, 'mem-001', 'mem-003', 102, 1, 'LIKE', b'0', @now, @now),
+    (3, 'mem-001', 'mem-002', 103, 2, 'LIKE', b'1', @now, @now),
+    (4, 'mem-003', 'mem-001', 104, 5, 'LIKE', b'0', @now, @now),
+    (5, 'mem-003', 'mem-001', 105, 7, 'LIKE', b'0', @now, @now),
+    (6, 'mem-003', 'mem-002', 106, 7, 'LIKE', b'1', @now, @now),
 
-    (2, 'mem-001', 'mem-003', 102, '마지막 기도 감상', 'LIKE', '/book-stories/1', b'0', @now, @now),
+    -- ===== COMMENT 알림 (source_id = comment.id, domain_id = book_story_id) =====
+    (7, 'mem-001', 'mem-002', 1, 1, 'COMMENT', b'0', @now, @now),
+    (8, 'mem-002', 'mem-003', 2, 4, 'COMMENT', b'0', @now, @now),
+    (9, 'mem-003', 'mem-001', 4, 6, 'COMMENT', b'1', @now, @now),
 
-    (3, 'mem-001', 'mem-002', 103, '녹색 자본론 정리', 'LIKE', '/book-stories/2', b'1', @now, @now),
+    -- ===== FOLLOW 알림 (source_id = follow.id, domain_id = null) =====
+    (10, 'mem-003', 'mem-001', 201, NULL, 'FOLLOW', b'0', @now, @now),
+    (11, 'mem-003', 'mem-002', 202, NULL, 'FOLLOW', b'0', @now, @now),
+    (12, 'mem-001', 'mem-003', 203, NULL, 'FOLLOW', b'1', @now, @now),
+    (13, 'mem-002', 'mem-003', 204, NULL, 'FOLLOW', b'0', @now, @now),
 
-    (4, 'mem-003', 'mem-001', 104, '인생의 태도 한 문장', 'LIKE', '/book-stories/5', b'0', @now, @now),
+    -- ===== JOIN_CLUB 알림 (source_id = club_member.id, domain_id = club_id) =====
+    (14, 'mem-002', 'SYSTEM', 2, 1, 'JOIN_CLUB', b'0', @now, @now),
+    (15, 'mem-001', 'SYSTEM', 4, 2, 'JOIN_CLUB', b'0', @now, @now),
+    (16, 'mem-002', 'SYSTEM', 5, 2, 'JOIN_CLUB', b'1', @now, @now),
 
-    (5, 'mem-003', 'mem-001', 105, '불의 잔 4권 포인트', 'LIKE', '/book-stories/7', b'0', @now, @now),
+    -- ===== CLUB_MEETING_CREATED 알림 (source_id = meeting.id, domain_id = club_id) =====
+    (17, 'mem-001', 'SYSTEM', 1, 1, 'CLUB_MEETING_CREATED', b'0', @now, @now),
+    (18, 'mem-002', 'SYSTEM', 1, 1, 'CLUB_MEETING_CREATED', b'0', @now, @now),
+    (19, 'mem-001', 'SYSTEM', 2, 1, 'CLUB_MEETING_CREATED', b'1', @now, @now),
+    (20, 'mem-002', 'SYSTEM', 2, 1, 'CLUB_MEETING_CREATED', b'0', @now, @now),
+    (21, 'mem-001', 'SYSTEM', 3, 2, 'CLUB_MEETING_CREATED', b'0', @now, @now),
+    (22, 'mem-002', 'SYSTEM', 3, 2, 'CLUB_MEETING_CREATED', b'0', @now, @now),
 
-    (6, 'mem-003', 'mem-002', 106, '불의 잔 4권 포인트', 'LIKE', '/book-stories/7', b'1', @now, @now),
-
-    -- ===== FOLLOW 알림 (follow 기반) =====
-    (7, 'mem-003', 'mem-001', 201, '테스터1', 'FOLLOW', '/members/mem-001', b'0', @now, @now),
-
-    (8, 'mem-003', 'mem-002', 202, '테스터2', 'FOLLOW', '/members/mem-002', b'0', @now, @now),
-
-    (9, 'mem-001', 'mem-003', 203, '어드민1', 'FOLLOW', '/members/mem-003', b'1', @now, @now),
-
-    (10, 'mem-002', 'mem-003', 204, '어드민1', 'FOLLOW', '/members/mem-003', b'0', @now, @now),
-
-    -- ===== JOIN_CLUB 알림 (가입 승인 가정) =====
-    (11, 'mem-002', 'mem-001', 2, '서울 독서모임', 'JOIN_CLUB', '/clubs/1', b'0', @now, @now),
-
-    (12, 'mem-001', 'mem-003', 4, '에세이 살롱', 'JOIN_CLUB', '/clubs/2', b'0', @now, @now),
-
-    (13, 'mem-002', 'mem-003', 5, '에세이 살롱', 'JOIN_CLUB', '/clubs/2', b'1', @now, @now);
+    -- ===== CLUB_NOTICE_CREATED 알림 (source_id = notice.id, domain_id = club_id) =====
+    (23, 'mem-001', 'SYSTEM', 4, 1, 'CLUB_NOTICE_CREATED', b'0', @now, @now),
+    (24, 'mem-002', 'SYSTEM', 4, 1, 'CLUB_NOTICE_CREATED', b'0', @now, @now),
+    (25, 'mem-001', 'SYSTEM', 5, 2, 'CLUB_NOTICE_CREATED', b'1', @now, @now),
+    (26, 'mem-002', 'SYSTEM', 5, 2, 'CLUB_NOTICE_CREATED', b'0', @now, @now);


### PR DESCRIPTION
## 🚀 변경사항
책이야기에 조회 수 기능을 추가했습니다.
-> 이때 redis를 활용해서 redis에 조회 건수를 카운트 해놓고 서버 내부에서 스케쥴러를 통해 1분에 한번씩 update 쿼리를 날리게 구현했습니다.
책 ID로 책 이야기를 검색할 수 있는 기능을 추가했습니다.
책이야기, 책이야기 댓글 삭제 기능을 구현했습니다.
-> 책이야기 댓글의 경우 삭제 시 soft delete를 적용했습니다.
-> 회원이 탈퇴 했을 경우에는 해당 회원이 작성한 책이야기, 책이야기 댓글들을 모두 soft delete 처리하도록 했습니다.
책이야기 상세 보기 페이지에서 작성자가 작성한 책이야기 기준으로 이전 책이야기, 다음 책이야기 id를 응답 dto에 포함시켰습니다.

## 🔗 관련 이슈
- Closes #143 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료
