### PR TITLE
[FEAT] 소식 추가

### DIFF
--- a/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
+++ b/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -21,6 +22,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 

--- a/src/main/java/checkmo/news/internal/converter/NewsConverter.java
+++ b/src/main/java/checkmo/news/internal/converter/NewsConverter.java
@@ -33,6 +33,18 @@ public class NewsConverter {
                 .build();
     }
 
+    public static NewsResponseDTO.DetailInfo toDetailInfo(News news) {
+        return NewsResponseDTO.DetailInfo.builder()
+                .newsId(news.getId())
+                .title(news.getTitle())
+                .content(news.getContent())
+                .thumbnailUrl(news.getThumbnailUrl())
+                .originalLink(news.getOriginalLink())
+                .imageUrls(news.getImageUrls())
+                .publishStartAt(news.getPublishStartAt())
+                .build();
+    }
+
     private static String truncateDescription(String content) {
         if (content == null) {
             return null;

--- a/src/main/java/checkmo/news/internal/converter/NewsConverter.java
+++ b/src/main/java/checkmo/news/internal/converter/NewsConverter.java
@@ -45,6 +45,32 @@ public class NewsConverter {
                 .build();
     }
 
+    public static NewsResponseDTO.AdminBasicInfo toAdminBasicInfo(News news) {
+        return NewsResponseDTO.AdminBasicInfo.builder()
+                .newsId(news.getId())
+                .title(news.getTitle())
+                .requesterEmail(news.getRequesterEmail())
+                .createdAt(news.getCreatedAt().toLocalDate())
+                .publishStartAt(news.getPublishStartAt())
+                .publishEndAt(news.getPublishEndAt())
+                .build();
+    }
+
+    public static NewsResponseDTO.AdminDetailInfo toAdminDetailInfo(News news) {
+        return NewsResponseDTO.AdminDetailInfo.builder()
+                .newsId(news.getId())
+                .title(news.getTitle())
+                .requesterEmail(news.getRequesterEmail())
+                .content(news.getContent())
+                .thumbnailUrl(news.getThumbnailUrl())
+                .originalLink(news.getOriginalLink())
+                .imageUrls(news.getImageUrls())
+                .createdAt(news.getCreatedAt().toLocalDate())
+                .publishStartAt(news.getPublishStartAt())
+                .publishEndAt(news.getPublishEndAt())
+                .build();
+    }
+
     private static String truncateDescription(String content) {
         if (content == null) {
             return null;

--- a/src/main/java/checkmo/news/internal/converter/NewsConverter.java
+++ b/src/main/java/checkmo/news/internal/converter/NewsConverter.java
@@ -1,0 +1,22 @@
+package checkmo.news.internal.converter;
+
+import checkmo.news.internal.entity.News;
+import checkmo.news.web.dto.NewsRequestDTO;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NewsConverter {
+
+    public static News toNews(NewsRequestDTO.CreateNews request) {
+        return News.builder()
+                .title(request.getTitle())
+                .requesterEmail(request.getRequesterEmail())
+                .content(request.getContent())
+                .thumbnailUrl(request.getThumbnailUrl())
+                .originalLink(request.getOriginalLink())
+                .publishStartAt(request.getPublishStartAt())
+                .publishEndAt(request.getPublishEndAt())
+                .build();
+    }
+}

--- a/src/main/java/checkmo/news/internal/converter/NewsConverter.java
+++ b/src/main/java/checkmo/news/internal/converter/NewsConverter.java
@@ -2,11 +2,14 @@ package checkmo.news.internal.converter;
 
 import checkmo.news.internal.entity.News;
 import checkmo.news.web.dto.NewsRequestDTO;
+import checkmo.news.web.dto.NewsResponseDTO;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NewsConverter {
+
+    private static final int DESCRIPTION_MAX_LENGTH = 30;
 
     public static News toNews(NewsRequestDTO.CreateNews request) {
         return News.builder()
@@ -18,5 +21,25 @@ public class NewsConverter {
                 .publishStartAt(request.getPublishStartAt())
                 .publishEndAt(request.getPublishEndAt())
                 .build();
+    }
+
+    public static NewsResponseDTO.BasicInfo toBasicInfo(News news) {
+        return NewsResponseDTO.BasicInfo.builder()
+                .newsId(news.getId())
+                .title(news.getTitle())
+                .description(truncateDescription(news.getContent()))
+                .thumbnailUrl(news.getThumbnailUrl())
+                .publishStartAt(news.getPublishStartAt())
+                .build();
+    }
+
+    private static String truncateDescription(String content) {
+        if (content == null) {
+            return null;
+        }
+        if (content.length() <= DESCRIPTION_MAX_LENGTH) {
+            return content;
+        }
+        return content.substring(0, DESCRIPTION_MAX_LENGTH);
     }
 }

--- a/src/main/java/checkmo/news/internal/entity/News.java
+++ b/src/main/java/checkmo/news/internal/entity/News.java
@@ -115,4 +115,8 @@ public class News extends BaseEntity {
         this.publishStartAt = publishStartAt;
         this.publishEndAt = publishEndAt;
     }
+
+    public boolean isPublished(LocalDate today) {
+        return !today.isBefore(publishStartAt) && !today.isAfter(publishEndAt);
+    }
 }

--- a/src/main/java/checkmo/news/internal/entity/News.java
+++ b/src/main/java/checkmo/news/internal/entity/News.java
@@ -1,0 +1,97 @@
+package checkmo.news.internal.entity;
+
+import checkmo.common.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class News extends BaseEntity {
+
+    private static final int MAX_IMAGE_COUNT = 5;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 40)
+    private String title;
+
+    private String requesterEmail;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(length = 500)
+    private String thumbnailUrl;
+
+    @Column(length = 500)
+    private String originalLink;
+
+    @Column(nullable = false)
+    private LocalDate publishStartAt;
+
+    @Column(nullable = false)
+    private LocalDate publishEndAt;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "news", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
+    private List<NewsImage> images = new ArrayList<>();
+
+    // ========== 이미지 ==========
+    public List<String> replaceImages(List<String> imageUrls) {
+        if (imageUrls == null) {
+            return List.of();
+        }
+
+        if (imageUrls.size() > MAX_IMAGE_COUNT) {
+            throw new IllegalArgumentException("이미지는 최대 " + MAX_IMAGE_COUNT + "개까지 등록 가능합니다.");
+        }
+
+        List<String> oldImages = getImageUrls();
+        List<String> removedImages = oldImages.stream()
+                .filter(url -> !imageUrls.contains(url))
+                .toList();
+
+        int commonSize = Math.min(this.images.size(), imageUrls.size());
+        for (int i = 0; i < commonSize; i++) {
+            this.images.get(i).update(imageUrls.get(i), i);
+        }
+
+        for (int i = commonSize; i < imageUrls.size(); i++) {
+            this.images.add(NewsImage.builder()
+                    .news(this)
+                    .imageUrl(imageUrls.get(i))
+                    .sortOrder(i)
+                    .build());
+        }
+
+        for (int i = this.images.size() - 1; i >= imageUrls.size(); i--) {
+            this.images.remove(i);
+        }
+
+        return removedImages;
+    }
+
+    public List<String> getImageUrls() {
+        return this.images.stream().map(NewsImage::getImageUrl).toList();
+    }
+}

--- a/src/main/java/checkmo/news/internal/entity/News.java
+++ b/src/main/java/checkmo/news/internal/entity/News.java
@@ -1,6 +1,8 @@
 package checkmo.news.internal.entity;
 
 import checkmo.common.BaseEntity;
+import checkmo.news.internal.exception.NewsErrorStatus;
+import checkmo.news.internal.exception.NewsException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -34,6 +36,7 @@ public class News extends BaseEntity {
     @Column(nullable = false, length = 40)
     private String title;
 
+    @Column(nullable = false)
     private String requesterEmail;
 
     @Column(nullable = false, columnDefinition = "TEXT")
@@ -63,7 +66,7 @@ public class News extends BaseEntity {
         }
 
         if (imageUrls.size() > MAX_IMAGE_COUNT) {
-            throw new IllegalArgumentException("이미지는 최대 " + MAX_IMAGE_COUNT + "개까지 등록 가능합니다.");
+            throw new NewsException(NewsErrorStatus.NEWS_IMAGE_LIMIT_EXCEEDED);
         }
 
         List<String> oldImages = getImageUrls();

--- a/src/main/java/checkmo/news/internal/entity/News.java
+++ b/src/main/java/checkmo/news/internal/entity/News.java
@@ -97,4 +97,22 @@ public class News extends BaseEntity {
     public List<String> getImageUrls() {
         return this.images.stream().map(NewsImage::getImageUrl).toList();
     }
+
+    public void update(
+            String title,
+            String requesterEmail,
+            String content,
+            String thumbnailUrl,
+            String originalLink,
+            LocalDate publishStartAt,
+            LocalDate publishEndAt
+    ) {
+        this.title = title;
+        this.requesterEmail = requesterEmail;
+        this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+        this.originalLink = originalLink;
+        this.publishStartAt = publishStartAt;
+        this.publishEndAt = publishEndAt;
+    }
 }

--- a/src/main/java/checkmo/news/internal/entity/NewsImage.java
+++ b/src/main/java/checkmo/news/internal/entity/NewsImage.java
@@ -1,0 +1,48 @@
+package checkmo.news.internal.entity;
+
+import checkmo.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(name = "uk_news_image_order", columnNames = {"news_id", "sort_order"})
+})
+public class NewsImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 500)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private int sortOrder;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id", nullable = false)
+    private News news;
+
+    public void update(String imageUrl, int sortOrder) {
+        this.imageUrl = imageUrl;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/checkmo/news/internal/exception/NewsErrorStatus.java
+++ b/src/main/java/checkmo/news/internal/exception/NewsErrorStatus.java
@@ -1,0 +1,38 @@
+package checkmo.news.internal.exception;
+
+import checkmo.common.apiPayload.code.BaseErrorCode;
+import checkmo.common.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NewsErrorStatus implements BaseErrorCode {
+
+    NEWS_NOT_FOUND(HttpStatus.NOT_FOUND, "NEWS_400", "소식을 찾을 수 없습니다."),
+    NEWS_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "NEWS_401", "소식 이미지는 최대 5개까지 등록 가능합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .httpStatus(httpStatus)
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+}

--- a/src/main/java/checkmo/news/internal/exception/NewsErrorStatus.java
+++ b/src/main/java/checkmo/news/internal/exception/NewsErrorStatus.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum NewsErrorStatus implements BaseErrorCode {
 
     NEWS_NOT_FOUND(HttpStatus.NOT_FOUND, "NEWS_400", "소식을 찾을 수 없습니다."),
-    NEWS_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "NEWS_401", "소식 이미지는 최대 5개까지 등록 가능합니다.");
+    NEWS_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "NEWS_401", "소식 이미지는 최대 5개까지 등록 가능합니다."),
+    NEWS_NOT_PUBLISHED(HttpStatus.NOT_FOUND, "NEWS_402", "현재 공개되지 않은 소식입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/checkmo/news/internal/exception/NewsErrorStatus.java
+++ b/src/main/java/checkmo/news/internal/exception/NewsErrorStatus.java
@@ -12,7 +12,8 @@ public enum NewsErrorStatus implements BaseErrorCode {
 
     NEWS_NOT_FOUND(HttpStatus.NOT_FOUND, "NEWS_400", "소식을 찾을 수 없습니다."),
     NEWS_IMAGE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "NEWS_401", "소식 이미지는 최대 5개까지 등록 가능합니다."),
-    NEWS_NOT_PUBLISHED(HttpStatus.NOT_FOUND, "NEWS_402", "현재 공개되지 않은 소식입니다.");
+    NEWS_NOT_PUBLISHED(HttpStatus.NOT_FOUND, "NEWS_402", "현재 공개되지 않은 소식입니다."),
+    INVALID_PUBLISH_RANGE(HttpStatus.BAD_REQUEST, "NEWS_403", "게시 시작일은 종료일보다 이전이어야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/checkmo/news/internal/exception/NewsException.java
+++ b/src/main/java/checkmo/news/internal/exception/NewsException.java
@@ -1,0 +1,10 @@
+package checkmo.news.internal.exception;
+
+import checkmo.common.apiPayload.code.BaseErrorCode;
+import checkmo.common.apiPayload.exception.GeneralException;
+
+public class NewsException extends GeneralException {
+    public NewsException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/checkmo/news/internal/repository/NewsQueryRepository.java
+++ b/src/main/java/checkmo/news/internal/repository/NewsQueryRepository.java
@@ -1,0 +1,8 @@
+package checkmo.news.internal.repository;
+
+import checkmo.news.internal.entity.News;
+import java.util.List;
+
+public interface NewsQueryRepository {
+    List<News> searchNews(Long cursorId, int pageSize);
+}

--- a/src/main/java/checkmo/news/internal/repository/NewsQueryRepository.java
+++ b/src/main/java/checkmo/news/internal/repository/NewsQueryRepository.java
@@ -5,4 +5,6 @@ import java.util.List;
 
 public interface NewsQueryRepository {
     List<News> searchNews(Long cursorId, int pageSize);
+
+    List<News> searchNewsForAdmin(Long cursorId, int pageSize);
 }

--- a/src/main/java/checkmo/news/internal/repository/NewsQueryRepositoryImpl.java
+++ b/src/main/java/checkmo/news/internal/repository/NewsQueryRepositoryImpl.java
@@ -31,6 +31,16 @@ public class NewsQueryRepositoryImpl implements NewsQueryRepository {
                 .fetch();
     }
 
+    @Override
+    public List<News> searchNewsForAdmin(Long cursorId, int pageSize) {
+        return queryFactory
+                .selectFrom(news)
+                .where(createCursorExp(cursorId))
+                .orderBy(news.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
     private BooleanExpression isPublished(LocalDate today) {
         return news.publishStartAt.loe(today)
                 .and(news.publishEndAt.goe(today));

--- a/src/main/java/checkmo/news/internal/repository/NewsQueryRepositoryImpl.java
+++ b/src/main/java/checkmo/news/internal/repository/NewsQueryRepositoryImpl.java
@@ -1,0 +1,42 @@
+package checkmo.news.internal.repository;
+
+import static checkmo.news.internal.entity.QNews.news;
+
+import checkmo.news.internal.entity.News;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class NewsQueryRepositoryImpl implements NewsQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<News> searchNews(Long cursorId, int pageSize) {
+        LocalDate today = LocalDate.now();
+
+        return queryFactory
+                .selectFrom(news)
+                .where(
+                        isPublished(today),
+                        createCursorExp(cursorId)
+                )
+                .orderBy(news.id.desc())
+                .limit(pageSize)
+                .fetch();
+    }
+
+    private BooleanExpression isPublished(LocalDate today) {
+        return news.publishStartAt.loe(today)
+                .and(news.publishEndAt.goe(today));
+    }
+
+    private BooleanExpression createCursorExp(Long cursorId) {
+        return cursorId != null ? news.id.lt(cursorId) : null;
+    }
+}

--- a/src/main/java/checkmo/news/internal/repository/NewsQueryRepositoryImpl.java
+++ b/src/main/java/checkmo/news/internal/repository/NewsQueryRepositoryImpl.java
@@ -6,6 +6,7 @@ import checkmo.news.internal.entity.News;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -18,7 +19,7 @@ public class NewsQueryRepositoryImpl implements NewsQueryRepository {
 
     @Override
     public List<News> searchNews(Long cursorId, int pageSize) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
         return queryFactory
                 .selectFrom(news)

--- a/src/main/java/checkmo/news/internal/repository/NewsRepository.java
+++ b/src/main/java/checkmo/news/internal/repository/NewsRepository.java
@@ -1,0 +1,7 @@
+package checkmo.news.internal.repository;
+
+import checkmo.news.internal.entity.News;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsRepository extends JpaRepository<News, Long> {
+}

--- a/src/main/java/checkmo/news/internal/repository/NewsRepository.java
+++ b/src/main/java/checkmo/news/internal/repository/NewsRepository.java
@@ -3,5 +3,5 @@ package checkmo.news.internal.repository;
 import checkmo.news.internal.entity.News;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NewsRepository extends JpaRepository<News, Long> {
+public interface NewsRepository extends JpaRepository<News, Long>, NewsQueryRepository {
 }

--- a/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
+++ b/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
@@ -4,8 +4,12 @@ import checkmo.common.template.CursorPagingHelper;
 import checkmo.common.template.CursorResult;
 import checkmo.news.internal.converter.NewsConverter;
 import checkmo.news.internal.entity.News;
+import checkmo.news.internal.exception.NewsErrorStatus;
+import checkmo.news.internal.exception.NewsException;
 import checkmo.news.internal.service.query.NewsQueryService;
 import checkmo.news.web.dto.NewsResponseDTO;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -43,6 +47,12 @@ public class NewsQueryFacade {
 
     public NewsResponseDTO.DetailInfo fetchNewsDetail(Long newsId) {
         News news = newsQueryService.retrieveNews(newsId);
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        if (!news.isPublished(today)) {
+            throw new NewsException(NewsErrorStatus.NEWS_NOT_PUBLISHED);
+        }
+
         return NewsConverter.toDetailInfo(news);
     }
 

--- a/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
+++ b/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
@@ -38,4 +38,9 @@ public class NewsQueryFacade {
                 .pageSize(DEFAULT_PAGE_SIZE)
                 .build();
     }
+
+    public NewsResponseDTO.DetailInfo fetchNewsDetail(Long newsId) {
+        News news = newsQueryService.retrieveNews(newsId);
+        return NewsConverter.toDetailInfo(news);
+    }
 }

--- a/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
+++ b/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
@@ -8,6 +8,7 @@ import checkmo.news.internal.service.query.NewsQueryService;
 import checkmo.news.web.dto.NewsResponseDTO;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NewsQueryFacade {
 
     public static final int DEFAULT_PAGE_SIZE = 10;
+    public static final int ADMIN_PAGE_SIZE = 12;
 
     private final NewsQueryService newsQueryService;
 
@@ -42,5 +44,25 @@ public class NewsQueryFacade {
     public NewsResponseDTO.DetailInfo fetchNewsDetail(Long newsId) {
         News news = newsQueryService.retrieveNews(newsId);
         return NewsConverter.toDetailInfo(news);
+    }
+
+    public NewsResponseDTO.AdminNewsList fetchNewsListForAdmin(int page) {
+        Page<News> newsPage = newsQueryService.retrieveNewsPageForAdmin(page, ADMIN_PAGE_SIZE);
+
+        List<NewsResponseDTO.AdminBasicInfo> basicInfoList = newsPage.getContent().stream()
+                .map(NewsConverter::toAdminBasicInfo)
+                .toList();
+
+        return NewsResponseDTO.AdminNewsList.builder()
+                .basicInfoList(basicInfoList)
+                .page(page)
+                .totalPages(newsPage.getTotalPages())
+                .totalElements(newsPage.getTotalElements())
+                .build();
+    }
+
+    public NewsResponseDTO.AdminDetailInfo fetchNewsDetailForAdmin(Long newsId) {
+        News news = newsQueryService.retrieveNews(newsId);
+        return NewsConverter.toAdminDetailInfo(news);
     }
 }

--- a/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
+++ b/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
@@ -1,0 +1,41 @@
+package checkmo.news.internal.service;
+
+import checkmo.common.template.CursorPagingHelper;
+import checkmo.common.template.CursorResult;
+import checkmo.news.internal.converter.NewsConverter;
+import checkmo.news.internal.entity.News;
+import checkmo.news.internal.service.query.NewsQueryService;
+import checkmo.news.web.dto.NewsResponseDTO;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NewsQueryFacade {
+
+    public static final int DEFAULT_PAGE_SIZE = 10;
+
+    private final NewsQueryService newsQueryService;
+
+    public NewsResponseDTO.NewsList fetchNewsList(Long cursorId) {
+        CursorResult<News> newsCursorResult = CursorPagingHelper.getPage(
+                (pageSize) -> newsQueryService.retrieveNewsList(cursorId, pageSize),
+                News::getId,
+                DEFAULT_PAGE_SIZE
+        );
+
+        List<NewsResponseDTO.BasicInfo> basicInfoList = newsCursorResult.content().stream()
+                .map(NewsConverter::toBasicInfo)
+                .toList();
+
+        return NewsResponseDTO.NewsList.builder()
+                .basicInfoList(basicInfoList)
+                .hasNext(newsCursorResult.hasNext())
+                .nextCursor(newsCursorResult.nextCursor())
+                .pageSize(DEFAULT_PAGE_SIZE)
+                .build();
+    }
+}

--- a/src/main/java/checkmo/news/internal/service/command/NewsCommandService.java
+++ b/src/main/java/checkmo/news/internal/service/command/NewsCommandService.java
@@ -6,6 +6,7 @@ import checkmo.news.internal.exception.NewsErrorStatus;
 import checkmo.news.internal.exception.NewsException;
 import checkmo.news.internal.repository.NewsRepository;
 import checkmo.news.web.dto.NewsRequestDTO;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,8 @@ public class NewsCommandService {
     private final NewsRepository newsRepository;
 
     public Long createNews(NewsRequestDTO.CreateNews request) {
+        validatePublishRange(request.getPublishStartAt(), request.getPublishEndAt());
+
         News news = NewsConverter.toNews(request);
         news.replaceImages(request.getImageUrls());
 
@@ -26,6 +29,8 @@ public class NewsCommandService {
     }
 
     public Long updateNews(Long newsId, NewsRequestDTO.UpdateNews request) {
+        validatePublishRange(request.getPublishStartAt(), request.getPublishEndAt());
+
         News news = newsRepository.findById(newsId)
                 .orElseThrow(() -> new NewsException(NewsErrorStatus.NEWS_NOT_FOUND));
 
@@ -48,5 +53,11 @@ public class NewsCommandService {
                 .orElseThrow(() -> new NewsException(NewsErrorStatus.NEWS_NOT_FOUND));
 
         newsRepository.delete(news);
+    }
+
+    private void validatePublishRange(LocalDate publishStartAt, LocalDate publishEndAt) {
+        if (publishStartAt != null && publishEndAt != null && publishStartAt.isAfter(publishEndAt)) {
+            throw new NewsException(NewsErrorStatus.INVALID_PUBLISH_RANGE);
+        }
     }
 }

--- a/src/main/java/checkmo/news/internal/service/command/NewsCommandService.java
+++ b/src/main/java/checkmo/news/internal/service/command/NewsCommandService.java
@@ -1,0 +1,25 @@
+package checkmo.news.internal.service.command;
+
+import checkmo.news.internal.converter.NewsConverter;
+import checkmo.news.internal.entity.News;
+import checkmo.news.internal.repository.NewsRepository;
+import checkmo.news.web.dto.NewsRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NewsCommandService {
+
+    private final NewsRepository newsRepository;
+
+    public Long createNews(NewsRequestDTO.CreateNews request) {
+        News news = NewsConverter.toNews(request);
+        news.replaceImages(request.getImageUrls());
+
+        News savedNews = newsRepository.save(news);
+        return savedNews.getId();
+    }
+}

--- a/src/main/java/checkmo/news/internal/service/command/NewsCommandService.java
+++ b/src/main/java/checkmo/news/internal/service/command/NewsCommandService.java
@@ -22,9 +22,9 @@ public class NewsCommandService {
         validatePublishRange(request.getPublishStartAt(), request.getPublishEndAt());
 
         News news = NewsConverter.toNews(request);
-        news.replaceImages(request.getImageUrls());
-
         News savedNews = newsRepository.save(news);
+        savedNews.replaceImages(request.getImageUrls());
+
         return savedNews.getId();
     }
 

--- a/src/main/java/checkmo/news/internal/service/command/NewsCommandService.java
+++ b/src/main/java/checkmo/news/internal/service/command/NewsCommandService.java
@@ -2,6 +2,8 @@ package checkmo.news.internal.service.command;
 
 import checkmo.news.internal.converter.NewsConverter;
 import checkmo.news.internal.entity.News;
+import checkmo.news.internal.exception.NewsErrorStatus;
+import checkmo.news.internal.exception.NewsException;
 import checkmo.news.internal.repository.NewsRepository;
 import checkmo.news.web.dto.NewsRequestDTO;
 import lombok.RequiredArgsConstructor;
@@ -21,5 +23,30 @@ public class NewsCommandService {
 
         News savedNews = newsRepository.save(news);
         return savedNews.getId();
+    }
+
+    public Long updateNews(Long newsId, NewsRequestDTO.UpdateNews request) {
+        News news = newsRepository.findById(newsId)
+                .orElseThrow(() -> new NewsException(NewsErrorStatus.NEWS_NOT_FOUND));
+
+        news.update(
+                request.getTitle(),
+                request.getRequesterEmail(),
+                request.getContent(),
+                request.getThumbnailUrl(),
+                request.getOriginalLink(),
+                request.getPublishStartAt(),
+                request.getPublishEndAt()
+        );
+        news.replaceImages(request.getImageUrls());
+
+        return news.getId();
+    }
+
+    public void deleteNews(Long newsId) {
+        News news = newsRepository.findById(newsId)
+                .orElseThrow(() -> new NewsException(NewsErrorStatus.NEWS_NOT_FOUND));
+
+        newsRepository.delete(news);
     }
 }

--- a/src/main/java/checkmo/news/internal/service/query/NewsQueryService.java
+++ b/src/main/java/checkmo/news/internal/service/query/NewsQueryService.java
@@ -6,6 +6,10 @@ import checkmo.news.internal.exception.NewsException;
 import checkmo.news.internal.repository.NewsRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +22,15 @@ public class NewsQueryService {
 
     public List<News> retrieveNewsList(Long cursorId, int pageSize) {
         return newsRepository.searchNews(cursorId, pageSize);
+    }
+
+    public List<News> retrieveNewsListForAdmin(Long cursorId, int pageSize) {
+        return newsRepository.searchNewsForAdmin(cursorId, pageSize);
+    }
+
+    public Page<News> retrieveNewsPageForAdmin(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+        return newsRepository.findAll(pageable);
     }
 
     public News retrieveNews(Long newsId) {

--- a/src/main/java/checkmo/news/internal/service/query/NewsQueryService.java
+++ b/src/main/java/checkmo/news/internal/service/query/NewsQueryService.java
@@ -1,6 +1,8 @@
 package checkmo.news.internal.service.query;
 
 import checkmo.news.internal.entity.News;
+import checkmo.news.internal.exception.NewsErrorStatus;
+import checkmo.news.internal.exception.NewsException;
 import checkmo.news.internal.repository.NewsRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,5 +18,10 @@ public class NewsQueryService {
 
     public List<News> retrieveNewsList(Long cursorId, int pageSize) {
         return newsRepository.searchNews(cursorId, pageSize);
+    }
+
+    public News retrieveNews(Long newsId) {
+        return newsRepository.findById(newsId)
+                .orElseThrow(() -> new NewsException(NewsErrorStatus.NEWS_NOT_FOUND));
     }
 }

--- a/src/main/java/checkmo/news/internal/service/query/NewsQueryService.java
+++ b/src/main/java/checkmo/news/internal/service/query/NewsQueryService.java
@@ -1,0 +1,20 @@
+package checkmo.news.internal.service.query;
+
+import checkmo.news.internal.entity.News;
+import checkmo.news.internal.repository.NewsRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NewsQueryService {
+
+    private final NewsRepository newsRepository;
+
+    public List<News> retrieveNewsList(Long cursorId, int pageSize) {
+        return newsRepository.searchNews(cursorId, pageSize);
+    }
+}

--- a/src/main/java/checkmo/news/package-info.java
+++ b/src/main/java/checkmo/news/package-info.java
@@ -1,4 +1,4 @@
 @org.springframework.modulith.ApplicationModule(
-        allowedDependencies = {"authentication", "book", "common", "member"}
+        allowedDependencies = {"authentication", "common", "member"}
 )
 package checkmo.news;

--- a/src/main/java/checkmo/news/package-info.java
+++ b/src/main/java/checkmo/news/package-info.java
@@ -1,0 +1,4 @@
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {"authentication", "book", "common", "member"}
+)
+package checkmo.news;

--- a/src/main/java/checkmo/news/web/controller/NewsAdminController.java
+++ b/src/main/java/checkmo/news/web/controller/NewsAdminController.java
@@ -1,0 +1,103 @@
+package checkmo.news.web.controller;
+
+import checkmo.common.apiPayload.ApiResponse;
+import checkmo.news.internal.service.NewsQueryFacade;
+import checkmo.news.internal.service.command.NewsCommandService;
+import checkmo.news.web.dto.NewsRequestDTO;
+import checkmo.news.web.dto.NewsResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/news")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "소식 (관리자)", description = "소식 등록, 수정, 삭제 API (관리자 전용)")
+public class NewsAdminController {
+
+    private final NewsCommandService newsCommandService;
+    private final NewsQueryFacade newsQueryFacade;
+
+    @Operation(summary = "소식 목록 조회 (관리자)", description = "모든 소식 목록을 조회합니다. (게시 기간 관계없이, 페이지당 12개)")
+    @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", required = false, example = "0")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.")
+    })
+    @GetMapping
+    public ApiResponse<NewsResponseDTO.AdminNewsList> getNewsListForAdmin(
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        NewsResponseDTO.AdminNewsList newsList = newsQueryFacade.fetchNewsListForAdmin(page);
+        return ApiResponse.onSuccess(newsList);
+    }
+
+    @Operation(summary = "소식 상세 조회 (관리자)", description = "소식의 모든 상세 정보를 조회합니다.")
+    @Parameter(name = "newsId", description = "조회할 소식 ID", required = true, example = "1")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "소식을 찾을 수 없습니다.")
+    })
+    @GetMapping("/{newsId}")
+    public ApiResponse<NewsResponseDTO.AdminDetailInfo> getNewsForAdmin(@PathVariable Long newsId) {
+        NewsResponseDTO.AdminDetailInfo detailInfo = newsQueryFacade.fetchNewsDetailForAdmin(newsId);
+        return ApiResponse.onSuccess(detailInfo);
+    }
+
+    @Operation(summary = "소식 등록", description = "관리자만 소식을 등록할 수 있습니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.")
+    })
+    @PostMapping
+    public ApiResponse<Long> createNews(@Valid @RequestBody NewsRequestDTO.CreateNews request) {
+        Long newsId = newsCommandService.createNews(request);
+        return ApiResponse.onSuccess(newsId);
+    }
+
+    @Operation(summary = "소식 수정", description = "관리자만 소식을 수정할 수 있습니다.")
+    @Parameter(name = "newsId", description = "수정할 소식 ID", required = true, example = "1")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "소식을 찾을 수 없습니다.")
+    })
+    @PatchMapping("/{newsId}")
+    public ApiResponse<Long> updateNews(
+            @PathVariable Long newsId,
+            @Valid @RequestBody NewsRequestDTO.UpdateNews request
+    ) {
+        Long updatedNewsId = newsCommandService.updateNews(newsId, request);
+        return ApiResponse.onSuccess(updatedNewsId);
+    }
+
+    @Operation(summary = "소식 삭제", description = "관리자만 소식을 삭제할 수 있습니다.")
+    @Parameter(name = "newsId", description = "삭제할 소식 ID", required = true, example = "1")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "소식을 찾을 수 없습니다.")
+    })
+    @DeleteMapping("/{newsId}")
+    public ApiResponse<String> deleteNews(@PathVariable Long newsId) {
+        newsCommandService.deleteNews(newsId);
+        return ApiResponse.onSuccess("소식이 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/checkmo/news/web/controller/NewsController.java
+++ b/src/main/java/checkmo/news/web/controller/NewsController.java
@@ -1,0 +1,42 @@
+package checkmo.news.web.controller;
+
+import checkmo.common.apiPayload.ApiResponse;
+import checkmo.news.internal.service.command.NewsCommandService;
+import checkmo.news.web.dto.NewsRequestDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/news")
+@RequiredArgsConstructor
+@Tag(name = "소식", description = "소식 업로드, 조회 API")
+public class NewsController {
+
+    private final NewsCommandService newsCommandService;
+
+    @Operation(summary = "소식 등록", description = "관리자만 소식을 등록할 수 있습니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.")
+    })
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public ApiResponse<Long> createNews(
+            @Valid @RequestBody NewsRequestDTO.CreateNews request
+    ) {
+        Long newsId = newsCommandService.createNews(request);
+        return ApiResponse.onSuccess(newsId);
+    }
+
+    // 소식 조회 API
+
+    // 소식 상세 조회 API
+}

--- a/src/main/java/checkmo/news/web/controller/NewsController.java
+++ b/src/main/java/checkmo/news/web/controller/NewsController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,9 +36,7 @@ public class NewsController {
     })
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
-    public ApiResponse<Long> createNews(
-            @Valid @RequestBody NewsRequestDTO.CreateNews request
-    ) {
+    public ApiResponse<Long> createNews(@Valid @RequestBody NewsRequestDTO.CreateNews request) {
         Long newsId = newsCommandService.createNews(request);
         return ApiResponse.onSuccess(newsId);
     }
@@ -51,12 +50,23 @@ public class NewsController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류가 발생했습니다.")
     })
     @GetMapping
-    public ApiResponse<NewsResponseDTO.NewsList> getNewsList(
-            @RequestParam(required = false) Long cursorId
-    ) {
+    public ApiResponse<NewsResponseDTO.NewsList> getNewsList(@RequestParam(required = false) Long cursorId) {
         NewsResponseDTO.NewsList newsList = newsQueryFacade.fetchNewsList(cursorId);
         return ApiResponse.onSuccess(newsList);
     }
 
-    // 소식 상세 조회 API
+    @Operation(summary = "소식 상세 조회", description = "특정 소식의 상세 정보를 조회합니다.")
+    @Parameter(name = "newsId", description = "조회할 소식 ID", required = true, example = "1")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "소식을 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류가 발생했습니다.")
+    })
+    @GetMapping("/{newsId}")
+    public ApiResponse<NewsResponseDTO.DetailInfo> getNews(@PathVariable Long newsId) {
+        NewsResponseDTO.DetailInfo detailInfo = newsQueryFacade.fetchNewsDetail(newsId);
+        return ApiResponse.onSuccess(detailInfo);
+    }
 }

--- a/src/main/java/checkmo/news/web/controller/NewsController.java
+++ b/src/main/java/checkmo/news/web/controller/NewsController.java
@@ -1,16 +1,21 @@
 package checkmo.news.web.controller;
 
 import checkmo.common.apiPayload.ApiResponse;
+import checkmo.news.internal.service.NewsQueryFacade;
 import checkmo.news.internal.service.command.NewsCommandService;
 import checkmo.news.web.dto.NewsRequestDTO;
+import checkmo.news.web.dto.NewsResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -20,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class NewsController {
 
     private final NewsCommandService newsCommandService;
+    private final NewsQueryFacade newsQueryFacade;
 
     @Operation(summary = "소식 등록", description = "관리자만 소식을 등록할 수 있습니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponses({
@@ -36,7 +42,21 @@ public class NewsController {
         return ApiResponse.onSuccess(newsId);
     }
 
-    // 소식 조회 API
+    @Operation(summary = "소식 조회", description = "공개 기간 내의 소식 목록을 조회합니다.")
+    @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "1")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류가 발생했습니다.")
+    })
+    @GetMapping
+    public ApiResponse<NewsResponseDTO.NewsList> getNewsList(
+            @RequestParam(required = false) Long cursorId
+    ) {
+        NewsResponseDTO.NewsList newsList = newsQueryFacade.fetchNewsList(cursorId);
+        return ApiResponse.onSuccess(newsList);
+    }
 
     // 소식 상세 조회 API
 }

--- a/src/main/java/checkmo/news/web/controller/NewsController.java
+++ b/src/main/java/checkmo/news/web/controller/NewsController.java
@@ -2,44 +2,24 @@ package checkmo.news.web.controller;
 
 import checkmo.common.apiPayload.ApiResponse;
 import checkmo.news.internal.service.NewsQueryFacade;
-import checkmo.news.internal.service.command.NewsCommandService;
-import checkmo.news.web.dto.NewsRequestDTO;
 import checkmo.news.web.dto.NewsResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/news")
 @RequiredArgsConstructor
-@Tag(name = "소식", description = "소식 업로드, 조회 API")
+@Tag(name = "소식", description = "소식 조회 API")
 public class NewsController {
 
-    private final NewsCommandService newsCommandService;
     private final NewsQueryFacade newsQueryFacade;
-
-    @Operation(summary = "소식 등록", description = "관리자만 소식을 등록할 수 있습니다.")
-    @io.swagger.v3.oas.annotations.responses.ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.")
-    })
-    @PreAuthorize("hasRole('ADMIN')")
-    @PostMapping
-    public ApiResponse<Long> createNews(@Valid @RequestBody NewsRequestDTO.CreateNews request) {
-        Long newsId = newsCommandService.createNews(request);
-        return ApiResponse.onSuccess(newsId);
-    }
 
     @Operation(summary = "소식 조회", description = "공개 기간 내의 소식 목록을 조회합니다.")
     @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "1")

--- a/src/main/java/checkmo/news/web/dto/NewsRequestDTO.java
+++ b/src/main/java/checkmo/news/web/dto/NewsRequestDTO.java
@@ -1,0 +1,38 @@
+package checkmo.news.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class NewsRequestDTO {
+
+    @Getter
+    @NoArgsConstructor
+    public static class CreateNews {
+        @NotBlank(message = "소식 제목은 필수입니다.")
+        @Size(max = 40, message = "소식 제목은 40자 이하로 입력해주세요.")
+        private String title;
+
+        private String requesterEmail;
+
+        @NotBlank(message = "소식 내용은 필수입니다.")
+        private String content;
+
+        private String thumbnailUrl;
+
+        private String originalLink;
+
+        @NotNull(message = "게시 시작일은 필수입니다.")
+        private LocalDate publishStartAt;
+
+        @NotNull(message = "게시 종료일은 필수입니다.")
+        private LocalDate publishEndAt;
+
+        @Size(max = 5, message = "기타 이미지는 최대 5개까지 가능합니다.")
+        private List<@NotBlank(message = "이미지 URL은 비어있을 수 없습니다.") String> imageUrls;
+    }
+}

--- a/src/main/java/checkmo/news/web/dto/NewsRequestDTO.java
+++ b/src/main/java/checkmo/news/web/dto/NewsRequestDTO.java
@@ -35,4 +35,30 @@ public class NewsRequestDTO {
         @Size(max = 5, message = "기타 이미지는 최대 5개까지 가능합니다.")
         private List<@NotBlank(message = "이미지 URL은 비어있을 수 없습니다.") String> imageUrls;
     }
+
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateNews {
+        @NotBlank(message = "소식 제목은 필수입니다.")
+        @Size(max = 40, message = "소식 제목은 40자 이하로 입력해주세요.")
+        private String title;
+
+        private String requesterEmail;
+
+        @NotBlank(message = "소식 내용은 필수입니다.")
+        private String content;
+
+        private String thumbnailUrl;
+
+        private String originalLink;
+
+        @NotNull(message = "게시 시작일은 필수입니다.")
+        private LocalDate publishStartAt;
+
+        @NotNull(message = "게시 종료일은 필수입니다.")
+        private LocalDate publishEndAt;
+
+        @Size(max = 5, message = "기타 이미지는 최대 5개까지 가능합니다.")
+        private List<@NotBlank(message = "이미지 URL은 비어있을 수 없습니다.") String> imageUrls;
+    }
 }

--- a/src/main/java/checkmo/news/web/dto/NewsRequestDTO.java
+++ b/src/main/java/checkmo/news/web/dto/NewsRequestDTO.java
@@ -17,6 +17,7 @@ public class NewsRequestDTO {
         @Size(max = 40, message = "소식 제목은 40자 이하로 입력해주세요.")
         private String title;
 
+        @NotBlank(message = "요청자 이메일은 필수입니다.")
         private String requesterEmail;
 
         @NotBlank(message = "소식 내용은 필수입니다.")
@@ -43,6 +44,7 @@ public class NewsRequestDTO {
         @Size(max = 40, message = "소식 제목은 40자 이하로 입력해주세요.")
         private String title;
 
+        @NotBlank(message = "요청자 이메일은 필수입니다.")
         private String requesterEmail;
 
         @NotBlank(message = "소식 내용은 필수입니다.")

--- a/src/main/java/checkmo/news/web/dto/NewsResponseDTO.java
+++ b/src/main/java/checkmo/news/web/dto/NewsResponseDTO.java
@@ -34,4 +34,20 @@ public class NewsResponseDTO {
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
         private LocalDate publishStartAt;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class DetailInfo {
+        private Long newsId;
+        private String title;
+        private String content;
+        private String thumbnailUrl;
+        private String originalLink;
+        private List<String> imageUrls;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate publishStartAt;
+    }
 }

--- a/src/main/java/checkmo/news/web/dto/NewsResponseDTO.java
+++ b/src/main/java/checkmo/news/web/dto/NewsResponseDTO.java
@@ -1,0 +1,37 @@
+package checkmo.news.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class NewsResponseDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class NewsList {
+        private List<BasicInfo> basicInfoList;
+        private boolean hasNext;
+        private Long nextCursor;
+        private int pageSize;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class BasicInfo {
+        private Long newsId;
+        private String title;
+        private String description;
+        private String thumbnailUrl;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate publishStartAt;
+    }
+}

--- a/src/main/java/checkmo/news/web/dto/NewsResponseDTO.java
+++ b/src/main/java/checkmo/news/web/dto/NewsResponseDTO.java
@@ -50,4 +50,57 @@ public class NewsResponseDTO {
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
         private LocalDate publishStartAt;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AdminNewsList {
+        private List<AdminBasicInfo> basicInfoList;
+        private int page;
+        private int totalPages;
+        private long totalElements;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AdminBasicInfo {
+        private Long newsId;
+        private String title;
+        private String requesterEmail;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate createdAt;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate publishStartAt;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate publishEndAt;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AdminDetailInfo {
+        private Long newsId;
+        private String title;
+        private String requesterEmail;
+        private String content;
+        private String thumbnailUrl;
+        private String originalLink;
+        private List<String> imageUrls;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate createdAt;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate publishStartAt;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        private LocalDate publishEndAt;
+    }
 }

--- a/src/main/resources/db/migration/V20260123_1__create_news_and_news_image_tables.sql
+++ b/src/main/resources/db/migration/V20260123_1__create_news_and_news_image_tables.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS news (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    title VARCHAR(40) NOT NULL,
+    requester_email VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    thumbnail_url VARCHAR(500),
+    original_link VARCHAR(500),
+    publish_start_at DATE NOT NULL,
+    publish_end_at DATE NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS news_image (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    news_id BIGINT NOT NULL,
+    image_url VARCHAR(500) NOT NULL,
+    sort_order INT NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_news_image_news FOREIGN KEY (news_id) REFERENCES news(id),
+    UNIQUE KEY uk_news_image_order (news_id, sort_order)
+);

--- a/src/main/resources/db/seed/local/V20260122_3__insert_local_seed.sql
+++ b/src/main/resources/db/seed/local/V20260122_3__insert_local_seed.sql
@@ -243,31 +243,32 @@ VALUES
 -- =========================
 -- 17) vote
 -- =========================
-INSERT INTO vote (id, club_id, title, content, tag, important, anonymity, duplication, start_time, deadline,
-                  item1, item2, item3, item4, item5, created_at, updated_at)
+INSERT INTO vote (id, title, content, anonymity, duplication, start_time, deadline,
+                  item1, item2, item3, item4, item5, item6, created_at, updated_at)
 VALUES
-    (1, 1, '다음 모임 시간 투표', '선호 시간을 골라주세요', 'VOTE', b'1', b'0', b'0',
+    (1, '다음 모임 시간 투표', '선호 시간을 골라주세요', b'0', b'0',
      @now, DATE_ADD(@now, INTERVAL 14 DAY),
-     '토요일 오전', '토요일 오후', '일요일 오전', NULL, NULL, @now, @now);
+     '토요일 오전', '토요일 오후', '일요일 오전', NULL, NULL, NULL, @now, @now);
 
 -- =========================
 -- 18) club_member_vote
 -- =========================
-INSERT INTO club_member_vote (vote_id, club_member_id, item1, item2, item3, item4, item5)
+INSERT INTO club_member_vote (vote_id, club_member_id, item1, item2, item3, item4, item5, item6, created_at, updated_at)
 VALUES
-    (1, 1, b'1', b'0', b'0', b'0', b'0'),
-    (1, 2, b'0', b'1', b'0', b'0', b'0');
+    (1, 1, b'1', b'0', b'0', b'0', b'0', b'0', @now, @now),
+    (1, 2, b'0', b'1', b'0', b'0', b'0', b'0', @now, @now);
 
 -- =========================
 -- 19) notice
 -- =========================
-INSERT INTO notice (id, club_id, meeting_id, meeting_version, title, content, tag, important, created_at, updated_at)
+INSERT INTO notice (id, club_id, meeting_id, vote_id, title, content, tag, important, created_at, updated_at)
 VALUES
-    (1, 1, 1, 1, '[모임공지] 살인자ㅇ난감 함께 읽기', '모임 정보가 생성되었습니다. 장소/시간 확인 후 참여 부탁드려요.', 'MEETING', b'1', @now, @now),
-    (2, 1, 2, 1, '[모임공지] 거인의 어깨 1 스터디',  '모임 정보가 생성되었습니다. 토론 주제는 투자 철학 요약/비교입니다.', 'MEETING', b'1', @now, @now),
-    (3, 2, 3, 1, '[모임공지] 인생의 태도 모임',      '좋아하는 문장을 한 문장씩 공유하는 방식으로 진행합니다.',         'MEETING', b'1', @now, @now),
-    (4, 1, NULL, 1, '[공지] 모임 규칙', '장소/시간 확인 부탁드립니다.', 'NOTICE', b'1', @now, @now),
-    (5, 2, NULL, 1, '발제 자료 공유',         '발제 예제 링크를 공유합니다.', 'NOTICE', b'0', @now, @now);
+    (1, 1, 1, NULL, '[모임공지] 살인자ㅇ난감 함께 읽기', '모임 정보가 생성되었습니다. 장소/시간 확인 후 참여 부탁드려요.', 'MEETING', b'1', @now, @now),
+    (2, 1, 2, NULL, '[모임공지] 거인의 어깨 1 스터디',  '모임 정보가 생성되었습니다. 토론 주제는 투자 철학 요약/비교입니다.', 'MEETING', b'1', @now, @now),
+    (3, 2, 3, NULL, '[모임공지] 인생의 태도 모임',      '좋아하는 문장을 한 문장씩 공유하는 방식으로 진행합니다.',         'MEETING', b'1', @now, @now),
+    (4, 1, NULL, NULL, '[공지] 모임 규칙', '장소/시간 확인 부탁드립니다.', 'GENERAL', b'1', @now, @now),
+    (5, 2, NULL, NULL, '발제 자료 공유',         '발제 예제 링크를 공유합니다.', 'GENERAL', b'0', @now, @now),
+    (6, 1, NULL, 1, '다음 모임 시간 투표', '선호 시간을 골라주세요', 'VOTE', b'1', @now, @now);
 
 -- =========================
 -- 20) notification

--- a/src/main/resources/db/seed/local/V20260123_2__insert_news_seed.sql
+++ b/src/main/resources/db/seed/local/V20260123_2__insert_news_seed.sql
@@ -1,0 +1,66 @@
+-- =========================
+-- News 테스트 데이터
+-- =========================
+SET @now := NOW(6);
+
+INSERT INTO news (id, title, requester_email, content, thumbnail_url, original_link, publish_start_at, publish_end_at, created_at, updated_at)
+VALUES
+    (1, '책모 앱 정식 출시 안내',
+     'admin@checkmo.local',
+     '안녕하세요, 책모입니다. 오랜 준비 끝에 드디어 책모 앱이 정식 출시되었습니다! 이제 더 편리하게 독서 모임을 관리하고, 책 이야기를 나눌 수 있습니다. 많은 관심과 사랑 부탁드립니다.',
+     'https://images.unsplash.com/photo-1512820790803-83ca734da794?w=400',
+     'https://checkmo.local/news/1',
+     '2026-01-01', '2026-12-31',
+     @now, @now),
+
+    (2, '1월 독서 챌린지 이벤트',
+     'admin@checkmo.local',
+     '새해를 맞아 1월 독서 챌린지를 진행합니다! 이번 달 동안 책 5권을 읽고 책 이야기를 작성하시면 추첨을 통해 도서 상품권을 드립니다. 참여 방법: 1) 책 읽기 2) 책 이야기 작성 3) #1월챌린지 태그 달기',
+     'https://images.unsplash.com/photo-1507842217343-583bb7270b66?w=400',
+     'https://checkmo.local/events/january-challenge',
+     '2026-01-01', '2026-01-31',
+     @now, @now),
+
+    (3, '신규 기능 업데이트: 모임 일정 알림',
+     'admin@checkmo.local',
+     '모임 일정을 놓치지 않도록 알림 기능이 추가되었습니다. 모임 하루 전, 1시간 전에 푸시 알림을 받을 수 있습니다. 설정에서 알림을 켜고 중요한 모임을 놓치지 마세요!',
+     'https://images.unsplash.com/photo-1611532736597-de2d4265fba3?w=400',
+     NULL,
+     '2026-01-10', '2026-02-28',
+     @now, @now),
+
+    (4, '독서모임 운영 가이드 공개',
+     'admin@checkmo.local',
+     '성공적인 독서모임 운영을 위한 가이드를 공개합니다. 모임 주제 선정부터 토론 진행 방법, 멤버 관리 팁까지 상세하게 안내해 드립니다. 처음 독서모임을 시작하시는 분들께 도움이 되길 바랍니다.',
+     'https://images.unsplash.com/photo-1481627834876-b7833e8f5570?w=400',
+     'https://checkmo.local/guide/book-club',
+     '2026-01-15', '2026-06-30',
+     @now, @now),
+
+    (5, '서버 점검 안내 (1/25)',
+     'admin@checkmo.local',
+     '서비스 개선을 위한 정기 점검이 예정되어 있습니다. 점검 시간: 2026년 1월 25일 02:00 ~ 06:00 (약 4시간). 점검 중에는 서비스 이용이 불가합니다. 이용에 불편을 드려 죄송합니다.',
+     NULL,
+     NULL,
+     '2026-01-20', '2026-01-25',
+     @now, @now),
+
+    (6, '2월 북토크 행사 사전 신청',
+     'admin@checkmo.local',
+     '2월에 진행되는 특별 북토크 행사에 여러분을 초대합니다! 베스트셀러 작가와 함께하는 온라인 북토크로, 선착순 100명에게 참여 기회를 드립니다. 관심 있으신 분들은 사전 신청해 주세요.',
+     'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?w=400',
+     'https://checkmo.local/events/february-booktalk',
+     '2026-01-22', '2026-02-10',
+     @now, @now);
+
+-- =========================
+-- NewsImage 테스트 데이터
+-- =========================
+INSERT INTO news_image (id, news_id, image_url, sort_order, created_at, updated_at)
+VALUES
+    (1, 1, 'https://images.unsplash.com/photo-1512820790803-83ca734da794?w=800', 0, @now, @now),
+    (2, 1, 'https://images.unsplash.com/photo-1495446815901-a7297e633e8d?w=800', 1, @now, @now),
+    (3, 2, 'https://images.unsplash.com/photo-1507842217343-583bb7270b66?w=800', 0, @now, @now),
+    (4, 4, 'https://images.unsplash.com/photo-1481627834876-b7833e8f5570?w=800', 0, @now, @now),
+    (5, 4, 'https://images.unsplash.com/photo-1519682337058-a94d519337bc?w=800', 1, @now, @now),
+    (6, 6, 'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?w=800', 0, @now, @now);


### PR DESCRIPTION
## 🚀 변경사항
소식 기능을 구현했습니다.
관리자 전용 페이지를 따로 구현해서 관리자가 등록, 수정, 삭제 할 수 있게 했고
일반 회원은 단순 전체 조회와 상세 조회를 가능하게 했습니다.
그리고 관리자 전용 전체 조회와 상세 조회 페이지를 만들어서 일반 회원이 볼 수 없는 데이터들을 추가로 확인할 수 있게 구성했습니다.

## 🔗 관련 이슈
- Closes #143 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full news management: admins can create, edit, publish/unpublish, and delete news items via admin APIs.
  * Support for up to 5 images per news item, with ordered image display and thumbnails.
  * Configurable publish date ranges governing visibility.
  * Public-facing endpoints: browse published news with detailed views and cursor-based pagination for smooth navigation.
  * Seed data added for local testing of news and images.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->