### PR TITLE
feat(관리자) : 회원 관리 구현 및 소셜 로그인 redirect-uri 변경

### DIFF
--- a/src/main/java/checkmo/bookStory/web/controller/BookStoryAdminController.java
+++ b/src/main/java/checkmo/bookStory/web/controller/BookStoryAdminController.java
@@ -88,4 +88,26 @@ public class BookStoryAdminController {
         Long deletedCommentId = bookStoryCommentCommandService.deleteCommentByAdmin(bookStoryId, commentId);
         return ApiResponse.onSuccess(deletedCommentId);
     }
+
+    @Operation(
+            summary = "특정 회원 책이야기 목록 조회 (관리자)",
+            description = "관리자가 특정 회원이 작성한 책이야기 목록을 조회합니다. 커서 기반 무한 스크롤을 지원합니다."
+    )
+    @Parameter(name = "memberNickname", description = "조회할 회원 닉네임", required = true, example = "hy_0716")
+    @Parameter(name = "cursorId", description = "커서 ID (처음에는 null)", required = false, example = "10")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
+    })
+    @GetMapping("/members/{memberNickname}")
+    public ApiResponse<BookStoryResponseDTO.BookStoryList> getMemberBookStoriesForAdmin(
+            @CurrentId String memberId,
+            @PathVariable String memberNickname,
+            @RequestParam(required = false) Long cursorId
+    ) {
+        return ApiResponse.onSuccess(
+                bookStoryQueryFacade.fetchMemberBookStories(memberId, memberNickname, cursorId)
+        );
+    }
 }

--- a/src/main/java/checkmo/clubManagement/web/controller/ClubAdminController.java
+++ b/src/main/java/checkmo/clubManagement/web/controller/ClubAdminController.java
@@ -93,4 +93,23 @@ public class ClubAdminController {
     ) {
         return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveAdminActiveClubMembers(clubId, page));
     }
+
+    @Operation(
+            summary = "특정 회원 가입 모임 조회 (관리자)",
+            description = "관리자가 특정 회원이 가입한 활성 모임 목록을 조회합니다."
+    )
+    @Parameter(name = "memberNickname", description = "조회할 회원 닉네임", required = true, example = "hy_0716")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
+    })
+    @GetMapping("/members/{memberNickname}")
+    public ApiResponse<ClubResponseDTO.ClubPreviewList> getMemberClubsForAdmin(
+            @PathVariable String memberNickname
+    ) {
+        return ApiResponse.onSuccess(
+                clubManagementQueryFacade.retrieveClubListByMemberNickname(memberNickname)
+        );
+    }
 }

--- a/src/main/java/checkmo/member/internal/repository/MemberRepository.java
+++ b/src/main/java/checkmo/member/internal/repository/MemberRepository.java
@@ -6,6 +6,7 @@ import checkmo.member.internal.repository.projection.MemberIdAndNicknameProjecti
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -50,4 +51,11 @@ public interface MemberRepository extends JpaRepository<Member, String>, MemberR
     List<String> findActiveEmailsByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
     boolean existsByEmail(String email);
+
+
+    Page<Member> findByIdContainingIgnoreCaseOrEmailContainingIgnoreCase(
+            String idKeyword,
+            String emailKeyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/checkmo/member/internal/service/MemberQueryFacade.java
+++ b/src/main/java/checkmo/member/internal/service/MemberQueryFacade.java
@@ -23,6 +23,7 @@ import checkmo.member.web.dto.MemberResponseDTO.RecommendedMemberList;
 import checkmo.member.web.dto.MemberResponseDTO.ReportInfo;
 import checkmo.member.web.dto.MemberResponseDTO.ReportList;
 import checkmo.member.web.dto.MemberResponseDTO.othersDetailInfo;
+import org.springframework.data.domain.Page;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -39,6 +40,7 @@ public class MemberQueryFacade {
     // 페이징 기본 크기 상수
     private static final int DEFAULT_PAGE_SIZE = 20;
     private static final int RECOMMENDED_MEMBER_LIMIT = 4;
+    private static final int ADMIN_PAGE_SIZE = 12;
 
     private final MemberQueryService memberQueryService;
     private final MemberFollowQueryService memberFollowQueryService;
@@ -261,6 +263,59 @@ public class MemberQueryFacade {
         List<String> emails = memberQueryService.retrieveActiveEmailsByKeyword(keyword, limit);
         return MemberResponseDTO.MemberEmailList.builder()
                 .emails(emails)
+                .build();
+    }
+
+
+    /**
+     * 관리자 전용 회원 목록 조회
+     */
+    public MemberResponseDTO.AdminMemberList retrieveMembersForAdmin(String keyword, int page) {
+        int safePage = Math.max(page, 1);
+
+        Page<Member> memberPage = memberQueryService.retrieveMembersForAdmin(
+                keyword,
+                safePage - 1,
+                ADMIN_PAGE_SIZE
+        );
+
+        List<MemberResponseDTO.AdminBasicInfo> memberList = memberPage.getContent().stream()
+                .map(member -> MemberResponseDTO.AdminBasicInfo.builder()
+                        .memberId(member.getId())
+                        .nickname(member.getNickName())
+                        .name(member.getName())
+                        .email(member.getEmail())
+                        .phoneNumber(member.getPhoneNumber())
+                        .build())
+                .toList();
+
+        return MemberResponseDTO.AdminMemberList.builder()
+                .memberList(memberList)
+                .page(safePage)
+                .pageSize(memberPage.getSize())
+                .totalPages(memberPage.getTotalPages())
+                .totalElements(memberPage.getTotalElements())
+                .hasNext(memberPage.hasNext())
+                .build();
+    }
+
+    /**
+     * 관리자 전용 회원 기본 상세 조회
+     * 현재 컨트롤러 기준: 닉네임으로 조회
+     */
+    public MemberResponseDTO.AdminMemberDetailInfo retrieveMemberDetailInfoForAdmin(String memberNickName) {
+        Member member = memberQueryService.retrieveMemberByNickname(memberNickName);
+
+        return MemberResponseDTO.AdminMemberDetailInfo.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickName())
+                .name(member.getName())
+                .email(member.getEmail())
+                .phoneNumber(member.getPhoneNumber())
+                .description(member.getDescription())
+                .profileImageUrl(member.getImgUrl())
+                .categories(member.getInterestCategories())
+                .active(member.isActive())
                 .build();
     }
 }

--- a/src/main/java/checkmo/member/internal/service/query/MemberQueryService.java
+++ b/src/main/java/checkmo/member/internal/service/query/MemberQueryService.java
@@ -16,6 +16,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 @Service
 @RequiredArgsConstructor
@@ -128,4 +132,19 @@ public class MemberQueryService {
         int boundedLimit = Math.min(Math.max(limit, 1), 100);
         return memberRepository.findActiveEmailsByKeyword(normalizedKeyword, PageRequest.of(0, boundedLimit));
     }
+
+    public Page<Member> retrieveMembersForAdmin(String keyword, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        if (keyword == null || keyword.isBlank()) {
+            return memberRepository.findAll(pageable);
+        }
+
+        return memberRepository.findByIdContainingIgnoreCaseOrEmailContainingIgnoreCase(
+                keyword,
+                keyword,
+                pageable
+        );
+    }
+
 }

--- a/src/main/java/checkmo/member/web/controller/MemberAdminController.java
+++ b/src/main/java/checkmo/member/web/controller/MemberAdminController.java
@@ -2,6 +2,8 @@ package checkmo.member.web.controller;
 
 import checkmo.common.apiPayload.ApiResponse;
 import checkmo.member.internal.service.MemberQueryFacade;
+import checkmo.member.web.dto.MemberResponseDTO.AdminMemberDetailInfo;
+import checkmo.member.web.dto.MemberResponseDTO.AdminMemberList;
 import checkmo.member.web.dto.MemberResponseDTO.MemberEmailList;
 import checkmo.member.web.dto.MemberResponseDTO.ReportList;
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,5 +52,40 @@ public class MemberAdminController {
             @RequestParam(defaultValue = "20") int limit
     ) {
         return ApiResponse.onSuccess(memberQueryFacade.retrieveActiveEmailsForAdmin(keyword, limit));
+    }
+
+    @Operation(
+            summary = "회원 목록 조회 (관리자)",
+            description = "관리자 전용 회원 목록 조회 API입니다. 아이디 또는 이메일 검색과 페이지네이션을 지원합니다."
+    )
+    @Parameter(name = "page", description = "페이지 번호 (1부터 시작)", required = false, example = "1")
+    @Parameter(name = "keyword", description = "회원 ID 또는 이메일 검색어", required = false, example = "yhi9839")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.")
+    })
+    @GetMapping
+    public ApiResponse<AdminMemberList> getMembersForAdmin(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(required = false) String keyword
+    ){
+        return ApiResponse.onSuccess(memberQueryFacade.retrieveMembersForAdmin(keyword, page));
+    }
+
+    @Operation(
+            summary = "회원 상세 조회 (관리자)",
+            description = "관리자 전용 회원 상세 기본 정보 조회 API입니다. 프로필, 이름, 이메일, 전화번호, 관심 카테고리 등을 조회합니다."
+    )
+    @Parameter(name = "memberNickName", description = "조회할 회원 닉네임", required = true)
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
+    })
+    @GetMapping("/{memberNickName}")
+    public ApiResponse<AdminMemberDetailInfo> getMemberDetailForAdmin(
+            @PathVariable String memberNickName
+    ){
+        return ApiResponse.onSuccess(memberQueryFacade.retrieveMemberDetailInfoForAdmin(memberNickName));
     }
 }

--- a/src/main/java/checkmo/member/web/dto/MemberResponseDTO.java
+++ b/src/main/java/checkmo/member/web/dto/MemberResponseDTO.java
@@ -164,4 +164,46 @@ public class MemberResponseDTO {
     public static class MemberEmailList {
         private List<String> emails;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AdminMemberList {
+        private List<AdminBasicInfo> memberList;
+        private int page;
+        private int pageSize;
+        private int totalPages;
+        private long totalElements;
+        private boolean hasNext;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AdminBasicInfo {
+        private String memberId;
+        private String nickname;
+        private String name;
+        private String email;
+        private String phoneNumber;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AdminMemberDetailInfo {
+        private String memberId;
+        private String nickname;
+        private String name;
+        private String email;
+        private String phoneNumber;
+        private String description;
+        private String profileImageUrl;
+        private Set<MemberInterestCategory> categories;
+        private boolean active;
+    }
+
 }

--- a/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
+++ b/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
@@ -98,4 +98,9 @@ public class NewsQueryFacade {
         News news = newsQueryService.retrieveNews(newsId);
         return NewsConverter.toAdminDetailInfo(news);
     }
+
+    public NewsResponseDTO.NewsList fetchMemberNewsListForAdmin(String memberNickname, Long cursorId) {
+        String memberId = memberAPI.fetchMemberId(memberNickname);
+        return fetchMyNewsList(memberId, cursorId);
+    }
 }

--- a/src/main/java/checkmo/news/web/controller/NewsAdminController.java
+++ b/src/main/java/checkmo/news/web/controller/NewsAdminController.java
@@ -100,4 +100,27 @@ public class NewsAdminController {
         newsCommandService.deleteNews(newsId);
         return ApiResponse.onSuccess("소식이 성공적으로 삭제되었습니다.");
     }
+
+    @Operation(
+            summary = "특정 회원 등록 소식 조회 (관리자)",
+            description = "관리자가 특정 회원이 등록한 소식 목록을 조회합니다. 커서 기반 무한 스크롤을 지원합니다."
+    )
+    @io.swagger.v3.oas.annotations.Parameters({
+            @Parameter(name = "memberNickname", description = "조회할 회원 닉네임", required = true, example = "hy_0716"),
+            @Parameter(name = "cursorId", description = "커서 ID (처음에는 null)", required = false, example = "1")
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
+    })
+    @GetMapping("/members/{memberNickname}")
+    public ApiResponse<NewsResponseDTO.NewsList> getMemberNewsForAdmin(
+            @PathVariable String memberNickname,
+            @RequestParam(required = false) Long cursorId
+    ) {
+        return ApiResponse.onSuccess(
+                newsQueryFacade.fetchMemberNewsListForAdmin(memberNickname, cursorId)
+        );
+    }
 }

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -14,7 +14,7 @@ spring:
             scope:
               - email
               - profile
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "https://api.checkmo.co.kr/login/oauth2/code/google"
             authorization-grant-type: authorization_code
 
           kakao:
@@ -24,7 +24,7 @@ spring:
             scope:
               - account_email
               - profile_nickname
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "https://api.checkmo.co.kr/login/oauth2/code/kakao"
             authorization-grant-type: authorization_code
 
           naver:
@@ -33,7 +33,7 @@ spring:
             scope:
               - name
               - email
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "https://api.checkmo.co.kr/login/oauth2/code/naver"
             authorization-grant-type: authorization_code
             client-name: Naver
 


### PR DESCRIPTION
## 🚀 변경사항
회원 관리 구현
- 회원 목록 조회
- 회원 상세 조회
- 회원 책이야기 조회
- 회원 소식 조회
- 회원 가입 모임 조회

소셜 로그인
- redirect-uri 변경   
## 🔗 관련 이슈
- Closes #200 

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can now search and browse members with pagination.
  * Admins can view detailed member information including profile and contact details.
  * Admins can access specific members' book stories, clubs, and news activity.

* **Chores**
  * Updated OAuth2 redirect URIs for Google, Kakao, and Naver authentication providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->