### PR TITLE
[Refactor] 이미지 저장 경로 분리

### DIFF
--- a/src/main/java/checkmo/clubManagement/ClubManagementEvent.java
+++ b/src/main/java/checkmo/clubManagement/ClubManagementEvent.java
@@ -15,4 +15,8 @@ public class ClubManagementEvent {
     @Builder
     public record ClubDeletedEvent(Long clubId) {
     }
+
+    @Builder
+    public record DeleteClubImage(String imageUrl) {
+    }
 }

--- a/src/main/java/checkmo/clubManagement/internal/service/command/ClubManagementCommandService.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/command/ClubManagementCommandService.java
@@ -1,5 +1,6 @@
 package checkmo.clubManagement.internal.service.command;
 
+import checkmo.clubManagement.ClubManagementEvent;
 import checkmo.clubManagement.internal.converter.ClubManagementConverter;
 import checkmo.clubManagement.internal.entity.Club;
 import checkmo.clubManagement.internal.entity.ClubMember;
@@ -49,6 +50,15 @@ public class ClubManagementCommandService {
         }
 
         validateClubName(request, club);
+
+        String oldImageUrl = club.getProfileImgUrl();
+        if (oldImageUrl != null && !oldImageUrl.equals(request.getProfileImageUrl())) {
+            applicationEventPublisher.publishEvent(
+                    ClubManagementEvent.DeleteClubImage.builder()
+                            .imageUrl(oldImageUrl)
+                            .build()
+            );
+        }
 
         club.updateField(
                 request.getName(),

--- a/src/main/java/checkmo/infra/package-info.java
+++ b/src/main/java/checkmo/infra/package-info.java
@@ -1,4 +1,4 @@
 @org.springframework.modulith.ApplicationModule(
-        allowedDependencies = {"authentication", "member", "clubNotice", "common"}
+        allowedDependencies = {"authentication", "member", "clubManagement", "clubNotice", "common"}
 )
 package checkmo.infra;

--- a/src/main/java/checkmo/infra/s3/internal/entity/FileUploadType.java
+++ b/src/main/java/checkmo/infra/s3/internal/entity/FileUploadType.java
@@ -1,0 +1,14 @@
+package checkmo.infra.s3.internal.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FileUploadType {
+    PROFILE("profiles"),
+    CLUB("clubs"),
+    NOTICE("notices");
+
+    private final String path;
+}

--- a/src/main/java/checkmo/infra/s3/internal/listener/S3EventListener.java
+++ b/src/main/java/checkmo/infra/s3/internal/listener/S3EventListener.java
@@ -1,5 +1,6 @@
 package checkmo.infra.s3.internal.listener;
 
+import checkmo.clubManagement.ClubManagementEvent;
 import checkmo.clubNotice.ClubNoticeEvent;
 import checkmo.infra.s3.internal.service.S3Service;
 import checkmo.member.MemberEvent;
@@ -20,6 +21,11 @@ public class S3EventListener {
     @ApplicationModuleListener
     public void handleDeleteProfileImageEvent(MemberEvent.DeleteProfileImage event) {
         deleteSingleUrl(event.imageUrl(), "프로필 이미지", event);
+    }
+
+    @ApplicationModuleListener
+    public void handleDeleteClubImageEvent(ClubManagementEvent.DeleteClubImage event) {
+        deleteSingleUrl(event.imageUrl(), "클럽 이미지", event);
     }
 
     @ApplicationModuleListener

--- a/src/main/java/checkmo/infra/s3/internal/service/S3Service.java
+++ b/src/main/java/checkmo/infra/s3/internal/service/S3Service.java
@@ -1,6 +1,7 @@
 package checkmo.infra.s3.internal.service;
 
 import checkmo.infra.s3.internal.config.properties.S3Properties;
+import checkmo.infra.s3.internal.entity.FileUploadType;
 import checkmo.infra.s3.internal.exception.S3ErrorStatus;
 import checkmo.infra.s3.internal.exception.S3InfraException;
 import checkmo.infra.s3.web.dto.S3ResponseDTO;
@@ -31,14 +32,14 @@ public class S3Service {
     private final S3Client s3Client;
     private final S3Properties s3Properties;
 
-    public S3ResponseDTO.PresignedUrl generatePresignedUploadUrl(String fileName, String contentType) {
+    public S3ResponseDTO.PresignedUrl generatePresignedUploadUrl(String fileName, String contentType, FileUploadType uploadType) {
         // Content-Type 검증
         if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType.toLowerCase())) {
             throw new S3InfraException(S3ErrorStatus.INVALID_FILE_TYPE);
         }
 
         // S3에 저장될 파일의 고유 경로(key) 생성
-        String key = generateUniqueKey(fileName);
+        String key = generateUniqueKey(fileName, uploadType);
 
         // 생성된 key를 기반으로 presigned url 생성
         String presignedUrl = generatePresignedUrl(key, contentType);
@@ -130,13 +131,13 @@ public class S3Service {
         }
     }
 
-    private String generateUniqueKey(String originalFileName) {
+    private String generateUniqueKey(String originalFileName, FileUploadType uploadType) {
         String extension = getFileExtension(originalFileName);
 
         String uniqueId = UUID.randomUUID().toString();
 
         // S3 버킷에 저장될 경로와 UUID 파일명.확장자 -> 이게 Key가 됨
-        return String.format("images/%s%s", uniqueId, extension);
+        return String.format("images/%s/%s%s", uploadType.getPath(), uniqueId, extension);
     }
 
     private String getFileExtension(String fileName) {

--- a/src/main/java/checkmo/infra/s3/web/controller/S3Controller.java
+++ b/src/main/java/checkmo/infra/s3/web/controller/S3Controller.java
@@ -1,6 +1,7 @@
 package checkmo.infra.s3.web.controller;
 
 import checkmo.common.apiPayload.ApiResponse;
+import checkmo.infra.s3.internal.entity.FileUploadType;
 import checkmo.infra.s3.internal.service.S3Service;
 import checkmo.infra.s3.web.dto.S3RequestDTO;
 import checkmo.infra.s3.web.dto.S3ResponseDTO;
@@ -22,17 +23,57 @@ public class S3Controller {
 
     private final S3Service s3Service;
 
-    @Operation(summary = "이미지용 presigned URL 발급 API", description = "프로필 이미지/독서 클럽/클럽 공지사항의 이미지 업로드를 위한 S3 presigned URL을 발급합니다.")
+    @Operation(summary = "프로필 이미지 업로드 URL 발급", description = "회원 프로필 이미지 업로드를 위한 URL을 발급합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
     })
-    @PostMapping("/image/upload-url")
+    @PostMapping("/profile/upload-url")
     public ApiResponse<S3ResponseDTO.PresignedUrl> getProfileImageUploadUrl(
             @Valid @RequestBody S3RequestDTO.ImageUpload request
     ) {
         return ApiResponse.onSuccess(
-                s3Service.generatePresignedUploadUrl(request.getOriginalFileName(), request.getContentType()));
+                s3Service.generatePresignedUploadUrl(
+                        request.getOriginalFileName(),
+                        request.getContentType(),
+                        FileUploadType.PROFILE
+                ));
+    }
+
+    @Operation(summary = "클럽 대표 이미지 업로드 URL 발급", description = "독서 클럽 대표 이미지 업로드를 위한 URL을 발급합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @PostMapping("/club/upload-url")
+    public ApiResponse<S3ResponseDTO.PresignedUrl> getClubImageUploadUrl(
+            @Valid @RequestBody S3RequestDTO.ImageUpload request
+    ) {
+        return ApiResponse.onSuccess(
+                s3Service.generatePresignedUploadUrl(
+                        request.getOriginalFileName(),
+                        request.getContentType(),
+                        FileUploadType.CLUB
+                ));
+    }
+
+    @Operation(summary = "공지사항 이미지 업로드 URL 발급", description = "공지사항에 들어갈 이미지 업로드를 위한 URL을 발급합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @PostMapping("/notice/upload-url")
+    public ApiResponse<S3ResponseDTO.PresignedUrl> getNoticeImageUploadUrl(
+            @Valid @RequestBody S3RequestDTO.ImageUpload request
+    ) {
+        return ApiResponse.onSuccess(
+                s3Service.generatePresignedUploadUrl(
+                        request.getOriginalFileName(),
+                        request.getContentType(),
+                        FileUploadType.NOTICE
+                ));
     }
 }

--- a/src/main/java/checkmo/infra/s3/web/controller/S3Controller.java
+++ b/src/main/java/checkmo/infra/s3/web/controller/S3Controller.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/s3")
+@RequestMapping("/api/image")
 @RequiredArgsConstructor
 @Tag(name = "S3 Image", description = "S3에 저장할 이미지에 대해서 presigned URL을 발급하는 API")
 public class S3Controller {

--- a/src/main/java/checkmo/infra/s3/web/controller/S3Controller.java
+++ b/src/main/java/checkmo/infra/s3/web/controller/S3Controller.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,57 +24,22 @@ public class S3Controller {
 
     private final S3Service s3Service;
 
-    @Operation(summary = "프로필 이미지 업로드 URL 발급", description = "회원 프로필 이미지 업로드를 위한 URL을 발급합니다.")
+    @Operation(summary = "이미지 업로드 URL 발급", description = "이미지 업로드를 위한 presigned URL을 발급합니다. (type: PROFILE, CLUB, NOTICE)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
     })
-    @PostMapping("/profile/upload-url")
-    public ApiResponse<S3ResponseDTO.PresignedUrl> getProfileImageUploadUrl(
+    @PostMapping("/{type}/upload-url")
+    public ApiResponse<S3ResponseDTO.PresignedUrl> getImageUploadUrl(
+            @PathVariable FileUploadType type,
             @Valid @RequestBody S3RequestDTO.ImageUpload request
     ) {
         return ApiResponse.onSuccess(
                 s3Service.generatePresignedUploadUrl(
                         request.getOriginalFileName(),
                         request.getContentType(),
-                        FileUploadType.PROFILE
-                ));
-    }
-
-    @Operation(summary = "클럽 대표 이미지 업로드 URL 발급", description = "독서 클럽 대표 이미지 업로드를 위한 URL을 발급합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
-    })
-    @PostMapping("/club/upload-url")
-    public ApiResponse<S3ResponseDTO.PresignedUrl> getClubImageUploadUrl(
-            @Valid @RequestBody S3RequestDTO.ImageUpload request
-    ) {
-        return ApiResponse.onSuccess(
-                s3Service.generatePresignedUploadUrl(
-                        request.getOriginalFileName(),
-                        request.getContentType(),
-                        FileUploadType.CLUB
-                ));
-    }
-
-    @Operation(summary = "공지사항 이미지 업로드 URL 발급", description = "공지사항에 들어갈 이미지 업로드를 위한 URL을 발급합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
-    })
-    @PostMapping("/notice/upload-url")
-    public ApiResponse<S3ResponseDTO.PresignedUrl> getNoticeImageUploadUrl(
-            @Valid @RequestBody S3RequestDTO.ImageUpload request
-    ) {
-        return ApiResponse.onSuccess(
-                s3Service.generatePresignedUploadUrl(
-                        request.getOriginalFileName(),
-                        request.getContentType(),
-                        FileUploadType.NOTICE
+                        type
                 ));
     }
 }


### PR DESCRIPTION
## 🚀 변경사항
이미지 저장 경로 변경
이미지 사용처 마다 서로 다른 저장 경로에 저장되게 해서 s3 상에서 이미지들을 더 관리하기 쉽게 했습니다.

## 🔗 관련 이슈
- Closes #166 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single image upload endpoint now supports PROFILE, CLUB, and NOTICE types.
  * Automatic cleanup: previous club images are removed when a club image is updated.

* **Refactor**
  * Image upload APIs consolidated under /api/image with type-specific paths.
  * Centralized image type handling and presigned URL generation for all image categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->