### PR TITLE
[refactor] 책이야기 조회 api 분리

### DIFF
--- a/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
+++ b/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
@@ -1,22 +1,16 @@
 package checkmo.bookStory.internal.service;
 
-import static checkmo.clubManagement.ClubManagementExternalDTO.BasicInfo;
-import static checkmo.clubManagement.ClubManagementExternalDTO.ClubList;
-
 import checkmo.book.BookAPI;
 import checkmo.book.BookExternalDTO;
 import checkmo.bookStory.internal.converter.BookStoryConverter;
 import checkmo.bookStory.internal.entity.BookStory;
 import checkmo.bookStory.internal.entity.Comment;
-import checkmo.bookStory.internal.exception.BookStoryErrorStatus;
-import checkmo.bookStory.internal.exception.BookStoryException;
 import checkmo.bookStory.internal.service.query.BookStoryViewCacheService;
 import checkmo.bookStory.internal.service.query.BookStoryQueryService;
 import checkmo.bookStory.web.dto.BookStoryRequestDTO;
 import checkmo.bookStory.web.dto.BookStoryResponseDTO;
 import checkmo.bookStory.web.dto.BookStoryResponseDTO.CommentInfo;
 import checkmo.bookStory.web.dto.BookStoryResponseDTO.DetailInfo;
-import checkmo.clubManagement.ClubManagementAPI;
 import checkmo.common.template.CursorPagingHelper;
 import checkmo.common.template.CursorResult;
 import checkmo.member.MemberAPI;
@@ -39,7 +33,6 @@ public class BookStoryQueryFacade {
 
     public static final int DEFAULT_PAGE_SIZE = 10;
 
-    private final ClubManagementAPI clubManagementAPI;
     private final MemberAPI memberAPI;
     private final BookAPI bookAPI;
 
@@ -109,25 +102,67 @@ public class BookStoryQueryFacade {
     }
 
     /**
-     * scope에 따라 책 이야기 목록을 조회합니다. 비즈니스 로직을 Facade에서 처리하여 컨트롤러는 단순히 호출만 담당
-     *
-     * @param memberId             조회하는 회원의 ID
-     * @param scope                조회 범위 ("ALL", "MY", "FOLLOWING", "CLUB", "TARGET")
-     * @param clubId               클럽 ID (scope가 "CLUB"일 때 필수)
-     * @param targetMemberNickname 대상 회원 닉네임 (scope가 "TARGET"일 때 필수)
-     * @param cursorId             페이지 번호 (1부터 시작)
-     * @return scope에 따른 책 이야기 목록 DTO
+     * 전체 책이야기 목록을 조회합니다.
      */
-    public BookStoryResponseDTO.BookStoryList fetchBookStories(
+    public BookStoryResponseDTO.BookStoryList fetchAllBookStories(String memberId, Long cursorId) {
+        return fetchBookStoriesInternal(memberId, BookStoryRequestDTO.BookStoryScope.ALL, null, null, cursorId);
+    }
+
+    /**
+     * 내가 작성한 책이야기 목록을 조회합니다.
+     */
+    public BookStoryResponseDTO.BookStoryList fetchMyBookStories(String memberId, Long cursorId) {
+        return fetchBookStoriesInternal(memberId, BookStoryRequestDTO.BookStoryScope.MY, null, null, cursorId);
+    }
+
+    /**
+     * 팔로우한 회원들의 책이야기 목록을 조회합니다.
+     */
+    public BookStoryResponseDTO.BookStoryList fetchFollowingBookStories(String memberId, Long cursorId) {
+        return fetchBookStoriesInternal(memberId, BookStoryRequestDTO.BookStoryScope.FOLLOWING, null, null, cursorId);
+    }
+
+    /**
+     * 특정 회원의 책이야기 목록을 조회합니다.
+     */
+    public BookStoryResponseDTO.BookStoryList fetchMemberBookStories(
             String memberId,
-            BookStoryRequestDTO.BookStoryScope scope,
-            Long clubId, String targetMemberNickname,
+            String targetNickname,
             Long cursorId
     ) {
-        // 1. targetMemberId 조회 (SCOPE=TARGET인 경우)
-        String targetMemberId = resolveTargetMemberId(scope, targetMemberNickname);
+        String targetMemberId = memberAPI.fetchMemberId(targetNickname);
+        return fetchBookStoriesInternal(memberId, BookStoryRequestDTO.BookStoryScope.TARGET, null, targetMemberId, cursorId);
+    }
 
-        // 2. BookStory 리스트 조회
+    /**
+     * 특정 클럽 멤버들의 책이야기 목록을 조회합니다.
+     */
+    public BookStoryResponseDTO.BookStoryList fetchClubBookStories(
+            String memberId,
+            Long clubId,
+            Long cursorId
+    ) {
+        return fetchBookStoriesInternal(memberId, BookStoryRequestDTO.BookStoryScope.CLUB, clubId, null, cursorId);
+    }
+
+    /**
+     * scope에 따라 책 이야기 목록을 조회합니다. 비즈니스 로직을 Facade에서 처리하여 컨트롤러는 단순히 호출만 담당
+     *
+     * @param memberId       조회하는 회원의 ID
+     * @param scope          조회 범위 ("ALL", "MY", "FOLLOWING", "CLUB", "TARGET")
+     * @param clubId         클럽 ID (scope가 "CLUB"일 때 필수)
+     * @param targetMemberId 대상 회원 ID (scope가 "TARGET"일 때 필수)
+     * @param cursorId       커서 ID
+     * @return scope에 따른 책 이야기 목록 DTO
+     */
+    private BookStoryResponseDTO.BookStoryList fetchBookStoriesInternal(
+            String memberId,
+            BookStoryRequestDTO.BookStoryScope scope,
+            Long clubId,
+            String targetMemberId,
+            Long cursorId
+    ) {
+        // 1. BookStory 리스트 조회
         CursorResult<BookStory> bookStoryCursorResult = CursorPagingHelper.getPage(
                 (pageSize) -> bookStoryQueryService.retrieveBookStories(
                         memberId, scope, clubId, targetMemberId, cursorId, pageSize
@@ -137,47 +172,25 @@ public class BookStoryQueryFacade {
         );
         List<BookStory> bookStories = bookStoryCursorResult.content();
 
-        // 좋아요 여부 조회
+        // 2. 좋아요 여부 조회
         Map<Long, Boolean> isLikedMap = fetchLikedInfo(memberId, bookStories);
 
-        // 책 정보 조회
+        // 3. 책 정보 조회
         Map<String, BookExternalDTO.BasicInfo> bookInfoMap = fetchBookInfo(bookStories);
 
-        // 작성자 정보 조회
+        // 4. 작성자 정보 조회
         Map<String, BasicInfoWithFollow> authorInfoMap = fetchAuthorInfo(memberId, bookStories);
 
-        // DTO 변환
+        // 5. DTO 변환
         List<BookStoryResponseDTO.BasicInfo> basicInfoList = convertToBookStoryResponses(memberId,
                 bookStories, isLikedMap, bookInfoMap, authorInfoMap);
 
-        // 클럽 정보 조회
-        ClubList clubList = clubManagementAPI.fetchMyClubs(memberId);
-        BasicInfo basicInfo = findClubInfoForScope(scope, clubId, clubList);
-
-        // 스코프 정보 변환 및 최종 응답 DTO 변환
-        var scopeInfo = BookStoryResponseDTO.ScopeInfo.builder()
-                .scope(scope)
-                .selectedClub(basicInfo)
-                .build();
-
         return BookStoryResponseDTO.BookStoryList.builder()
-                .scopeInfo(scopeInfo)
-                .memberClubList(clubList)
                 .basicInfoList(basicInfoList)
                 .hasNext(bookStoryCursorResult.hasNext())
                 .nextCursor(bookStoryCursorResult.nextCursor())
                 .pageSize(DEFAULT_PAGE_SIZE)
                 .build();
-    }
-
-    /**
-     * TARGET 스코프인 경우 닉네임으로 targetMemberId 조회
-     */
-    private String resolveTargetMemberId(BookStoryRequestDTO.BookStoryScope scope, String targetMemberNickname) {
-        if (scope == BookStoryRequestDTO.BookStoryScope.TARGET) {
-            return memberAPI.fetchMemberId(targetMemberNickname);
-        }
-        return null;
     }
 
     /**
@@ -231,23 +244,6 @@ public class BookStoryQueryFacade {
                         authorInfoMap.get(bookStory.getMemberId()),
                         isLikedMap.getOrDefault(bookStory.getId(), false)
                 )).toList();
-    }
-
-    /**
-     * 스코프에 해당하는 클럽 정보 조회
-     */
-    private BasicInfo findClubInfoForScope(
-            BookStoryRequestDTO.BookStoryScope scope,
-            Long clubId,
-            ClubList clubList
-    ) {
-        if (scope == BookStoryRequestDTO.BookStoryScope.CLUB) {
-            return clubList.getClubList().stream()
-                    .filter(club -> club.getClubId().equals(clubId))
-                    .findFirst()
-                    .orElseThrow(() -> new BookStoryException(BookStoryErrorStatus.CLUB_ACCESS_DENIED));
-        }
-        return null;
     }
 
     /**

--- a/src/main/java/checkmo/bookStory/web/controller/BookStoryController.java
+++ b/src/main/java/checkmo/bookStory/web/controller/BookStoryController.java
@@ -51,22 +51,57 @@ public class BookStoryController {
         return ApiResponse.onSuccess(bookStoryId);
     }
 
-    @Operation(summary = "책 이야기 전체보기 API", description = "조건에 따라 책 이야기 목록을 조회합니다.")
+    @Operation(summary = "전체 책이야기 조회 API", description = "모든 책이야기 목록을 조회합니다.")
+    @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "10")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @GetMapping
+    public ApiResponse<BookStoryResponseDTO.BookStoryList> getAllBookStories(
+            @CurrentId String memberId,
+            @RequestParam(required = false) Long cursorId
+    ) {
+        var bookStories = bookStoryQueryFacade.fetchAllBookStories(memberId, cursorId);
+        return ApiResponse.onSuccess(bookStories);
+    }
+
+    @Operation(summary = "내가 쓴 책이야기 조회 API", description = "로그인한 회원이 작성한 책이야기 목록을 조회합니다.")
+    @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "10")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @GetMapping("/me")
+    public ApiResponse<BookStoryResponseDTO.BookStoryList> getMyBookStories(
+            @CurrentId String memberId,
+            @RequestParam(required = false) Long cursorId
+    ) {
+        var bookStories = bookStoryQueryFacade.fetchMyBookStories(memberId, cursorId);
+        return ApiResponse.onSuccess(bookStories);
+    }
+
+    @Operation(summary = "팔로잉 책이야기 조회 API", description = "팔로우한 회원들의 책이야기 목록을 조회합니다.")
+    @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "10")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @GetMapping("/following")
+    public ApiResponse<BookStoryResponseDTO.BookStoryList> getFollowingBookStories(
+            @CurrentId String memberId,
+            @RequestParam(required = false) Long cursorId
+    ) {
+        var bookStories = bookStoryQueryFacade.fetchFollowingBookStories(memberId, cursorId);
+        return ApiResponse.onSuccess(bookStories);
+    }
+
+    @Operation(summary = "특정 회원 책이야기 조회 API", description = "특정 회원이 작성한 책이야기 목록을 조회합니다.")
     @Parameters({
-            @Parameter(
-                    name = "scope",
-                    description = """
-                            조회 범위:
-                            • ALL: 전체 책이야기
-                            • FOLLOWING: 팔로우한 회원의 책이야기
-                            • MY: 내 책이야기
-                            • CLUB: 특정 클럽 책이야기 (clubId 필수)
-                            • TARGET: 특정 회원의 책이야기 (targetMemberNickname 필수)""",
-                    required = true,
-                    example = "ALL"
-            ),
-            @Parameter(name = "clubId", description = "조회하는 Club ID (scope가 CLUB일 때 필수)", required = false, example = "1"),
-            @Parameter(name = "targetMemberNickname", description = "조회할 회원의 닉네임 (scope가 TARGET일 때 필수)", required = false, example = "MODUGGAGI"),
+            @Parameter(name = "nickname", description = "조회할 회원의 닉네임", required = true, example = "책벌레"),
             @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "10")
     })
     @ApiResponses({
@@ -74,25 +109,34 @@ public class BookStoryController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
     })
-    @GetMapping
-    public ApiResponse<BookStoryResponseDTO.BookStoryList> getBookStories(
+    @GetMapping("/members/{nickname}")
+    public ApiResponse<BookStoryResponseDTO.BookStoryList> getMemberBookStories(
             @CurrentId String memberId,
-            @RequestParam(required = false, defaultValue = "ALL") BookStoryRequestDTO.BookStoryScope scope,
-            @RequestParam(required = false) Long clubId,
-            @RequestParam(required = false) String targetMemberNickname,
+            @PathVariable String nickname,
             @RequestParam(required = false) Long cursorId
     ) {
-        if (scope == BookStoryRequestDTO.BookStoryScope.CLUB && clubId == null) {
-            throw new IllegalArgumentException("scope가 CLUB일 때는 clubId 파라미터가 필수입니다.");
-        }
+        var bookStories = bookStoryQueryFacade.fetchMemberBookStories(memberId, nickname, cursorId);
+        return ApiResponse.onSuccess(bookStories);
+    }
 
-        if (scope == BookStoryRequestDTO.BookStoryScope.TARGET && targetMemberNickname == null) {
-            throw new IllegalArgumentException("scope가 TARGET일 때는 targetMemberNickname 파라미터가 필수입니다.");
-        }
-
-        var bookStoriesByScope = bookStoryQueryFacade.fetchBookStories(memberId, scope, clubId, targetMemberNickname,
-                cursorId);
-        return ApiResponse.onSuccess(bookStoriesByScope);
+    @Operation(summary = "클럽 책이야기 조회 API", description = "특정 클럽 멤버들이 작성한 책이야기 목록을 조회합니다.")
+    @Parameters({
+            @Parameter(name = "clubId", description = "조회할 클럽 ID", required = true, example = "1"),
+            @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "10")
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @GetMapping("/clubs/{clubId}")
+    public ApiResponse<BookStoryResponseDTO.BookStoryList> getClubBookStories(
+            @CurrentId String memberId,
+            @PathVariable Long clubId,
+            @RequestParam(required = false) Long cursorId
+    ) {
+        var bookStories = bookStoryQueryFacade.fetchClubBookStories(memberId, clubId, cursorId);
+        return ApiResponse.onSuccess(bookStories);
     }
 
     @Operation(summary = "책 이야기 상세 조회 API", description = "특정 책 이야기의 상세 정보를 조회합니다.")

--- a/src/main/java/checkmo/bookStory/web/dto/BookStoryResponseDTO.java
+++ b/src/main/java/checkmo/bookStory/web/dto/BookStoryResponseDTO.java
@@ -1,9 +1,6 @@
 package checkmo.bookStory.web.dto;
 
-import static checkmo.clubManagement.ClubManagementExternalDTO.ClubList;
-
 import checkmo.book.BookExternalDTO;
-import checkmo.clubManagement.ClubManagementExternalDTO;
 import checkmo.member.MemberExternalDTO;
 import checkmo.member.MemberExternalDTO.BasicInfoWithFollow;
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -21,21 +18,10 @@ public class BookStoryResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class BookStoryList {
-        private ScopeInfo scopeInfo;    // 현재 선택된 범위 정보
-        private ClubList memberClubList; // 사용자가 속한 클럽 목록
         private List<BasicInfo> basicInfoList;
         private boolean hasNext;
         private Long nextCursor;
         private int pageSize;
-    }
-
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    public static class ScopeInfo {
-        private BookStoryRequestDTO.BookStoryScope scope; // 현재 범위 (ALL, MY, CLUB)
-        private ClubManagementExternalDTO.BasicInfo selectedClub; // 선택된 클럽 정보 (CLUB scope일 때만)
     }
 
     @Getter

--- a/src/main/java/checkmo/clubManagement/ClubManagementAPI.java
+++ b/src/main/java/checkmo/clubManagement/ClubManagementAPI.java
@@ -1,6 +1,5 @@
 package checkmo.clubManagement;
 
-import static checkmo.clubManagement.ClubManagementExternalDTO.ClubList;
 import static checkmo.clubManagement.ClubManagementExternalDTO.MembershipInfo;
 
 import checkmo.clubManagement.internal.excepetion.ClubManagementException;
@@ -33,14 +32,6 @@ public interface ClubManagementAPI {
      * @return 모임 ID를 키로 하는 모임 이름 맵
      */
     Map<Long, String> fetchClubNamesByClubIds(List<Long> clubIds);
-
-    /**
-     * 특정 회원이 가입한 모임 목록을 조회합니다. 마이페이지 등 다른 서비스에서 사용됩니다. 이때 회원이 활성화 상태인 모임만 조회됩니다.
-     *
-     * @param memberId 회원 ID
-     * @return 회원이 가입한 모임의 간략한 정보 목록 DTO
-     */
-    ClubList fetchMyClubs(String memberId);
 
     /**
      * 특정 클럽에 속한 ACTIVE한 회원 ID 목록을 조회합니다.

--- a/src/main/java/checkmo/clubManagement/internal/ClubManagementAPIImpl.java
+++ b/src/main/java/checkmo/clubManagement/internal/ClubManagementAPIImpl.java
@@ -1,17 +1,13 @@
 package checkmo.clubManagement.internal;
 
-import static checkmo.clubManagement.ClubManagementExternalDTO.ClubList;
 import static checkmo.clubManagement.ClubManagementExternalDTO.MembershipInfo;
 
 import checkmo.clubManagement.ClubManagementAPI;
-import checkmo.clubManagement.ClubManagementExternalDTO;
-import checkmo.clubManagement.ClubManagementExternalDTO.BasicInfo;
 import checkmo.clubManagement.internal.converter.ClubManagementConverter;
 import checkmo.clubManagement.internal.entity.ClubMember;
 import checkmo.clubManagement.internal.entity.ClubMemberStatus;
 import checkmo.clubManagement.internal.excepetion.ClubManagementErrorStatus;
 import checkmo.clubManagement.internal.excepetion.ClubManagementException;
-import checkmo.clubManagement.internal.repository.projection.ClubIdAndName;
 import checkmo.clubManagement.internal.service.command.ClubManagementCommandService;
 import checkmo.clubManagement.internal.service.query.ClubManagementQueryService;
 import checkmo.clubManagement.internal.service.query.ClubMemberQueryService;
@@ -48,17 +44,6 @@ public class ClubManagementAPIImpl implements ClubManagementAPI {
             return Map.of();
         }
         return clubManagementQueryService.retrieveClubNamesByIds(clubIds);
-    }
-
-    @Override
-    public ClubList fetchMyClubs(String memberId) {
-        List<ClubIdAndName> clubIdAndNames = clubMemberQueryService.retrieveActiveClubIdAndName(memberId);
-        List<BasicInfo> myClubBasicInfoList = clubIdAndNames.stream()
-                .map(cm -> new BasicInfo(cm.getId(), cm.getName()))
-                .toList();
-        return ClubManagementExternalDTO.ClubList.builder()
-                .clubList(myClubBasicInfoList)
-                .build();
     }
 
     @Override


### PR DESCRIPTION
기존 1개의 api를 프론트의 요청에 따라 5개로 분리했습니다.

## 🚀 변경사항
책이야기 조회 api를 1개에서 5개로 분리했습니다.

## 🔗 관련 이슈
- Closes #이슈번호

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured book story retrieval API with five dedicated endpoints for viewing all stories, personal stories, followed members' stories, specific member stories, and club-specific stories.
  * Simplified API responses by removing scope information and club list metadata from story listings.
  * Standardized pagination across all endpoints using cursor-based navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->