### PR TITLE
[REFACTOR] 내 모임 전체조회 + 공지 페이지네이션/최신1개

### DIFF
--- a/src/main/java/checkmo/clubManagement/internal/repository/ClubMemberRepository.java
+++ b/src/main/java/checkmo/clubManagement/internal/repository/ClubMemberRepository.java
@@ -3,7 +3,6 @@ package checkmo.clubManagement.internal.repository;
 import checkmo.clubManagement.internal.entity.ClubMember;
 import checkmo.clubManagement.internal.entity.ClubMemberStatus;
 import checkmo.clubManagement.internal.repository.projection.ClubIdAndName;
-import checkmo.clubManagement.internal.repository.projection.ClubIdAndNameAndClubMemberId;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -22,15 +21,6 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
             + "AND cm.clubMemberStatus IN :statuses "
             + "ORDER BY cm.id ASC")
     List<ClubIdAndName> findClubIdAndNameByMemberIdAndStatuses(String memberId, EnumSet<ClubMemberStatus> statuses);
-
-    @Query("SELECT c.id AS clubId, c.name AS clubName, cm.id AS clubMemberId "
-            + "FROM ClubMember cm JOIN cm.club c "
-            + "WHERE cm.memberId = :memberId "
-            + "AND cm.clubMemberStatus IN :statuses "
-            + "AND (:cursorId IS NULL OR cm.id < :cursorId) "
-            + "ORDER BY cm.id DESC")
-    List<ClubIdAndNameAndClubMemberId> findMyClubByCursor(
-            String memberId, EnumSet<ClubMemberStatus> statuses, Long cursorId, Pageable pageable);
 
     List<ClubMember> findAllByMemberIdAndClubIdIn(String memberId, List<Long> clubIds);
 

--- a/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
@@ -7,7 +7,7 @@ import checkmo.clubManagement.internal.entity.ClubMember;
 import checkmo.clubManagement.internal.entity.ClubMemberStatus;
 import checkmo.clubManagement.internal.excepetion.ClubManagementErrorStatus;
 import checkmo.clubManagement.internal.excepetion.ClubManagementException;
-import checkmo.clubManagement.internal.repository.projection.ClubIdAndNameAndClubMemberId;
+import checkmo.clubManagement.internal.repository.projection.ClubIdAndName;
 import checkmo.clubManagement.internal.repository.projection.ClubRecommendation;
 import checkmo.clubManagement.internal.service.query.ClubManagementQueryService;
 import checkmo.clubManagement.internal.service.query.ClubMemberQueryService;
@@ -106,24 +106,18 @@ public class ClubManagementQueryFacade {
                 .build();
     }
 
-    public MyClubResponseDTO.MyClubList retrieveMyClubList(String memberId, Long cursorId) {
-        CursorResult<ClubIdAndNameAndClubMemberId> cursorResult = CursorPagingHelper.getPage(
-                size -> clubMemberQueryService.retrieveMyActiveClubsByCursor(memberId, cursorId, size),
-                ClubIdAndNameAndClubMemberId::getClubMemberId,
-                DEFAULT_PAGE_SIZE
-        );
-        List<MyClubResponseDTO.ClubInfo> clubInfoList = cursorResult.content().stream()
+    public MyClubResponseDTO.MyClubList retrieveMyClubList(String memberId) {
+        List<ClubIdAndName> clubIdAndNames = clubMemberQueryService.retrieveAllMyActiveClubs(memberId);
+        List<MyClubResponseDTO.ClubInfo> clubInfoList = clubIdAndNames.stream()
                 .map(c -> MyClubResponseDTO.ClubInfo.builder()
-                        .clubId(c.getClubId())
-                        .clubName(c.getClubName())
+                        .clubId(c.getId())
+                        .clubName(c.getName())
                         .build()
                 )
                 .toList();
 
         return MyClubResponseDTO.MyClubList.builder()
                 .clubList(clubInfoList)
-                .hasNext(cursorResult.hasNext())
-                .nextCursor(cursorResult.nextCursor())
                 .build();
     }
 

--- a/src/main/java/checkmo/clubManagement/internal/service/query/ClubMemberQueryService.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/query/ClubMemberQueryService.java
@@ -6,7 +6,6 @@ import checkmo.clubManagement.internal.excepetion.ClubManagementErrorStatus;
 import checkmo.clubManagement.internal.excepetion.ClubManagementException;
 import checkmo.clubManagement.internal.repository.ClubMemberRepository;
 import checkmo.clubManagement.internal.repository.projection.ClubIdAndName;
-import checkmo.clubManagement.internal.repository.projection.ClubIdAndNameAndClubMemberId;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -36,14 +35,9 @@ public class ClubMemberQueryService {
                 .orElseThrow(() -> new ClubManagementException(ClubManagementErrorStatus.CLUB_MEMBER_NOT_FOUND));
     }
 
-    public List<ClubIdAndName> retrieveActiveClubIdAndName(String memberId) {
+    public List<ClubIdAndName> retrieveAllMyActiveClubs(String memberId) {
         EnumSet<ClubMemberStatus> activeStatuses = ClubMemberStatus.activeStatuses();
         return clubMemberRepository.findClubIdAndNameByMemberIdAndStatuses(memberId, activeStatuses);
-    }
-
-    public List<ClubIdAndNameAndClubMemberId> retrieveMyActiveClubsByCursor(String memberId, Long cursorId, int size) {
-        EnumSet<ClubMemberStatus> activeStatuses = ClubMemberStatus.activeStatuses();
-        return clubMemberRepository.findMyClubByCursor(memberId, activeStatuses, cursorId, PageRequest.of(0, size));
     }
 
     public Optional<ClubMember> findClubMember(Long clubId, String memberId) {

--- a/src/main/java/checkmo/clubManagement/web/controller/MyClubController.java
+++ b/src/main/java/checkmo/clubManagement/web/controller/MyClubController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated
@@ -23,17 +22,16 @@ public class MyClubController {
 
     private final ClubManagementQueryFacade clubManagementQueryFacade;
 
-    @Operation(summary = "내가 가입한 클럽 목록 조회", description = "내가 가입한 클럽 목록을 반환합니다.(단 가입 신청 상태/차단 상태는 제외) - 홈화면, 모임검색 화면, 마이페이지에서 다양하게 사용할 예정")
+    @Operation(summary = "내가 가입한 클럽 목록 전체 조회", description = "내가 가입한 클럽 목록을 반환합니다.(단 가입 신청 상태/차단 상태는 제외) - 홈화면, 모임검색 화면, 마이페이지에서 다양하게 사용할 예정")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
     })
     @GetMapping
     public ApiResponse<MyClubResponseDTO.MyClubList> getMyClubs(
-            @RequestParam(required = false) Long cursorId,
             @CurrentId String memberId
     ) {
-        return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveMyClubList(memberId, cursorId));
+        return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveMyClubList(memberId));
     }
 
 }

--- a/src/main/java/checkmo/clubManagement/web/dto/myClub/MyClubResponseDTO.java
+++ b/src/main/java/checkmo/clubManagement/web/dto/myClub/MyClubResponseDTO.java
@@ -14,8 +14,6 @@ public class MyClubResponseDTO {
     @Builder
     public static class MyClubList {
         private List<ClubInfo> clubList;
-        private boolean hasNext;
-        private Long nextCursor;
     }
 
     @Getter

--- a/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
+++ b/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
@@ -133,7 +133,8 @@ public class ClubMeetingConverter {
     public static MeetingInfo toMeetingInfoWithTeams(
             Meeting meeting,
             List<Team> teams,
-            Map<Integer, List<MeetingResponseDTO.MeetingMember>> teamNumberToMembers
+            Map<Integer, List<MeetingResponseDTO.MeetingMember>> teamNumberToMembers,
+            boolean staff
     ) {
         List<Team> safeTeams = (teams != null) ? teams : List.of();
         Map<Integer, List<MeetingResponseDTO.MeetingMember>> safeTeamNumberToMembers
@@ -157,6 +158,7 @@ public class ClubMeetingConverter {
                                 .members(safeTeamNumberToMembers.getOrDefault(teamNumber, List.of()))
                                 .build())
                         .toList())
+                .staff(staff)
                 .build();
 
     }

--- a/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
@@ -160,12 +160,13 @@ public class ClubMeetingQueryFacade {
             Long meetingId,
             String memberId
     ) {
-        validateClubAndClubMembership(clubId, memberId);
+        MembershipInfo clubMembership = validateClubAndClubMembership(clubId, memberId);
+        boolean staff = clubMembership.isStaff();
         Meeting meeting = clubMeetingQueryService.validateMeeting(clubId, meetingId);
 
         List<Team> teams = clubMeetingTeamQueryService.retrieveTeams(meetingId);
         if (teams == null || teams.isEmpty()) {
-            return ClubMeetingConverter.toMeetingInfoWithTeams(meeting, List.of(), Map.of());
+            return ClubMeetingConverter.toMeetingInfoWithTeams(meeting, List.of(), Map.of(), staff);
         }
 
         List<Long> teamIds = ExtractHelper.extractDistinctList(teams, Team::getId);
@@ -174,7 +175,7 @@ public class ClubMeetingQueryFacade {
         // 미팅의 모든 팀원 조회
         Map<Long, Long> clubMemberIdToTeamIdMap = clubMeetingTeamQueryService.retrieveTeamIdByClubMemberId(teamIds);
         if (clubMemberIdToTeamIdMap == null || clubMemberIdToTeamIdMap.isEmpty()) {
-            return ClubMeetingConverter.toMeetingInfoWithTeams(meeting, teams, Map.of());
+            return ClubMeetingConverter.toMeetingInfoWithTeams(meeting, teams, Map.of(), staff);
         }
 
         // 클럽 멤버의 멤버십 정보 배치 조회
@@ -193,7 +194,7 @@ public class ClubMeetingQueryFacade {
                 memberBasicInfoMap
         );
 
-        return ClubMeetingConverter.toMeetingInfoWithTeams(meeting, teams, teamNumberToMembersMap);
+        return ClubMeetingConverter.toMeetingInfoWithTeams(meeting, teams, teamNumberToMembersMap, staff);
     }
 
     public MeetingResponseDTO.MeetingMemberList retrieveMeetingMemberList(

--- a/src/main/java/checkmo/clubMeeting/web/dto/meeting/MeetingResponseDTO.java
+++ b/src/main/java/checkmo/clubMeeting/web/dto/meeting/MeetingResponseDTO.java
@@ -34,6 +34,13 @@ public class MeetingResponseDTO {
         private String location;
         private List<Integer> existingTeamNumbers;
         private List<TeamMember> teams;
+        @Getter(AccessLevel.NONE)
+        private boolean staff;
+
+        @JsonProperty("isStaff")
+        public boolean isStaff() {
+            return staff;
+        }
     }
 
     @Getter

--- a/src/main/java/checkmo/clubNotice/internal/exception/ClubNoticeErrorStatus.java
+++ b/src/main/java/checkmo/clubNotice/internal/exception/ClubNoticeErrorStatus.java
@@ -13,6 +13,7 @@ public enum ClubNoticeErrorStatus implements BaseErrorCode {
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE_400", "공지사항을 찾을 수 없습니다."),
     MEETING_NOT_IN_CLUB(HttpStatus.BAD_REQUEST, "NOTICE_401", "공지사항의 모임이 해당 동아리에 속해있지 않습니다."),
     PINNED_NOTICE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "NOTICE_402", "고정 공지사항은 최대 5개까지 설정할 수 있습니다."),
+    NOTICE_EMPTY(HttpStatus.NOT_FOUND, "NOTICE_403", "공지사항이 존재하지 않습니다."),
 
     // 투표
     INSUFFICIENT_VOTE_ITEMS(HttpStatus.BAD_REQUEST, "VOTE_400", "투표 항목이 2개 미만입니다."),

--- a/src/main/java/checkmo/clubNotice/internal/repository/NoticeRepository.java
+++ b/src/main/java/checkmo/clubNotice/internal/repository/NoticeRepository.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    Optional<Notice> findTop1ByClubIdOrderByCreatedAtDescIdDesc(Long clubId);
+
     @Query("SELECT DISTINCT n FROM Notice n "
             + "LEFT JOIN FETCH n.vote v "
             + "LEFT JOIN FETCH v.clubMemberVotes cmv "

--- a/src/main/java/checkmo/clubNotice/internal/repository/NoticeRepository.java
+++ b/src/main/java/checkmo/clubNotice/internal/repository/NoticeRepository.java
@@ -1,6 +1,7 @@
 package checkmo.clubNotice.internal.repository;
 
 import checkmo.clubNotice.internal.entity.Notice;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,11 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     Optional<Notice> findWithVoteAndClubMemberVotesByIdAndClubId(Long noticeId, Long clubId);
 
     Optional<Notice> findByIdAndClubId(Long noticeId, Long clubId);
+
+    @Query("SELECT n FROM Notice n "
+            + "WHERE n.clubId = :clubId AND n.pinned = true "
+            + "ORDER BY n.createdAt DESC, n.id DESC")
+    List<Notice> findTopPinnedByClubId(Long clubId, Pageable pageable);
 
     @Query("SELECT n FROM Notice n "
             + "WHERE n.clubId = :clubId "

--- a/src/main/java/checkmo/clubNotice/internal/service/ClubNoticeQueryFacade.java
+++ b/src/main/java/checkmo/clubNotice/internal/service/ClubNoticeQueryFacade.java
@@ -16,6 +16,7 @@ import checkmo.clubNotice.internal.service.query.NoticeCommentQueryService;
 import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO;
 import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO.ClubNoticePreviewPage;
 import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO.EachItem;
+import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO.LatestNoticePreview;
 import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO.NoticeCommentList;
 import checkmo.common.template.CursorPagingHelper;
 import checkmo.common.template.CursorResult;
@@ -51,6 +52,16 @@ public class ClubNoticeQueryFacade {
 
     private final ClubNoticeQueryService clubNoticeQueryService;
     private final NoticeCommentQueryService noticeCommentQueryService;
+
+    public LatestNoticePreview retrieveLatestNotice(Long clubId) {
+        clubManagementAPI.validateClub(clubId);
+        Notice notice = clubNoticeQueryService.retrieveLatestNotice(clubId)
+                .orElseThrow(() -> new ClubNoticeException(ClubNoticeErrorStatus.NOTICE_EMPTY));
+        return ClubNoticeResponseDTO.LatestNoticePreview.builder()
+                .id(notice.getId())
+                .title(notice.getTitle())
+                .build();
+    }
 
     public ClubNoticePreviewPage retrieveClubNoticeList(
             Long clubId,

--- a/src/main/java/checkmo/clubNotice/internal/service/ClubNoticeQueryFacade.java
+++ b/src/main/java/checkmo/clubNotice/internal/service/ClubNoticeQueryFacade.java
@@ -14,7 +14,7 @@ import checkmo.clubNotice.internal.exception.ClubNoticeException;
 import checkmo.clubNotice.internal.service.query.ClubNoticeQueryService;
 import checkmo.clubNotice.internal.service.query.NoticeCommentQueryService;
 import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO;
-import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO.ClubNoticePreviewList;
+import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO.ClubNoticePreviewPage;
 import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO.EachItem;
 import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO.NoticeCommentList;
 import checkmo.common.template.CursorPagingHelper;
@@ -40,6 +40,7 @@ import org.springframework.stereotype.Service;
 public class ClubNoticeQueryFacade {
 
     private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final int MAX_PINNED_NOTICES = 5;
 
     private static final String ANONYMOUS_NAME = "익명";
     private static final String ANONYMOUS_PROFILE_URL = "https://avatars.githubusercontent.com/u/217887881?s=200&v=4";
@@ -51,32 +52,40 @@ public class ClubNoticeQueryFacade {
     private final ClubNoticeQueryService clubNoticeQueryService;
     private final NoticeCommentQueryService noticeCommentQueryService;
 
-    public ClubNoticePreviewList retrieveClubNoticeList(
+    public ClubNoticePreviewPage retrieveClubNoticeList(
             Long clubId,
             String memberId,
-            int page,
-            boolean pinned
+            int page
     ) {
         clubManagementAPI.validateClub(clubId);
         clubManagementAPI.fetchMembershipInfo(clubId, memberId);
 
-        PageResult<Notice> noticePageResult = PagePagingHelper.getPage(
-                pageable -> clubNoticeQueryService.retrieveNotices(clubId, pinned, pageable),
+        List<Notice> pinnedNotices = clubNoticeQueryService.retrievePinnedNotices(clubId, MAX_PINNED_NOTICES);
+
+        PageResult<Notice> normalPageResult = PagePagingHelper.getPage(
+                pageable -> clubNoticeQueryService.retrieveNormalNotices(clubId, pageable),
                 page,
                 DEFAULT_PAGE_SIZE
         );
 
-        return ClubNoticePreviewList.builder()
-                .noticeList(
-                        noticePageResult.content().stream()
+        return ClubNoticePreviewPage.builder()
+                .pinnedNotices(
+                        pinnedNotices.stream()
                                 .map(ClubNoticeConverter::toClubNoticePreview)
                                 .toList()
                 )
-                .page(noticePageResult.page())
-                .size(noticePageResult.size())
-                .totalElements(noticePageResult.totalElements())
-                .totalPages(noticePageResult.totalPages())
-                .hasNext(noticePageResult.hasNext())
+                .normalNotices(
+                        ClubNoticeResponseDTO.NormalNoticePreviewPage.builder()
+                                .notices(normalPageResult.content().stream()
+                                        .map(ClubNoticeConverter::toClubNoticePreview)
+                                        .toList())
+                                .page(normalPageResult.page())
+                                .size(normalPageResult.size())
+                                .totalElements(normalPageResult.totalElements())
+                                .totalPages(normalPageResult.totalPages())
+                                .hasNext(normalPageResult.hasNext())
+                                .build()
+                )
                 .build();
     }
 

--- a/src/main/java/checkmo/clubNotice/internal/service/query/ClubNoticeQueryService.java
+++ b/src/main/java/checkmo/clubNotice/internal/service/query/ClubNoticeQueryService.java
@@ -4,9 +4,11 @@ import checkmo.clubNotice.internal.entity.Notice;
 import checkmo.clubNotice.internal.exception.ClubNoticeErrorStatus;
 import checkmo.clubNotice.internal.exception.ClubNoticeException;
 import checkmo.clubNotice.internal.repository.NoticeRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,8 +23,15 @@ public class ClubNoticeQueryService {
         return noticeRepository.findWithVoteAndClubMemberVotesByIdAndClubId(noticeId, clubId);
     }
 
-    public Page<Notice> retrieveNotices(Long clubId, boolean pinned, Pageable pageable) {
-        return noticeRepository.findAllByClubIdAndPinned(clubId, pinned, pageable);
+    public List<Notice> retrievePinnedNotices(Long clubId, int limit) {
+        return noticeRepository.findTopPinnedByClubId(
+                clubId,
+                PageRequest.of(0, limit)
+        );
+    }
+
+    public Page<Notice> retrieveNormalNotices(Long clubId, Pageable pageable) {
+        return noticeRepository.findAllByClubIdAndPinned(clubId, false, pageable);
     }
 
     public Notice validateNotice(Long clubId, Long noticeId) throws ClubNoticeException {

--- a/src/main/java/checkmo/clubNotice/internal/service/query/ClubNoticeQueryService.java
+++ b/src/main/java/checkmo/clubNotice/internal/service/query/ClubNoticeQueryService.java
@@ -19,6 +19,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClubNoticeQueryService {
     private final NoticeRepository noticeRepository;
 
+    public Optional<Notice> retrieveLatestNotice(Long clubId) {
+        return noticeRepository.findTop1ByClubIdOrderByCreatedAtDescIdDesc(clubId);
+    }
+
     public Optional<Notice> retrieveNoticeDetailWithVoteAndClubMemberVotes(Long clubId, Long noticeId) {
         return noticeRepository.findWithVoteAndClubMemberVotesByIdAndClubId(noticeId, clubId);
     }

--- a/src/main/java/checkmo/clubNotice/web/controller/ClubNoticeController.java
+++ b/src/main/java/checkmo/clubNotice/web/controller/ClubNoticeController.java
@@ -7,7 +7,7 @@ import checkmo.clubNotice.internal.service.command.ClubNoticeCommandService;
 import checkmo.clubNotice.internal.service.command.NoticeCommentCommandService;
 import checkmo.clubNotice.web.dto.ClubNoticeRequestDTO;
 import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO;
-import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO.ClubNoticePreviewList;
+import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO.ClubNoticePreviewPage;
 import checkmo.clubNotice.web.dto.ClubNoticeResponseDTO.NoticeCommentList;
 import checkmo.common.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,7 +35,7 @@ public class ClubNoticeController {
     private final ClubNoticeCommandService clubNoticeCommandService;
     private final NoticeCommentCommandService noticeCommentCommandService;
 
-    @Operation(summary = "공지사항 목록 조회", description = "특정 모임의 공지사항 목록을 조회합니다. 중요한 공지 또는 중요하지 않은 공지만 조회합니다.")
+    @Operation(summary = "공지사항 목록 조회", description = "중요한 공지(최대 5개)와 중요하지 않은 공지(10개)를 조회합니다. offset 기반 페이지네이션은 중요하지 않은 공지에만 적용됩니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "모임 멤버가 아님"),
@@ -43,14 +43,13 @@ public class ClubNoticeController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "모임을 찾을 수 없음"),
     })
     @GetMapping
-    public ApiResponse<ClubNoticePreviewList> getNoticeList(
+    public ApiResponse<ClubNoticePreviewPage> getNoticeList(
             @CurrentId String memberId,
             @PathVariable Long clubId,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(name = "is-pinned", defaultValue = "false") boolean pinned
+            @RequestParam(defaultValue = "1") int page
     ) {
         return ApiResponse.onSuccess(
-                clubNoticeQueryFacade.retrieveClubNoticeList(clubId, memberId, page, pinned));
+                clubNoticeQueryFacade.retrieveClubNoticeList(clubId, memberId, page));
     }
 
     @Operation(summary = "공지사항 상세 조회", description = "공지사항 상세 정보를 조회합니다.")

--- a/src/main/java/checkmo/clubNotice/web/controller/ClubNoticeController.java
+++ b/src/main/java/checkmo/clubNotice/web/controller/ClubNoticeController.java
@@ -35,6 +35,18 @@ public class ClubNoticeController {
     private final ClubNoticeCommandService clubNoticeCommandService;
     private final NoticeCommentCommandService noticeCommentCommandService;
 
+    @Operation(summary = "최신 공지사항 1개 조회", description = "모임의 최신 공지사항 1개를 조회합니다. 공지사항이 없을 경우 NOTICE_EMTPY 에러를 반환합니다.")
+    @GetMapping("/latest")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "모임을 찾을 수 없음"),
+    })
+    public ApiResponse<ClubNoticeResponseDTO.LatestNoticePreview> getLatestNotice(
+            @PathVariable Long clubId
+    ) {
+        return ApiResponse.onSuccess(clubNoticeQueryFacade.retrieveLatestNotice(clubId));
+    }
+
     @Operation(summary = "공지사항 목록 조회", description = "중요한 공지(최대 5개)와 중요하지 않은 공지(10개)를 조회합니다. offset 기반 페이지네이션은 중요하지 않은 공지에만 적용됩니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),

--- a/src/main/java/checkmo/clubNotice/web/dto/ClubNoticeRequestDTO.java
+++ b/src/main/java/checkmo/clubNotice/web/dto/ClubNoticeRequestDTO.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
@@ -103,9 +104,10 @@ public class ClubNoticeRequestDTO {
     @Getter
     @NoArgsConstructor
     public static class VoteResult {
-        @NotNull(message = "선택한 투표 항목 번호는 필수입니다.")
-        @Size(min = 1, max = 6, message = "투표 항목 번호는 1부터 6 사이여야 합니다.")
-        private List<@Min(1) @Max(6) Integer> selectedItemNumbers;
+        @NotEmpty(message = "투표 항목을 최소 1개 이상 선택해야 합니다.")
+        @Size(max = 6, message = "투표 항목은 최대 6개이하여야 합니다.")
+        private List<@Min(value = 1, message = "투표 항목 번호는 1 이상이어야 합니다.")
+        @Max(value = 6, message = "투표 항목 번호는 6이하여야 합니다.") Integer> selectedItemNumbers;
 
         // 몇 개를 선택했는지 확인하는 DTO용 메서드로, 복수 선택 검증에서 사용됨
         public int countSelectedItems() {

--- a/src/main/java/checkmo/clubNotice/web/dto/ClubNoticeResponseDTO.java
+++ b/src/main/java/checkmo/clubNotice/web/dto/ClubNoticeResponseDTO.java
@@ -19,6 +19,15 @@ public class ClubNoticeResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    public static class LatestNoticePreview {
+        private Long id;
+        private String title;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     public static class ClubNoticePreviewPage {
         private List<ClubNoticePreview> pinnedNotices;
         private NormalNoticePreviewPage normalNotices;

--- a/src/main/java/checkmo/clubNotice/web/dto/ClubNoticeResponseDTO.java
+++ b/src/main/java/checkmo/clubNotice/web/dto/ClubNoticeResponseDTO.java
@@ -19,8 +19,17 @@ public class ClubNoticeResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class ClubNoticePreviewList {
-        List<ClubNoticePreview> noticeList;
+    public static class ClubNoticePreviewPage {
+        private List<ClubNoticePreview> pinnedNotices;
+        private NormalNoticePreviewPage normalNotices;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class NormalNoticePreviewPage {
+        private List<ClubNoticePreview> notices;
         private int page;
         private int size;
         private long totalElements;
@@ -32,7 +41,7 @@ public class ClubNoticeResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static final class ClubNoticePreview {
+    public static class ClubNoticePreview {
         private Long id;
         private String title;
         @Getter(AccessLevel.NONE)


### PR DESCRIPTION
## 🚀 변경사항
- 내 독서모임 전체 조회 (무한 스크롤 X)
- 공지사항 API 개발 마무리
  - 고정 공지사항, 고정 아닌 공지사항 합쳐서 페이지네이션
  - 가장 최근 공지사항 1개 조회 API
  - 다시 투표했을 때 아무것도 선택하지 않고 제출하지 않도록 막기

## 🔗 관련 이슈
- Closes #174 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staff status indicator for meeting attendees
  * Added endpoint to retrieve the latest club notice
  * Restructured notice list to separate pinned and regular notices

* **Bug Fixes**
  * My clubs list now displays all clubs without pagination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->