### PR TITLE
refactor(websocket): stateless JWT 환경에서 WebSocket 인증 처리 수정

### DIFF
--- a/src/main/java/checkmo/realtime/web/websocket/config/WebSocketConfig.java
+++ b/src/main/java/checkmo/realtime/web/websocket/config/WebSocketConfig.java
@@ -14,7 +14,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
-import org.springframework.web.socket.server.support.HttpSessionHandshakeInterceptor;
+import checkmo.realtime.web.websocket.interceptor.SecurityContextHandshakeInterceptor;
 
 /**
  * 웹소켓 관련 설정(하트비트 스케줄러, stomp 엔드포인트, simple broker, 메시지 크기 제한 등)
@@ -28,6 +28,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     private final WebSocketProperties webSocketProperties;
     private final TeamAuthorizationInterceptor teamAuthorizationInterceptor;
     private final CustomStompErrorHandler customStompErrorHandler;
+    private final SecurityContextHandshakeInterceptor securityContextHandshakeInterceptor;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -35,7 +36,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // 클라이언트가 WebSocket 연결을 시도할 때 사용할 엔드포인트를 등록합니다.
         registry.setErrorHandler(customStompErrorHandler)
                 .addEndpoint("/ws-stomp")
-                .addInterceptors(httpSessionHandshakeInterceptor())
+                .addInterceptors(securityContextHandshakeInterceptor)
                 .setAllowedOrigins("*");
         // TODO: SockJS 설정
     }
@@ -77,8 +78,4 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         return scheduler;
     }
 
-    @Bean
-    HttpSessionHandshakeInterceptor httpSessionHandshakeInterceptor() {
-        return new HttpSessionHandshakeInterceptor();
-    }
 }

--- a/src/main/java/checkmo/realtime/web/websocket/config/WebSocketConfig.java
+++ b/src/main/java/checkmo/realtime/web/websocket/config/WebSocketConfig.java
@@ -37,7 +37,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.setErrorHandler(customStompErrorHandler)
                 .addEndpoint("/ws-stomp")
                 .addInterceptors(securityContextHandshakeInterceptor)
-                .setAllowedOrigins("*");
+                .setAllowedOrigins(allowedOrigins);
         // TODO: SockJS 설정
     }
 

--- a/src/main/java/checkmo/realtime/web/websocket/interceptor/SecurityContextHandshakeInterceptor.java
+++ b/src/main/java/checkmo/realtime/web/websocket/interceptor/SecurityContextHandshakeInterceptor.java
@@ -1,0 +1,35 @@
+package checkmo.realtime.web.websocket.interceptor;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+/**
+ * JwtAuthenticationFilter가 설정한 SecurityContext를 WebSocket 세션 속성으로 복사.
+ * stateless JWT 환경에서 HttpSessionHandshakeInterceptor 대체용.
+ */
+@Component
+public class SecurityContextHandshakeInterceptor implements HandshakeInterceptor {
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) {
+        SecurityContext context = SecurityContextHolder.getContext();
+        if (context.getAuthentication() != null && context.getAuthentication().isAuthenticated()) {
+            attributes.put(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+        }
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+    }
+}


### PR DESCRIPTION
HttpSessionHandshakeInterceptor를 SecurityContextHandshakeInterceptor로 교체. JwtAuthenticationFilter가 설정한 SecurityContext를 WebSocket 세션 속성으로 복사하여 STOMP CONNECT 인증이 정상 동작하도록 수정.

## 🚀 변경사항
<!-- 뭘 구현했는지/수정했는지 간단히 -->

## 🔗 관련 이슈
- Closes #이슈번호

## ✅ 체크리스트
- [ ] 로컬에서 테스트 완료
- [ ] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket authentication handling for authenticated connections; allowed origins are now configurable instead of hardcoded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->