### PR TITLE
[Feat] 네이버 소셜 로그인 추가

### DIFF
--- a/src/main/java/checkmo/authentication/internal/entity/Provider.java
+++ b/src/main/java/checkmo/authentication/internal/entity/Provider.java
@@ -4,6 +4,7 @@ public abstract class Provider {
 
     public static final String GOOGLE = "google";
     public static final String KAKAO = "kakao";
+    public static final String NAVER = "naver";
 
     public static abstract class Google {
         public static final String EMAIL = "email";
@@ -12,6 +13,12 @@ public abstract class Provider {
 
     public static abstract class Kakao {
         public static final String ACCOUNT = "kakao_account";
+        public static final String EMAIL = "email";
+        public static final String PROVIDER_ID = "id";
+    }
+
+    public static abstract class Naver {
+        public static final String RESPONSE = "response";
         public static final String EMAIL = "email";
         public static final String PROVIDER_ID = "id";
     }

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/CustomOAuth2UserService.java
@@ -18,7 +18,7 @@ import org.springframework.util.StringUtils;
 /**
  * Spring Security DefaultOAuth2UserService 구현체
  * <p>
- * 소셜 로그인 시 카카오, 구글로부터 받은 사용자 정보를 처리 기존 회원 인지 신규 회원인지에 따라 다르게 처리하기 추가 정보 입력(닉네임, 관심 도서 분야 등) 필요 여부도 결정
+ * 소셜 로그인 시 카카오, 구글, 네이버로부터 받은 사용자 정보를 처리 기존 회원 인지 신규 회원인지에 따라 다르게 처리하기 추가 정보 입력(닉네임, 관심 도서 분야 등) 필요 여부도 결정
  */
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2Attributes.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2Attributes.java
@@ -18,6 +18,7 @@ public class OAuth2Attributes {
         return switch (registrationId.toLowerCase()) {
             case Provider.GOOGLE -> ofGoogle(attributes);
             case Provider.KAKAO -> ofKakao(attributes);
+            case Provider.NAVER -> ofNaver(attributes);
             default -> throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다: " + registrationId);
         };
     }
@@ -34,6 +35,14 @@ public class OAuth2Attributes {
         return OAuth2Attributes.builder()
                 .email((String) kakaoAccount.get(Provider.Kakao.EMAIL))
                 .providerId(String.valueOf(attributes.get(Provider.Kakao.PROVIDER_ID)))
+                .build();
+    }
+
+    private static OAuth2Attributes ofNaver(Map<String, Object> attributes) {
+        Map<String, Object> response = (Map<String, Object>) attributes.get(Provider.Naver.RESPONSE);
+        return OAuth2Attributes.builder()
+                .email((String) response.get(Provider.Naver.EMAIL))
+                .providerId((String) response.get(Provider.Naver.PROVIDER_ID))
                 .build();
     }
 }


### PR DESCRIPTION
## 🚀 변경사항
네이버 로그인 추가, env파일에 NAVER_CLIENT_ID, NAVER_CLIENT_SECRET 추가

## 🔗 관련 이슈
- Closes #158 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
배포 환경에서 아무 아이디로나 로그인 가능하게 하려면 네이버 검수 받아야 해요.
그 전까지 개발 환경에서 테스트 가능한 아이디 추가하려면 책모 계정으로 네이버 개발자센터 로그인 후 내 애플리케이션 -> 책모 -> 멤버관리 -> 테스트ID 등록에다가 등록해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NAVER as a supported social login provider. Users can now authenticate using their NAVER accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->