### PR TITLE
[REFACTOR] teamNumber 기반에서 teamId 기반 작동으로 변경 + 클럽 삭제

### DIFF
--- a/src/main/java/checkmo/clubManagement/ClubManagementEvent.java
+++ b/src/main/java/checkmo/clubManagement/ClubManagementEvent.java
@@ -13,10 +13,10 @@ public class ClubManagementEvent {
     }
 
     @Builder
-    public record ClubDeletedEvent(Long clubId) {
+    public record DeletedClubEvent(Long clubId) {
     }
 
     @Builder
-    public record DeleteClubImage(String imageUrl) {
+    public record DeleteClubImageEvent(String imageUrl) {
     }
 }

--- a/src/main/java/checkmo/clubManagement/internal/service/command/ClubManagementCommandService.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/command/ClubManagementCommandService.java
@@ -1,6 +1,7 @@
 package checkmo.clubManagement.internal.service.command;
 
-import checkmo.clubManagement.ClubManagementEvent;
+import checkmo.clubManagement.ClubManagementEvent.DeleteClubImageEvent;
+import checkmo.clubManagement.ClubManagementEvent.DeletedClubEvent;
 import checkmo.clubManagement.internal.converter.ClubManagementConverter;
 import checkmo.clubManagement.internal.entity.Club;
 import checkmo.clubManagement.internal.entity.ClubMember;
@@ -13,6 +14,7 @@ import checkmo.clubManagement.web.dto.ClubRequestDTO.ClubDetail;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class ClubManagementCommandService {
 
     private final ClubManagementQueryService clubManagementQueryService;
@@ -53,11 +56,7 @@ public class ClubManagementCommandService {
 
         String oldImageUrl = club.getProfileImgUrl();
         if (oldImageUrl != null && !oldImageUrl.equals(request.getProfileImageUrl())) {
-            applicationEventPublisher.publishEvent(
-                    ClubManagementEvent.DeleteClubImage.builder()
-                            .imageUrl(oldImageUrl)
-                            .build()
-            );
+            publishDeletedClubImageEvent(oldImageUrl);
         }
 
         club.updateField(
@@ -83,10 +82,39 @@ public class ClubManagementCommandService {
         }
     }
 
-    // TODO: 클럽이 삭제될 때, 이벤트 발행
     public void deleteClub(Long clubId, String memberId) {
+        Club club = clubManagementQueryService.validateClub(clubId);
+        ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
+        if (!clubMember.isOwner()) {
+            throw new ClubManagementException(ClubManagementErrorStatus.CLUB_OWNER_ONLY);
+        }
+
+        String profileImgUrl = club.getProfileImgUrl();
+        if (profileImgUrl != null) {
+            publishDeletedClubImageEvent(profileImgUrl);
+        }
+
+        log.info("클럽 삭제 시작: clubId={}, memberId={}, deletedAt={}", clubId, memberId, LocalDateTime.now());
+        publishDeletedClubEvent(club.getId());
+        clubRepository.delete(club);
         // Club을 삭제함으로써 Cascade.REMOVE가 동작되어 ClubManagement 모듈 내 모든 엔티티(클럽 멤버, 책 추천, 클럽 카테고리) 제거
         // Meeting을 삭제함으로써 Cascade.REMOVE가 동작되어 ClubMeeting 모듈 내 모든 엔티티(토픽, 팀, 팀 토픽, 멤터 팀, 한줄평) 제거
         // Notice를 삭제함으로써 Cascade.REMOVE가 동작되어 ClubNotice 모듈 내 모든 엔티티(투표, 회원 투표) 제거 (단, 비즈니스 요구사항 변경에 따라 Notice와 Vote는 연관관계 수정되어야 함 -2025.11.12 기준-)
+    }
+
+    private void publishDeletedClubEvent(Long clubId) {
+        applicationEventPublisher.publishEvent(
+                DeletedClubEvent.builder()
+                        .clubId(clubId)
+                        .build()
+        );
+    }
+
+    private void publishDeletedClubImageEvent(String oldImageUrl) {
+        applicationEventPublisher.publishEvent(
+                DeleteClubImageEvent.builder()
+                        .imageUrl(oldImageUrl)
+                        .build()
+        );
     }
 }

--- a/src/main/java/checkmo/clubManagement/web/controller/ClubController.java
+++ b/src/main/java/checkmo/clubManagement/web/controller/ClubController.java
@@ -108,6 +108,24 @@ public class ClubController {
         return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveClubDetail(clubId, memberId));
     }
 
+    @Operation(summary = "[개설자] 독서 모임 삭제", description = "지정한 클럽을 삭제합니다. 삭제된 클럽은 복구할 수 없습니다.")
+    @Parameters({
+            @Parameter(name = "clubId", description = "삭제할 독서클럽 ID", required = true, example = "1"),
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "독서클럽 운영진만 접근할 수 있습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 독서클럽을 찾을 수 없습니다.")
+    })
+    @DeleteMapping("/{clubId}")
+    public ApiResponse<String> deleteClub(
+            @PathVariable Long clubId,
+            @CurrentId String memberId
+    ) {
+        clubManagementCommandService.deleteClub(clubId, memberId);
+        return ApiResponse.onSuccess("독서모임이 정상적으로 삭제되었습니다.");
+    }
+
     @Operation(summary = "독서 모임 검색", description = "키워드와 필터 기반으로 독서 모임을 검색합니다.")
     @Parameters({
             @Parameter(name = "cursorId", description = "커서 기반 페이지네이션을 위한 마지막 독서 모임 ID", required = false, example = "10"),

--- a/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
+++ b/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
@@ -11,7 +11,9 @@ import checkmo.clubMeeting.web.dto.bookshelf.BookShelfRequestDTO.BookShelfCreate
 import checkmo.clubMeeting.web.dto.bookshelf.BookShelfResponseDTO;
 import checkmo.clubMeeting.web.dto.meeting.MeetingResponseDTO;
 import checkmo.clubMeeting.web.dto.meeting.MeetingResponseDTO.MeetingInfo;
+import checkmo.clubMeeting.web.dto.meeting.MeetingResponseDTO.TeamKey;
 import checkmo.member.MemberExternalDTO;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
@@ -140,10 +142,12 @@ public class ClubMeetingConverter {
         Map<Integer, List<MeetingResponseDTO.MeetingMember>> safeTeamNumberToMembers
                 = (teamNumberToMembers != null) ? teamNumberToMembers : Map.of();
 
-        List<Integer> existingTeamNumbers = safeTeams.stream()
-                .map(Team::getTeamNumber)
-                .distinct()
-                .sorted()
+        List<MeetingResponseDTO.TeamKey> existingTeams = safeTeams.stream()
+                .map(team -> MeetingResponseDTO.TeamKey.builder()
+                        .teamId(team.getId())
+                        .teamNumber(team.getTeamNumber())
+                        .build())
+                .sorted(Comparator.comparingInt(TeamKey::getTeamNumber))
                 .toList();
 
         return MeetingInfo.builder()
@@ -151,11 +155,11 @@ public class ClubMeetingConverter {
                 .title(meeting.getTitle())
                 .meetingTime(meeting.getMeetingTime())
                 .location(meeting.getLocation())
-                .existingTeamNumbers(existingTeamNumbers)
-                .teams(existingTeamNumbers.stream()
-                        .map(teamNumber -> MeetingResponseDTO.TeamMember.builder()
-                                .teamNumber(teamNumber)
-                                .members(safeTeamNumberToMembers.getOrDefault(teamNumber, List.of()))
+                .existingTeams(existingTeams)
+                .teamMembers(existingTeams.stream()
+                        .map(teamKey -> MeetingResponseDTO.TeamMember.builder()
+                                .teamKey(teamKey)
+                                .members(safeTeamNumberToMembers.getOrDefault(teamKey.getTeamNumber(), List.of()))
                                 .build())
                         .toList())
                 .staff(staff)

--- a/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
+++ b/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
@@ -163,12 +163,19 @@ public class ClubMeetingConverter {
     public static List<MeetingResponseDTO.TeamKey> toExistingTeamsDTO(List<Team> teams) {
         List<Team> safeTeams = (teams != null) ? teams : List.of();
         return safeTeams.stream()
-                .map(t -> MeetingResponseDTO.TeamKey.builder()
-                        .teamId(t.getId())
-                        .teamNumber(t.getTeamNumber())
-                        .build())
+                .map(ClubMeetingConverter::toTeamKeyDTO)
                 .sorted(Comparator.comparingInt(MeetingResponseDTO.TeamKey::getTeamNumber))
                 .toList();
+    }
+
+    public static MeetingResponseDTO.TeamKey toTeamKeyDTO(Team team) {
+        if (team == null) {
+            return null;
+        }
+        return MeetingResponseDTO.TeamKey.builder()
+                .teamId(team.getId())
+                .teamNumber(team.getTeamNumber())
+                .build();
     }
 
     public static List<MeetingResponseDTO.MeetingMember> toMeetingMembersDTO(

--- a/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
+++ b/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
@@ -1,6 +1,7 @@
 package checkmo.clubMeeting.internal.converter;
 
 import checkmo.book.BookExternalDTO;
+import checkmo.clubManagement.ClubManagementExternalDTO.MembershipInfo;
 import checkmo.clubMeeting.ClubMeetingExternalDTO.DetailInfo;
 import checkmo.clubMeeting.internal.entity.BookReview;
 import checkmo.clubMeeting.internal.entity.Meeting;
@@ -132,23 +133,15 @@ public class ClubMeetingConverter {
                 .build();
     }
 
-    public static MeetingInfo toMeetingInfoWithTeams(
+    public static MeetingInfo toMeetingInfoDTO(
             Meeting meeting,
             List<Team> teams,
             Map<Integer, List<MeetingResponseDTO.MeetingMember>> teamNumberToMembers,
             boolean staff
     ) {
-        List<Team> safeTeams = (teams != null) ? teams : List.of();
+        List<TeamKey> existingTeams = toExistingTeamsDTO(teams);
         Map<Integer, List<MeetingResponseDTO.MeetingMember>> safeTeamNumberToMembers
                 = (teamNumberToMembers != null) ? teamNumberToMembers : Map.of();
-
-        List<MeetingResponseDTO.TeamKey> existingTeams = safeTeams.stream()
-                .map(team -> MeetingResponseDTO.TeamKey.builder()
-                        .teamId(team.getId())
-                        .teamNumber(team.getTeamNumber())
-                        .build())
-                .sorted(Comparator.comparingInt(TeamKey::getTeamNumber))
-                .toList();
 
         return MeetingInfo.builder()
                 .meetingId(meeting.getId())
@@ -165,6 +158,54 @@ public class ClubMeetingConverter {
                 .staff(staff)
                 .build();
 
+    }
+
+    public static List<MeetingResponseDTO.TeamKey> toExistingTeamsDTO(List<Team> teams) {
+        List<Team> safeTeams = (teams != null) ? teams : List.of();
+        return safeTeams.stream()
+                .map(t -> MeetingResponseDTO.TeamKey.builder()
+                        .teamId(t.getId())
+                        .teamNumber(t.getTeamNumber())
+                        .build())
+                .sorted(Comparator.comparingInt(MeetingResponseDTO.TeamKey::getTeamNumber))
+                .toList();
+    }
+
+    public static List<MeetingResponseDTO.MeetingMember> toMeetingMembersDTO(
+            List<MembershipInfo> clubMemberships,
+            Map<String, MemberExternalDTO.BasicInfo> memberBasicInfoMap,
+            Map<Long, Long> clubMemberIdToTeamIdMap,
+            Map<Long, Integer> teamIdToTeamNumberMap
+    ) {
+        List<MembershipInfo> safeMemberships = (clubMemberships != null) ? clubMemberships : List.of();
+        Map<String, MemberExternalDTO.BasicInfo> safeMemberInfoMap =
+                (memberBasicInfoMap != null) ? memberBasicInfoMap : Map.of();
+        Map<Long, Long> safeClubMemberToTeamIdMap =
+                (clubMemberIdToTeamIdMap != null) ? clubMemberIdToTeamIdMap : Map.of();
+        Map<Long, Integer> safeTeamIdToTeamNumberMap =
+                (teamIdToTeamNumberMap != null) ? teamIdToTeamNumberMap : Map.of();
+
+        return safeMemberships.stream()
+                .map(m -> {
+                    Long clubMemberId = m.getClubMemberId();
+                    String memberId = m.getMemberId();
+
+                    MemberExternalDTO.BasicInfo basic = safeMemberInfoMap.get(memberId);
+
+                    Long teamId = safeClubMemberToTeamIdMap.get(clubMemberId);
+                    MeetingResponseDTO.TeamKey teamKey = (teamId == null) ? null
+                            : MeetingResponseDTO.TeamKey.builder()
+                                    .teamId(teamId)
+                                    .teamNumber(safeTeamIdToTeamNumberMap.get(teamId))
+                                    .build();
+
+                    return MeetingResponseDTO.MeetingMember.builder()
+                            .clubMemberId(clubMemberId)
+                            .memberInfo(basic)
+                            .teamKey(teamKey)
+                            .build();
+                })
+                .toList();
     }
 
     // =====================================================

--- a/src/main/java/checkmo/clubMeeting/internal/listener/ClubMeetingEventListener.java
+++ b/src/main/java/checkmo/clubMeeting/internal/listener/ClubMeetingEventListener.java
@@ -1,0 +1,18 @@
+package checkmo.clubMeeting.internal.listener;
+
+import checkmo.clubManagement.ClubManagementEvent.DeletedClubEvent;
+import checkmo.clubMeeting.internal.service.command.ClubMeetingCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ClubMeetingEventListener {
+    private final ClubMeetingCommandService clubMeetingCommandService;
+
+    @ApplicationModuleListener
+    public void handleDeletedClubEvent(DeletedClubEvent event) {
+        clubMeetingCommandService.deleteAll(event.clubId());
+    }
+}

--- a/src/main/java/checkmo/clubMeeting/internal/repository/MeetingRepository.java
+++ b/src/main/java/checkmo/clubMeeting/internal/repository/MeetingRepository.java
@@ -2,6 +2,7 @@ package checkmo.clubMeeting.internal.repository;
 
 import checkmo.clubMeeting.internal.entity.Meeting;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,6 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long>, Meeting
             Long clubId, LocalDateTime now);
 
     Optional<Meeting> findByClubIdAndId(Long clubId, Long meetingId);
+
+    List<Meeting> findAllByClubId(Long clubId);
 }

--- a/src/main/java/checkmo/clubMeeting/internal/repository/TeamRepository.java
+++ b/src/main/java/checkmo/clubMeeting/internal/repository/TeamRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
+    Optional<Team> findByIdAndMeetingId(Long id, Long meetingId);
+
     Optional<Team> findByMeetingIdAndTeamNumber(Long meetingId, Integer teamNumber);
 
     List<Team> findAllByMeetingIdOrderByTeamNumberAsc(Long meetingId);

--- a/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
@@ -166,7 +166,7 @@ public class ClubMeetingQueryFacade {
 
         List<Team> teams = clubMeetingTeamQueryService.retrieveTeams(meetingId);
         if (teams == null || teams.isEmpty()) {
-            return ClubMeetingConverter.toMeetingInfoWithTeams(meeting, List.of(), Map.of(), staff);
+            return ClubMeetingConverter.toMeetingInfoDTO(meeting, List.of(), Map.of(), staff);
         }
 
         List<Long> teamIds = ExtractHelper.extractDistinctList(teams, Team::getId);
@@ -175,7 +175,7 @@ public class ClubMeetingQueryFacade {
         // 미팅의 모든 팀원 조회
         Map<Long, Long> clubMemberIdToTeamIdMap = clubMeetingTeamQueryService.retrieveTeamIdByClubMemberId(teamIds);
         if (clubMemberIdToTeamIdMap == null || clubMemberIdToTeamIdMap.isEmpty()) {
-            return ClubMeetingConverter.toMeetingInfoWithTeams(meeting, teams, Map.of(), staff);
+            return ClubMeetingConverter.toMeetingInfoDTO(meeting, teams, Map.of(), staff);
         }
 
         // 클럽 멤버의 멤버십 정보 배치 조회
@@ -194,7 +194,7 @@ public class ClubMeetingQueryFacade {
                 memberBasicInfoMap
         );
 
-        return ClubMeetingConverter.toMeetingInfoWithTeams(meeting, teams, teamNumberToMembersMap, staff);
+        return ClubMeetingConverter.toMeetingInfoDTO(meeting, teams, teamNumberToMembersMap, staff);
     }
 
     public MeetingResponseDTO.MeetingMemberList retrieveMeetingMemberList(
@@ -209,37 +209,43 @@ public class ClubMeetingQueryFacade {
         }
         clubMeetingQueryService.validateMeeting(clubId, meetingId);
 
+        // 미팅에 존재하는 모든 팀 조회
+        List<Team> teams = clubMeetingTeamQueryService.retrieveTeams(meetingId);
+        List<Long> teamIds = ExtractHelper.extractDistinctList(teams, Team::getId);
+        Map<Long, Integer> teamIdToTeamNumberMap = mapTeamIdToTeamNumber(teams);
+
+        // 전체 클럽 회원 조회
         CursorResult<MembershipInfo> membershipCursorResult = CursorPagingHelper.getPage(
                 size -> clubManagementAPI.fetchActiveMembershipInfo(clubId, cursorId, size),
                 MembershipInfo::getClubMemberId,
                 DEFAULT_PAGE_SIZE
         );
         List<MembershipInfo> clubMembershipList = membershipCursorResult.content();
-
+        if (clubMembershipList == null || clubMembershipList.isEmpty()) {
+            return MeetingResponseDTO.MeetingMemberList.builder()
+                    .existingTeams(ClubMeetingConverter.toExistingTeamsDTO(teams))
+                    .clubMembers(List.of())
+                    .hasNext(membershipCursorResult.hasNext())
+                    .nextCursor(membershipCursorResult.nextCursor())
+                    .build();
+        }
+        // 클럽 멤버의 멤버 정보 배치 조회
         Map<String, MemberExternalDTO.BasicInfo> memberInfoMap
                 = memberAPI.fetchMemberBasicInfoByMemberIds(
                 ExtractHelper.extractDistinctList(clubMembershipList, MembershipInfo::getMemberId));
 
-        // 미팅에 존재하는 모든 팀 조회
-        List<Team> teams = clubMeetingTeamQueryService.retrieveTeams(meetingId);
-        Map<Long, Integer> teamIdToTeamNumberMap = mapTeamIdToTeamNumber(teams);
-        List<Long> teamIds = ExtractHelper.extractDistinctList(teams, Team::getId);
-
-        // Map<clubMemberId, teamId> 형태로 모든 팀의 팀원 조회
-        Map<Long, Long> memberIdToTeamIdMap = clubMeetingTeamQueryService.retrieveTeamIdByClubMemberId(teamIds);
-
-        // memberId -> teamNumber 맵 구성
-        Map<Long, Integer> memberIdToTeamNumberMap
-                = mapClubMemberIdToTeamNumber(clubMembershipList, memberIdToTeamIdMap, teamIdToTeamNumberMap);
-
+        // 팀 배정 정보 조회
+        Map<Long, Long> clubMemberIdToTeamIdMap = clubMeetingTeamQueryService.retrieveTeamIdByClubMemberId(teamIds);
         return MeetingResponseDTO.MeetingMemberList.builder()
-                .members(
-                        clubMembershipList.stream()
-                                .map(membership
-                                        -> toMeetingMemberDTO(membership, memberInfoMap, memberIdToTeamNumberMap))
-                                .toList()
+                .existingTeams(ClubMeetingConverter.toExistingTeamsDTO(teams))
+                .clubMembers(
+                        ClubMeetingConverter.toMeetingMembersDTO(
+                                clubMembershipList,
+                                memberInfoMap,
+                                clubMemberIdToTeamIdMap,
+                                teamIdToTeamNumberMap
+                        )
                 )
-                .existingTeamNumbers(ExtractHelper.extractDistinctList(teams, Team::getTeamNumber))
                 .hasNext(membershipCursorResult.hasNext())
                 .nextCursor(membershipCursorResult.nextCursor())
                 .build();
@@ -323,32 +329,6 @@ public class ClubMeetingQueryFacade {
                 .toList();
     }
 
-    private Map<Long, Integer> mapClubMemberIdToTeamNumber(
-            List<MembershipInfo> membershipInfos,
-            Map<Long, Long> clubMemberIdToTeamIdMap,
-            Map<Long, Integer> teamIdToTeamNumberMap
-    ) {
-        if (membershipInfos == null || membershipInfos.isEmpty()) {
-            return Map.of();
-        }
-
-        Map<Long, Integer> result = new HashMap<>();
-        for (MembershipInfo membershipInfo : membershipInfos) {
-            Long clubMemberId = membershipInfo.getClubMemberId();
-            Long teamId = clubMemberIdToTeamIdMap.get(clubMemberId);
-            if (teamId == null) {
-                // 팀이 없는 멤버는 teamNumber = null
-                result.put(clubMemberId, null);
-                continue;
-            }
-
-            Integer teamNumber = teamIdToTeamNumberMap.get(teamId);
-            result.put(clubMemberId, teamNumber);
-        }
-
-        return result;
-    }
-
     private Map<Integer, List<MeetingResponseDTO.MeetingMember>> mapTeamNumberToMeetingMembers(
             Map<Long, Long> clubMemberIdToTeamIdMap,
             Map<Long, Integer> teamIdToTeamNumberMap,
@@ -379,7 +359,7 @@ public class ClubMeetingQueryFacade {
             MeetingResponseDTO.MeetingMember dto = MeetingResponseDTO.MeetingMember.builder()
                     .clubMemberId(clubMemberId)
                     .memberInfo(info)
-                    .teamNumber(null)
+                    .teamKey(null)
                     .build();
 
             result.computeIfAbsent(teamNumber, k -> new java.util.ArrayList<>()).add(dto);
@@ -397,21 +377,6 @@ public class ClubMeetingQueryFacade {
                         Team::getId, // key: 팀 ID
                         Team::getTeamNumber // value: 팀 번호
                 ));
-    }
-
-    private MeetingResponseDTO.MeetingMember toMeetingMemberDTO(
-            MembershipInfo membershipInfo,
-            Map<String, MemberExternalDTO.BasicInfo> memberBasicInfoMap,
-            Map<Long, Integer> clubMemberIdToTeamNumberMap
-    ) {
-        MemberExternalDTO.BasicInfo memberInfo = memberBasicInfoMap.get(membershipInfo.getMemberId());
-        Long clubMemberId = membershipInfo.getClubMemberId();
-        Integer teamNumber = clubMemberIdToTeamNumberMap.get(clubMemberId);
-        return MeetingResponseDTO.MeetingMember.builder()
-                .clubMemberId(clubMemberId)
-                .memberInfo(memberInfo)
-                .teamNumber(teamNumber)
-                .build();
     }
 
     // ========== 추출 메서드 ==========

--- a/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
@@ -21,6 +21,7 @@ import checkmo.clubMeeting.web.dto.bookshelf.BookShelfResponseDTO;
 import checkmo.clubMeeting.web.dto.bookshelf.BookShelfResponseDTO.BookShelfDetail;
 import checkmo.clubMeeting.web.dto.meeting.MeetingResponseDTO;
 import checkmo.clubMeeting.web.dto.meeting.MeetingResponseDTO.MeetingMemberList;
+import checkmo.clubMeeting.web.dto.meeting.MeetingResponseDTO.TeamKey;
 import checkmo.common.template.CursorPagingHelper;
 import checkmo.common.template.CursorResult;
 import checkmo.common.template.ExtractHelper;
@@ -236,12 +237,14 @@ public class ClubMeetingQueryFacade {
     }
 
     public MeetingResponseDTO.TeamTopic retrieveSelectableTopics(
-            Long clubId, Long meetingId, Integer teamNumber, String memberId, Long cursorId) {
+            Long clubId, Long meetingId, Long teamId, String memberId, Long cursorId
+    ) {
         validateClubAndClubMembership(clubId, memberId);
         clubMeetingQueryService.validateMeeting(clubId, meetingId);
-        Team team = clubMeetingTeamQueryService.validateTeam(meetingId, teamNumber);
+        Team team = clubMeetingTeamQueryService.validateTeam(meetingId, teamId);
 
-        List<Integer> existingTeamNumbers = clubMeetingTeamQueryService.retrieveExistingTeamNumbers(meetingId);
+        List<Team> teams = clubMeetingTeamQueryService.retrieveTeams(meetingId);
+        List<TeamKey> existingTeams = ClubMeetingConverter.toExistingTeamsDTO(teams);
 
         CursorResult<Topic> topicCursorResult = CursorPagingHelper.getPage(
                 size -> clubTopicQueryService.retrieveTopics(meetingId, cursorId, size),
@@ -259,8 +262,8 @@ public class ClubMeetingQueryFacade {
                 ExtractHelper.extractDistinctList(topics, Topic::getMemberId));
 
         return MeetingResponseDTO.TeamTopic.builder()
-                .existingTeamNumbers(existingTeamNumbers)
-                .requestedTeamNumber(teamNumber)
+                .existingTeams(existingTeams)
+                .requestedTeam(ClubMeetingConverter.toTeamKeyDTO(team))
                 .topics(topics.stream()
                         .map(t -> ClubMeetingConverter.toTopicDTO(
                                         t,

--- a/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
@@ -20,6 +20,7 @@ import checkmo.clubMeeting.internal.service.query.ClubTopicQueryService;
 import checkmo.clubMeeting.web.dto.bookshelf.BookShelfResponseDTO;
 import checkmo.clubMeeting.web.dto.bookshelf.BookShelfResponseDTO.BookShelfDetail;
 import checkmo.clubMeeting.web.dto.meeting.MeetingResponseDTO;
+import checkmo.clubMeeting.web.dto.meeting.MeetingResponseDTO.MeetingMemberList;
 import checkmo.common.template.CursorPagingHelper;
 import checkmo.common.template.CursorResult;
 import checkmo.common.template.ExtractHelper;
@@ -211,7 +212,6 @@ public class ClubMeetingQueryFacade {
 
         // 미팅에 존재하는 모든 팀 조회
         List<Team> teams = clubMeetingTeamQueryService.retrieveTeams(meetingId);
-        List<Long> teamIds = ExtractHelper.extractDistinctList(teams, Team::getId);
         Map<Long, Integer> teamIdToTeamNumberMap = mapTeamIdToTeamNumber(teams);
 
         // 전체 클럽 회원 조회
@@ -222,12 +222,7 @@ public class ClubMeetingQueryFacade {
         );
         List<MembershipInfo> clubMembershipList = membershipCursorResult.content();
         if (clubMembershipList == null || clubMembershipList.isEmpty()) {
-            return MeetingResponseDTO.MeetingMemberList.builder()
-                    .existingTeams(ClubMeetingConverter.toExistingTeamsDTO(teams))
-                    .clubMembers(List.of())
-                    .hasNext(membershipCursorResult.hasNext())
-                    .nextCursor(membershipCursorResult.nextCursor())
-                    .build();
+            return buildEmptyMeetingMemberList(teams, membershipCursorResult);
         }
         // 클럽 멤버의 멤버 정보 배치 조회
         Map<String, MemberExternalDTO.BasicInfo> memberInfoMap
@@ -235,20 +230,9 @@ public class ClubMeetingQueryFacade {
                 ExtractHelper.extractDistinctList(clubMembershipList, MembershipInfo::getMemberId));
 
         // 팀 배정 정보 조회
-        Map<Long, Long> clubMemberIdToTeamIdMap = clubMeetingTeamQueryService.retrieveTeamIdByClubMemberId(teamIds);
-        return MeetingResponseDTO.MeetingMemberList.builder()
-                .existingTeams(ClubMeetingConverter.toExistingTeamsDTO(teams))
-                .clubMembers(
-                        ClubMeetingConverter.toMeetingMembersDTO(
-                                clubMembershipList,
-                                memberInfoMap,
-                                clubMemberIdToTeamIdMap,
-                                teamIdToTeamNumberMap
-                        )
-                )
-                .hasNext(membershipCursorResult.hasNext())
-                .nextCursor(membershipCursorResult.nextCursor())
-                .build();
+        Map<Long, Long> clubMemberIdToTeamIdMap = retrieveClubMemberIdToTeamIdMap(teams);
+        return buildMeetingMemberList(teams, clubMembershipList, memberInfoMap, clubMemberIdToTeamIdMap,
+                teamIdToTeamNumberMap, membershipCursorResult);
     }
 
     public MeetingResponseDTO.TeamTopic retrieveSelectableTopics(
@@ -293,6 +277,49 @@ public class ClubMeetingQueryFacade {
     private MembershipInfo validateClubAndClubMembership(Long clubId, String memberId) {
         clubManagementAPI.validateClub(clubId);
         return clubManagementAPI.fetchMembershipInfo(clubId, memberId);
+    }
+
+    private Map<Long, Long> retrieveClubMemberIdToTeamIdMap(List<Team> teams) {
+        if (teams == null || teams.isEmpty()) {
+            return Map.of();
+        }
+        List<Long> teamIds = ExtractHelper.extractDistinctList(teams, Team::getId);
+        return clubMeetingTeamQueryService.retrieveTeamIdByClubMemberId(teamIds);
+    }
+
+    private MeetingMemberList buildEmptyMeetingMemberList(
+            List<Team> teams,
+            CursorResult<MembershipInfo> membershipCursorResult
+    ) {
+        return MeetingMemberList.builder()
+                .existingTeams(ClubMeetingConverter.toExistingTeamsDTO(teams))
+                .clubMembers(List.of())
+                .hasNext(membershipCursorResult.hasNext())
+                .nextCursor(membershipCursorResult.nextCursor())
+                .build();
+    }
+
+    private MeetingMemberList buildMeetingMemberList(
+            List<Team> teams,
+            List<MembershipInfo> clubMembershipList,
+            Map<String, MemberExternalDTO.BasicInfo> memberInfoMap,
+            Map<Long, Long> clubMemberIdToTeamIdMap,
+            Map<Long, Integer> teamIdToTeamNumberMap,
+            CursorResult<MembershipInfo> membershipCursorResult
+    ) {
+        return MeetingMemberList.builder()
+                .existingTeams(ClubMeetingConverter.toExistingTeamsDTO(teams))
+                .clubMembers(
+                        ClubMeetingConverter.toMeetingMembersDTO(
+                                clubMembershipList,
+                                memberInfoMap,
+                                clubMemberIdToTeamIdMap,
+                                teamIdToTeamNumberMap
+                        )
+                )
+                .hasNext(membershipCursorResult.hasNext())
+                .nextCursor(membershipCursorResult.nextCursor())
+                .build();
     }
 
     private List<BookShelfResponseDTO.TopicDetail> mapTopicsToTopicDetail(

--- a/src/main/java/checkmo/clubMeeting/internal/service/command/ClubMeetingCommandService.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/command/ClubMeetingCommandService.java
@@ -161,4 +161,10 @@ public class ClubMeetingCommandService {
                 .toList();
         toRemove.forEach(meeting::removeTeam);
     }
+
+    public void deleteAll(Long clubId) {
+        List<Meeting> meetings = meetingRepository.findAllByClubId(clubId);
+        meetingRepository.deleteAll(meetings);
+        meetingRepository.flush();
+    }
 }

--- a/src/main/java/checkmo/clubMeeting/internal/service/query/ClubMeetingTeamQueryService.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/query/ClubMeetingTeamQueryService.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,14 +27,6 @@ public class ClubMeetingTeamQueryService {
 
     public List<Team> retrieveTeams(Long meetingId) {
         return teamRepository.findAllByMeetingIdOrderByTeamNumberAsc(meetingId);
-    }
-
-    public List<Integer> retrieveExistingTeamNumbers(Long meetingId) {
-        return teamRepository.findTeamNumberByMeetingId(meetingId);
-    }
-
-    public List<ClubMemberTeam> retrieveClubMemberTeams(Long teamId, Long cursorId, int size) {
-        return clubMemberTeamRepository.findAllByTeamIdsAndCursorId(teamId, cursorId, PageRequest.of(0, size));
     }
 
     public Map<Long, Long> retrieveTeamIdByClubMemberId(List<Long> teamIds) {
@@ -56,6 +47,11 @@ public class ClubMeetingTeamQueryService {
             return Set.of();
         }
         return new HashSet<>(teamTopicRepository.findTopicIdsByTeamIdAndTopicIds(teamId, topicIds));
+    }
+
+    public Team validateTeam(Long meetingId, Long teamId) throws ClubMeetingException {
+        return teamRepository.findByIdAndMeetingId(teamId, meetingId)
+                .orElseThrow(() -> new ClubMeetingException(ClubMeetingErrorStatus.TEAM_NOT_FOUND));
     }
 
     public Team validateTeam(Long meetingId, Integer teamNumber) throws ClubMeetingException {

--- a/src/main/java/checkmo/clubMeeting/web/controller/ClubMeetingController.java
+++ b/src/main/java/checkmo/clubMeeting/web/controller/ClubMeetingController.java
@@ -21,7 +21,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -152,29 +151,4 @@ public class ClubMeetingController {
                 clubMeetingQueryFacade.retrieveSelectableTopics(clubId, meetingId, teamNumber, memberId, cursorId));
     }
 
-    @Operation(summary = "팀에서 발제 선택/해제", description = "팀에서 발제를 선택/해제합니다.")
-    @Parameters({
-            @Parameter(name = "clubId", description = "독서클럽 ID", required = true, example = "1"),
-            @Parameter(name = "meetingId", description = "독서모임 ID", required = true, example = "1"),
-            @Parameter(name = "topicId", description = "선택/해제할 Topic ID", required = true, example = "1"),
-    })
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 모임의 회원이 아닙니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "독서클럽을 찾을 수 없습니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 정기모임을 찾을 수 없습니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 팀을 찾을 수 없습니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 발제를 찾을 수 없습니다.")
-    })
-    @PostMapping("/{meetingId}/topics/{topicId}")
-    public ApiResponse<MeetingResponseDTO.TopicSelection> selectOrCancelTopic(
-            @PathVariable Long clubId,
-            @PathVariable Long meetingId,
-            @PathVariable Long topicId,
-            @RequestBody @Valid MeetingRequestDTO.TopicSelection request,
-            @CurrentId String memberId
-    ) {
-        return ApiResponse.onSuccess(
-                clubTopicCommandService.toggleTopic(clubId, meetingId, topicId, memberId, request));
-    }
 }

--- a/src/main/java/checkmo/clubMeeting/web/controller/ClubMeetingController.java
+++ b/src/main/java/checkmo/clubMeeting/web/controller/ClubMeetingController.java
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -129,7 +128,7 @@ public class ClubMeetingController {
     @Parameters({
             @Parameter(name = "clubId", description = "독서클럽 ID", required = true, example = "1"),
             @Parameter(name = "meetingId", description = "독서모임 ID", required = true, example = "1"),
-            @Parameter(name = "teamNumber", description = "팀  번호(조회하려는 조 이름이 x조(x는 A부터 Z까지 알파벳 중 하나)이면 x - ‘A’ + 1 로 조회하려는 조 번호로 요청", required = true, example = "1"),
+            @Parameter(name = "teamId", description = "팀  ID(조회하려는 조 이름이 x조)", required = true, example = "1"),
             @Parameter(name = "cursorId", description = "커서 ID (null이면 처음부터 조회)", required = false, example = "5"),
     })
     @ApiResponses({
@@ -139,16 +138,16 @@ public class ClubMeetingController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 정기모임을 찾을 수 없습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 팀을 찾을 수 없습니다.")
     })
-    @GetMapping("/{meetingId}/teams/{teamNumber}/topics")
+    @GetMapping("/{meetingId}/teams/{teamId}/topics")
     public ApiResponse<MeetingResponseDTO.TeamTopic> getSelectedTopics(
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
-            @PathVariable @Min(value = 1) Integer teamNumber,
+            @PathVariable Long teamId,
             @RequestParam(required = false) @ValidCursor Long cursorId,
             @CurrentId String memberId
     ) {
         return ApiResponse.onSuccess(
-                clubMeetingQueryFacade.retrieveSelectableTopics(clubId, meetingId, teamNumber, memberId, cursorId));
+                clubMeetingQueryFacade.retrieveSelectableTopics(clubId, meetingId, teamId, memberId, cursorId));
     }
 
 }

--- a/src/main/java/checkmo/clubMeeting/web/dto/meeting/MeetingResponseDTO.java
+++ b/src/main/java/checkmo/clubMeeting/web/dto/meeting/MeetingResponseDTO.java
@@ -1,7 +1,6 @@
 package checkmo.clubMeeting.web.dto.meeting;
 
 import checkmo.member.MemberExternalDTO;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -27,13 +26,24 @@ public class MeetingResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    public static class TeamKey {
+        @Schema(description = "팀 ID", example = "153")
+        private Long teamId;
+        @Schema(description = "팀 번호", example = "1")
+        private Integer teamNumber;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     public static class MeetingInfo {
         private Long meetingId;
         private String title;
         private LocalDateTime meetingTime;
         private String location;
-        private List<Integer> existingTeamNumbers;
-        private List<TeamMember> teams;
+        private List<TeamKey> existingTeams;
+        private List<TeamMember> teamMembers;
         @Getter(AccessLevel.NONE)
         private boolean staff;
 
@@ -95,7 +105,6 @@ public class MeetingResponseDTO {
         private Long clubMemberId;
         @Schema(description = "참여자 정보(프로필 사진, 닉네임 정보)")
         private MemberExternalDTO.BasicInfo memberInfo; // 참여자 정보
-        @JsonInclude(JsonInclude.Include.NON_NULL) // 정기모임 조회에서 사용 X
         @Schema(description = "배정된 팀 번호(만약 팀이 배정되지 않았다면 null)", example = "1")
         private Integer teamNumber;
     }
@@ -105,8 +114,8 @@ public class MeetingResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class TeamMember {
-        private Integer teamNumber; // 팀 번호
-        private List<MeetingMember> members; // 해당 팀의 참여자 목록
+        private TeamKey teamKey;
+        private List<MeetingMember> members;
     }
 
     @Getter

--- a/src/main/java/checkmo/clubMeeting/web/dto/meeting/MeetingResponseDTO.java
+++ b/src/main/java/checkmo/clubMeeting/web/dto/meeting/MeetingResponseDTO.java
@@ -76,8 +76,8 @@ public class MeetingResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class TeamTopic {
-        private List<Integer> existingTeamNumbers;
-        private Integer requestedTeamNumber;
+        private List<TeamKey> existingTeams;
+        private TeamKey requestedTeam;
         private List<Topic> topics;
         private boolean hasNext;
         private Long nextCursor;

--- a/src/main/java/checkmo/clubMeeting/web/dto/meeting/MeetingResponseDTO.java
+++ b/src/main/java/checkmo/clubMeeting/web/dto/meeting/MeetingResponseDTO.java
@@ -88,10 +88,8 @@ public class MeetingResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class MeetingMemberList {
-        @Schema(description = "존재하는 팀 번호 목록", example = "[1, 2, 3]")
-        private List<Integer> existingTeamNumbers;
-        @Schema(description = "모임 참여자 목록")
-        private List<MeetingMember> members;
+        private List<TeamKey> existingTeams;
+        private List<MeetingMember> clubMembers;
         private boolean hasNext;
         private Long nextCursor;
     }
@@ -105,8 +103,8 @@ public class MeetingResponseDTO {
         private Long clubMemberId;
         @Schema(description = "참여자 정보(프로필 사진, 닉네임 정보)")
         private MemberExternalDTO.BasicInfo memberInfo; // 참여자 정보
-        @Schema(description = "배정된 팀 번호(만약 팀이 배정되지 않았다면 null)", example = "1")
-        private Integer teamNumber;
+        @Schema(description = "배정된 팀 식별 정보(만약 팀이 배정되지 않았다면 null)", example = "1")
+        private TeamKey teamKey;
     }
 
     @Getter

--- a/src/main/java/checkmo/clubNotice/internal/listener/ClubNoticeEventListener.java
+++ b/src/main/java/checkmo/clubNotice/internal/listener/ClubNoticeEventListener.java
@@ -1,0 +1,18 @@
+package checkmo.clubNotice.internal.listener;
+
+import checkmo.clubManagement.ClubManagementEvent.DeletedClubEvent;
+import checkmo.clubNotice.internal.service.command.ClubNoticeCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ClubNoticeEventListener {
+    private final ClubNoticeCommandService clubNoticeCommandService;
+
+    @ApplicationModuleListener
+    public void handleDeletedClubEvent(DeletedClubEvent event) {
+        clubNoticeCommandService.deleteAll(event.clubId());
+    }
+}

--- a/src/main/java/checkmo/clubNotice/internal/repository/NoticeRepository.java
+++ b/src/main/java/checkmo/clubNotice/internal/repository/NoticeRepository.java
@@ -9,6 +9,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    @Query("SELECT DISTINCT n FROM Notice n LEFT JOIN n.images WHERE n.clubId = :clubId")
+    List<Notice> findAllWithImagesByClubId(Long clubId);
+
     Optional<Notice> findTop1ByClubIdOrderByCreatedAtDescIdDesc(Long clubId);
 
     @Query("SELECT DISTINCT n FROM Notice n "

--- a/src/main/java/checkmo/clubNotice/internal/service/command/ClubNoticeCommandService.java
+++ b/src/main/java/checkmo/clubNotice/internal/service/command/ClubNoticeCommandService.java
@@ -132,14 +132,6 @@ public class ClubNoticeCommandService {
         noticeRepository.delete(notice);
     }
 
-    private void publishNoticeImageDeletedEvent(List<String> removedImages) {
-        applicationEventPublisher.publishEvent(
-                ClubNoticeEvent.DeleteNoticeImage.builder()
-                        .imageUrls(removedImages)
-                        .build()
-        );
-    }
-
     public Long haveVote(Long clubId, Long noticeId, Long voteId, String memberId, VoteResult request) {
         clubManagementAPI.validateClub(clubId);
         Long clubMemberId = clubManagementAPI.fetchActiveClubMemberId(clubId, memberId);
@@ -166,5 +158,26 @@ public class ClubNoticeCommandService {
     private void validateVotingTime(Vote vote) {
         LocalDateTime now = LocalDateTime.now();
         vote.validateVotingTime(now);
+    }
+
+    public void deleteAll(Long clubId) {
+        List<Notice> notices = noticeRepository.findAllWithImagesByClubId(clubId);
+        List<String> imageUrls = notices.stream()
+                .flatMap(n -> n.getImageUrls().stream())
+                .distinct()
+                .toList();
+        if (!imageUrls.isEmpty()) {
+            publishNoticeImageDeletedEvent(imageUrls);
+        }
+        noticeRepository.deleteAll(notices);
+        noticeRepository.flush();
+    }
+
+    private void publishNoticeImageDeletedEvent(List<String> removedImages) {
+        applicationEventPublisher.publishEvent(
+                ClubNoticeEvent.DeleteNoticeImage.builder()
+                        .imageUrls(removedImages)
+                        .build()
+        );
     }
 }

--- a/src/main/java/checkmo/infra/s3/internal/listener/S3EventListener.java
+++ b/src/main/java/checkmo/infra/s3/internal/listener/S3EventListener.java
@@ -1,6 +1,6 @@
 package checkmo.infra.s3.internal.listener;
 
-import checkmo.clubManagement.ClubManagementEvent;
+import checkmo.clubManagement.ClubManagementEvent.DeleteClubImageEvent;
 import checkmo.clubNotice.ClubNoticeEvent;
 import checkmo.infra.s3.internal.service.S3Service;
 import checkmo.member.MemberEvent;
@@ -24,7 +24,7 @@ public class S3EventListener {
     }
 
     @ApplicationModuleListener
-    public void handleDeleteClubImageEvent(ClubManagementEvent.DeleteClubImage event) {
+    public void handleDeleteClubImageEvent(DeleteClubImageEvent event) {
         deleteSingleUrl(event.imageUrl(), "클럽 이미지", event);
     }
 


### PR DESCRIPTION
## 🚀 변경사항
- teamNumber -> teamId 기반 작동
  - 정기모임 조회
  - [운영진] 조 관리 - 독서모임 회원 전체 조회
  - 정기모임 팀별 발제 조회
```
- 팀 정보 응답에 TeamKey(teamId, teamNumber) 도입
- teamId를 기준으로 API/웹소켓 destination을 통일해 매핑(meetingId + teamNumber) 비용 제거
--
UI가 바뀌어서 더이상 teamNumber의 장점 X
websocket destination 에서  teamId 기반 간단하게 하기 위해
```
 
- 클럽 삭제 기능 추가

## 🔗 관련 이슈
- Closes #177 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added club deletion functionality with automatic cleanup of associated meetings and notices.
  * Added new DELETE API endpoint for clubs.

* **API Changes**
  * Updated team-related endpoint parameter from team number to team ID.
  * Removed topic selection endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->