### PR TITLE
feat: API 테스트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     // ============= 테스트 =============
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'io.rest-assured:rest-assured'
+    testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // ============= 환경 변수 관리 =============

--- a/docs/api-test/README.md
+++ b/docs/api-test/README.md
@@ -1,0 +1,73 @@
+# RestAssured + H2 API 테스트 가이드
+
+## 목적
+
+이 문서는 Checkmo의 HTTP REST API를 실제 Spring Boot 서버(`RANDOM_PORT`)로 띄운 뒤 RestAssured로 호출하는 통합 테스트 기준을 정리한다. 테스트 데이터베이스는 H2 인메모리 DB를 사용하고, 인증/인가가 필요한 API도 실제 JWT 필터 체인을 통과하도록 fixture를 만든다.
+
+## 실행 명령
+
+```bash
+./gradlew test --tests checkmo.support.ApiTestInfrastructureTest
+```
+
+전체 API 테스트가 확장된 뒤에는 다음 명령을 기준으로 검증한다.
+
+```bash
+./gradlew test --tests '*Api*'
+./gradlew test
+```
+
+## 테스트 프로파일
+
+- `src/test/resources/application.yml`이 메인 `application.yml`을 테스트 classpath에서 가린다.
+- `test` 프로파일만 활성화한다.
+- 운영 프로파일인 `prod`, `redis`, `aladin`, `mail`, `jwt`, `oauth2`, `s3`는 테스트 active profile에 포함하지 않는다.
+- H2는 `MODE=MySQL`로 실행해 MySQL 문법과 최대한 가깝게 동작시킨다.
+
+## 테스트 메타 어노테이션
+
+API 테스트의 공통 스프링 컨텍스트 설정은 `@ApiTest`에 모았다.
+
+- `@Tag("integration")`: JUnit 태그로 통합 테스트를 식별한다.
+- `@ActiveProfiles("test")`: H2와 테스트용 더미 설정만 사용한다.
+- `@SpringBootTest(webEnvironment = RANDOM_PORT)`: 실제 HTTP 서버를 띄우고 RestAssured로 호출한다.
+- `@TestConstructor(autowireMode = ALL)`: 이후 생성자 주입 방식의 테스트를 작성할 수 있게 열어 둔다.
+
+`ApiTestSupport`는 `@ApiTest`를 사용하면서 RestAssured 포트 설정, H2 데이터 cleanup, JWT fixture, 외부 경계 mock을 담당한다. 따라서 새 REST API 테스트는 기본적으로 `ApiTestSupport`를 상속한다.
+
+HTTP 서버가 필요 없는 일반 스프링 컨텍스트 통합 테스트에는 별도의 `@SpringTest`를 사용한다. `@SpringTest`는 같은 `test` 프로파일과 `integration` 태그를 쓰지만 `webEnvironment = NONE`으로 컨텍스트를 띄운다. 이 둘을 분리한 이유는 REST API 테스트와 일반 스프링 통합 테스트의 실행 비용과 목적이 다르기 때문이다.
+
+## 스키마 전략
+
+현재 API 테스트는 Flyway를 끄고 Hibernate `create-drop`으로 스키마를 만든다.
+
+이 선택은 API 동작 검증을 우선하기 위한 것이다. 기존 Flyway 마이그레이션은 운영 MySQL을 기준으로 작성되어 있고, H2 호환성 문제를 API 테스트의 선행 조건으로 만들면 테스트 목적이 "REST API 동작"에서 "마이그레이션 호환성"으로 흔들린다. Flyway 마이그레이션 검증은 별도 MySQL/Testcontainers 계층에서 다루는 것이 맞다.
+
+## 외부 경계 처리
+
+테스트 기반 클래스 `ApiTestSupport`는 다음 경계를 테스트 더블로 고정한다.
+
+- Redis 토큰 캐시와 RedisTemplate 계열 빈
+- 알라딘 호출용 RestTemplate
+- 메일 발송 서비스
+- S3 서비스
+- ApplicationReadyEvent 또는 `@Scheduled`로 실행될 수 있는 스케줄러
+
+이렇게 하는 이유는 API 테스트가 네트워크, 운영 자격 증명, 로컬 Redis/MySQL 실행 여부와 무관하게 항상 같은 결과를 내야 하기 때문이다.
+
+## 인증 fixture
+
+`ApiTestSupport`는 다음 사용자를 만들 수 있어야 한다.
+
+- 익명 사용자: 쿠키 없음, 인증 필요 API에서 401 확인
+- 일반 완료 사용자: `ROLE_USER`, `profileCompleted=true`
+- 일반 미완료 사용자: `ROLE_USER`, `profileCompleted=false`, 보호 API에서 403 확인
+- 관리자 사용자: `ROLE_ADMIN`, 관리자 API의 성공/403 비교에 사용
+
+현재 기반 검증은 `ApiTestInfrastructureTest`에서 H2, 프로파일 격리, RestAssured 호출, 401, 403, 완료 사용자 JWT, 관리자 JWT 발급을 확인한다.
+
+## 관련 문서
+
+- 제외 범위와 이유: [exclusions.md](./exclusions.md)
+- 전체 REST 엔드포인트 테스트 매트릭스: [coverage-matrix.md](./coverage-matrix.md)
+- 테스트별 추가 이유: [test-rationale.md](./test-rationale.md)

--- a/docs/api-test/coverage-matrix.md
+++ b/docs/api-test/coverage-matrix.md
@@ -1,0 +1,143 @@
+# REST API 테스트 커버리지 매트릭스
+
+## 기준
+
+이 매트릭스는 `.omx/plans/endpoint-inventory-restassured-h2-api-tests-20260528T071303Z.md`의 REST 컨트롤러 인벤토리와 대조해 작성했다. WebSocket/STOMP 컨트롤러는 REST API 범위가 아니므로 제외 문서에 따로 기록했다.
+
+상태 값은 다음 의미다.
+
+- `완료`: 현재 테스트 코드가 존재한다.
+- `예정`: 이번 API 테스트 확장 작업에서 추가해야 한다.
+- `부분`: 일부 공통 보안/기반 검증으로만 확인됐고, 전용 도메인 테스트가 남아 있다.
+
+검증 축은 `성공`, `401`, `403`, `400`, `도메인 실패` 중 해당되는 항목을 적용한다. 모든 인증 필요 API는 최소 401을 포함하고, 권한이나 소유권이 있는 API는 403을 포함한다.
+
+## 전체 엔드포인트
+
+| 컨트롤러 | 메서드 | 경로 | 상태 | 테스트를 추가하는 이유 |
+| --- | --- | --- | --- | --- |
+| HealthCheckController | GET | `/health` | 완료 | 인증 없이 서비스 상태를 확인하는 기준점이다. |
+| AuthController | POST | `/api/auth/email-verification` | 완료 | 회원가입 전 이메일 인증 요청의 성공, 이메일 형식 오류, 중복 요청을 검증한다. |
+| AuthController | POST | `/api/auth/email-verification/confirm` | 완료 | 인증 코드 일치, 만료, 불일치 상태를 검증한다. |
+| AuthController | POST | `/api/auth/signup` | 완료 | 가입 성공, 중복 이메일/닉네임, 검증 실패 payload를 검증한다. |
+| AuthController | POST | `/api/auth/login` | 완료 | 쿠키 발급 성공과 잘못된 자격 증명 실패를 검증한다. |
+| AuthController | POST | `/api/auth/logout` | 완료 | JWT 쿠키 기반 로그아웃과 인증 누락 처리를 검증한다. |
+| AuthController | POST | `/api/auth/temp-password` | 완료 | 임시 비밀번호 발급, 미존재 이메일, 메일 경계 더블을 검증한다. |
+| BookController | GET | `/api/books/search` | 완료 | 알라딘 검색 경계의 deterministic 응답과 공개 조회 계약을 검증한다. |
+| BookController | GET | `/api/books/{isbn}` | 완료 | 도서 상세 조회 성공과 외부 조회 실패를 검증한다. |
+| BookController | GET | `/api/books/recommend` | 완료 | 추천 도서 조회와 캐시/외부 경계 fallback을 검증한다. |
+| BookController | POST | `/api/books/{isbn}/like` | 완료 | 인증 사용자 좋아요 토글, 401, 중복/해제 상태를 검증한다. |
+| BookController | GET | `/api/books/me/likes` | 완료 | 내 좋아요 목록의 인증 필요 계약을 검증한다. |
+| BookController | GET | `/api/books/{memberNickname}/likes` | 완료 | 다른 회원 좋아요 목록 공개 조회와 대상 없음 실패를 검증한다. |
+| BookStoryAdminController | GET | `/api/admin/book-stories` | 완료 | 관리자 목록 조회, 익명 401, 비관리자 403을 검증한다. |
+| BookStoryAdminController | GET | `/api/admin/book-stories/{bookStoryId}` | 완료 | 관리자 상세 조회와 not found를 검증한다. |
+| BookStoryAdminController | DELETE | `/api/admin/book-stories/{bookStoryId}` | 완료 | 관리자 삭제 권한과 not found를 검증한다. |
+| BookStoryAdminController | DELETE | `/api/admin/book-stories/{bookStoryId}/comments/{commentId}` | 완료 | 관리자 댓글 삭제 권한과 댓글 없음 실패를 검증한다. |
+| BookStoryAdminController | GET | `/api/admin/book-stories/members/{memberNickname}` | 완료 | 특정 회원 글 관리자 조회와 회원 없음 실패를 검증한다. |
+| BookStoryController | POST | `/api/book-stories` | 완료 | 글 작성 성공, 401, 403, validation을 검증한다. |
+| BookStoryController | GET | `/api/book-stories` | 완료 | 공개 목록 조회와 페이징 파라미터를 검증한다. |
+| BookStoryController | GET | `/api/book-stories/me` | 완료 | 내 글 목록의 인증 필요 계약을 검증한다. |
+| BookStoryController | GET | `/api/book-stories/following` | 완료 | 팔로잉 글 목록의 인증 필요 계약을 검증한다. |
+| BookStoryController | GET | `/api/book-stories/members/{nickname}` | 완료 | 회원별 글 조회와 대상 없음 실패를 검증한다. |
+| BookStoryController | GET | `/api/book-stories/clubs/{clubId}` | 완료 | 클럽별 글 조회와 클럽 없음 실패를 검증한다. |
+| BookStoryController | GET | `/api/book-stories/{bookStoryId}` | 완료 | 글 상세 조회와 not found를 검증한다. |
+| BookStoryController | POST | `/api/book-stories/{bookStoryId}/like` | 완료 | 좋아요 토글, 401, 대상 없음 실패를 검증한다. |
+| BookStoryController | PATCH | `/api/book-stories/{bookStoryId}` | 완료 | 작성자 수정, 소유권 403, validation을 검증한다. |
+| BookStoryController | DELETE | `/api/book-stories/{bookStoryId}` | 완료 | 작성자 삭제, 소유권 403, not found를 검증한다. |
+| BookStoryController | POST | `/api/book-stories/{bookStoryId}/comments` | 완료 | 댓글 작성, 401, validation을 검증한다. |
+| BookStoryController | PATCH | `/api/book-stories/{bookStoryId}/comments/{commentId}` | 완료 | 댓글 수정 권한과 댓글 없음 실패를 검증한다. |
+| BookStoryController | DELETE | `/api/book-stories/{bookStoryId}/comments/{commentId}` | 완료 | 댓글 삭제 권한과 댓글 없음 실패를 검증한다. |
+| BookStoryController | GET | `/api/book-stories/search/{bookId}` | 완료 | 도서 기준 글 검색과 페이징을 검증한다. |
+| ClubAdminController | GET | `/api/admin/clubs` | 완료 | 관리자 클럽 목록, 익명 401, 비관리자 403을 검증한다. |
+| ClubAdminController | GET | `/api/admin/clubs/{clubId}` | 완료 | 관리자 클럽 상세와 not found를 검증한다. |
+| ClubAdminController | PUT | `/api/admin/clubs/{clubId}` | 완료 | 관리자 클럽 수정, validation, not found를 검증한다. |
+| ClubAdminController | GET | `/api/admin/clubs/{clubId}/active-members` | 완료 | 관리자 활성 멤버 조회와 클럽 없음 실패를 검증한다. |
+| ClubAdminController | GET | `/api/admin/clubs/members/{memberNickname}` | 완료 | 회원별 클럽 관리자 조회와 회원 없음 실패를 검증한다. |
+| ClubController | GET | `/api/clubs/check-name` | 완료 | 클럽명 중복 확인과 query validation을 검증한다. |
+| ClubController | POST | `/api/clubs` | 완료 | 클럽 생성, 401, 403, validation을 검증한다. |
+| ClubController | PUT | `/api/clubs/{clubId}` | 완료 | 운영자 수정 권한, 비운영자 403, validation을 검증한다. |
+| ClubController | GET | `/api/clubs/{clubId}` | 완료 | 클럽 상세 조회와 not found를 검증한다. |
+| ClubController | DELETE | `/api/clubs/{clubId}` | 완료 | 운영자 삭제 권한과 비운영자 403을 검증한다. |
+| ClubController | GET | `/api/clubs/search` | 완료 | 공개 검색과 검색 파라미터를 검증한다. |
+| ClubController | GET | `/api/clubs/recommendations` | 완료 | 개인화 추천의 인증 필요 계약을 검증한다. |
+| ClubController | GET | `/api/clubs/{clubId}/home` | 완료 | 클럽 홈 공개 조회와 not found를 검증한다. |
+| ClubController | POST | `/api/clubs/{clubId}/join` | 완료 | 가입 성공, 중복 가입, 정원/상태 실패를 검증한다. |
+| ClubController | GET | `/api/clubs/{clubId}/me` | 완료 | 내 클럽 멤버십 상태 조회와 401을 검증한다. |
+| ClubController | GET | `/api/clubs/{clubId}/members` | 완료 | 클럽 멤버 목록과 비멤버/클럽 없음 실패를 검증한다. |
+| ClubController | PATCH | `/api/clubs/{clubId}/members/{clubMemberId}` | 완료 | 멤버 역할/상태 변경 권한과 validation을 검증한다. |
+| ClubController | DELETE | `/api/clubs/{clubId}/leave` | 완료 | 탈퇴 성공, 운영자 탈퇴 제한, 비멤버 실패를 검증한다. |
+| ClubController | GET | `/api/clubs` | 완료 | 클럽 목록 공개 조회와 페이징을 검증한다. |
+| MyClubController | GET | `/api/me/clubs` | 완료 | 내 클럽 목록의 인증 필요 계약을 검증한다. |
+| ClubBookshelfController | GET | `/api/clubs/{clubId}/bookshelves` | 완료 | 책장 목록 조회와 클럽 접근 권한을 검증한다. |
+| ClubBookshelfController | GET | `/api/clubs/{clubId}/bookshelves/{meetingId}` | 완료 | 모임 책장 상세와 not found를 검증한다. |
+| ClubBookshelfController | POST | `/api/clubs/{clubId}/bookshelves` | 완료 | 책장 생성 권한, validation, 중복/상태 실패를 검증한다. |
+| ClubBookshelfController | GET | `/api/clubs/{clubId}/bookshelves/{meetingId}/edit` | 완료 | 수정 화면 데이터 조회 권한을 검증한다. |
+| ClubBookshelfController | PATCH | `/api/clubs/{clubId}/bookshelves/{meetingId}` | 완료 | 책장 수정 권한, validation, not found를 검증한다. |
+| ClubBookshelfController | DELETE | `/api/clubs/{clubId}/bookshelves/{meetingId}` | 완료 | 책장 삭제 권한과 not found를 검증한다. |
+| ClubBookshelfController | GET | `/api/clubs/{clubId}/bookshelves/{meetingId}/topics` | 완료 | 토론 주제 목록 조회와 접근 권한을 검증한다. |
+| ClubBookshelfController | POST | `/api/clubs/{clubId}/bookshelves/{meetingId}/topics` | 완료 | 토론 주제 생성, validation, 권한 실패를 검증한다. |
+| ClubBookshelfController | PATCH | `/api/clubs/{clubId}/bookshelves/{meetingId}/topics/{topicId}` | 완료 | 토론 주제 수정 권한과 not found를 검증한다. |
+| ClubBookshelfController | DELETE | `/api/clubs/{clubId}/bookshelves/{meetingId}/topics/{topicId}` | 완료 | 토론 주제 삭제 권한과 not found를 검증한다. |
+| ClubBookshelfController | GET | `/api/clubs/{clubId}/bookshelves/{meetingId}/reviews` | 완료 | 후기 목록 조회와 접근 권한을 검증한다. |
+| ClubBookshelfController | POST | `/api/clubs/{clubId}/bookshelves/{meetingId}/reviews` | 완료 | 후기 작성, validation, 중복/권한 실패를 검증한다. |
+| ClubBookshelfController | PATCH | `/api/clubs/{clubId}/bookshelves/{meetingId}/reviews/{reviewId}` | 완료 | 후기 수정 권한과 not found를 검증한다. |
+| ClubBookshelfController | DELETE | `/api/clubs/{clubId}/bookshelves/{meetingId}/reviews/{reviewId}` | 완료 | 후기 삭제 권한과 not found를 검증한다. |
+| ClubMeetingController | GET | `/api/clubs/{clubId}/meetings/next` | 완료 | 다음 모임 조회와 클럽 접근 권한을 검증한다. |
+| ClubMeetingController | GET | `/api/clubs/{clubId}/meetings/{meetingId}` | 완료 | 모임 상세와 not found를 검증한다. |
+| ClubMeetingController | GET | `/api/clubs/{clubId}/meetings/{meetingId}/members` | 완료 | 모임 멤버 조회와 권한 실패를 검증한다. |
+| ClubMeetingController | PUT | `/api/clubs/{clubId}/meetings/{meetingId}/teams` | 완료 | 팀 편성 권한, validation, 상태 실패를 검증한다. |
+| ClubMeetingController | GET | `/api/clubs/{clubId}/meetings/{meetingId}/teams/{teamId}/topics` | 완료 | 팀별 주제 조회와 접근 권한을 검증한다. |
+| ClubNoticeController | GET | `/api/clubs/{clubId}/notices/latest` | 완료 | 최신 공지 공개 조회와 클럽 없음 실패를 검증한다. |
+| ClubNoticeController | GET | `/api/clubs/{clubId}/notices` | 완료 | 공지 목록 조회와 접근 권한을 검증한다. |
+| ClubNoticeController | GET | `/api/clubs/{clubId}/notices/{noticeId}` | 완료 | 공지 상세와 not found를 검증한다. |
+| ClubNoticeController | POST | `/api/clubs/{clubId}/notices` | 완료 | 공지 작성 권한, validation, 403을 검증한다. |
+| ClubNoticeController | PATCH | `/api/clubs/{clubId}/notices/{noticeId}` | 완료 | 공지 수정 권한과 not found를 검증한다. |
+| ClubNoticeController | DELETE | `/api/clubs/{clubId}/notices/{noticeId}` | 완료 | 공지 삭제 권한과 not found를 검증한다. |
+| ClubNoticeController | POST | `/api/clubs/{clubId}/notices/{noticeId}/votes/{voteId}` | 완료 | 투표 성공, 중복/마감 상태 실패를 검증한다. |
+| ClubNoticeController | GET | `/api/clubs/{clubId}/notices/{noticeId}/comments` | 완료 | 공지 댓글 목록 조회와 접근 권한을 검증한다. |
+| ClubNoticeController | POST | `/api/clubs/{clubId}/notices/{noticeId}/comments` | 완료 | 공지 댓글 작성, validation, 401을 검증한다. |
+| ClubNoticeController | PATCH | `/api/clubs/{clubId}/notices/{noticeId}/comments/{commentId}` | 완료 | 댓글 수정 권한과 not found를 검증한다. |
+| ClubNoticeController | DELETE | `/api/clubs/{clubId}/notices/{noticeId}/comments/{commentId}` | 완료 | 댓글 삭제 권한과 not found를 검증한다. |
+| S3Controller | POST | `/api/image/{type}/upload-url` | 완료 | 이미지 업로드 URL 발급, 파일 형식 validation, 프로필 미완료 403을 검증한다. |
+| MemberAdminController | GET | `/api/admin/members/emails` | 완료 | 관리자 이메일 검색, 익명 401, 비관리자 403을 검증한다. |
+| MemberAdminController | GET | `/api/admin/members` | 완료 | 관리자 회원 목록과 검색/페이징을 검증한다. |
+| MemberAdminController | GET | `/api/admin/members/{memberNickName}` | 완료 | 관리자 회원 상세와 회원 없음 실패를 검증한다. |
+| MemberController | POST | `/api/members/additional-info` | 완료 | 프로필 추가 정보 입력과 validation, 401을 검증한다. |
+| MemberController | POST | `/api/members/check-nickname` | 완료 | 닉네임 중복 확인과 query validation을 검증한다. |
+| MemberController | POST | `/api/members/{memberNickname}/following` | 완료 | 팔로우 성공, 자기 자신/중복/대상 없음 실패를 검증한다. |
+| MemberController | DELETE | `/api/members/{memberNickname}/following` | 완료 | 언팔로우 성공과 팔로우 관계 없음 실패를 검증한다. |
+| MemberController | DELETE | `/api/members/{memberNickname}/follower` | 완료 | 팔로워 삭제 권한과 관계 없음 실패를 검증한다. |
+| MemberController | POST | `/api/members/{memberNickname}/block` | 완료 | 차단 성공, 자기 자신 차단 실패, 대상 없음 실패를 검증한다. |
+| MemberController | DELETE | `/api/members/{memberNickname}/block` | 완료 | 차단 해제 성공과 차단 관계 없음 실패를 검증한다. |
+| MemberController | GET | `/api/members/me/following` | 완료 | 내 팔로잉 목록 인증 계약과 페이징을 검증한다. |
+| MemberController | GET | `/api/members/me/follower` | 완료 | 내 팔로워 목록 인증 계약과 페이징을 검증한다. |
+| MemberController | GET | `/api/members/me/blocks` | 완료 | 내 차단 목록 인증 계약과 페이징을 검증한다. |
+| MemberController | GET | `/api/members/{memberNickname}/followings` | 완료 | 다른 회원 팔로잉 목록과 회원 없음 실패를 검증한다. |
+| MemberController | GET | `/api/members/{memberNickname}/followers` | 완료 | 다른 회원 팔로워 목록과 회원 없음 실패를 검증한다. |
+| MemberController | PATCH | `/api/members/me` | 완료 | 내 프로필 수정, validation, 프로필 미완료 403을 검증한다. |
+| MemberController | GET | `/api/members/me` | 완료 | 내 프로필 조회, 401, 프로필 미완료 403을 검증한다. |
+| MemberController | GET | `/api/members/me/follow-count` | 완료 | 기반 테스트에서 200/401/403을 확인했고, 도메인 전용 검증은 회원 배치에서 보강한다. |
+| MemberController | GET | `/api/members/{memberNickname}` | 완료 | 다른 회원 프로필 조회와 회원 없음 실패를 검증한다. |
+| MemberController | POST | `/api/members/find-email` | 완료 | 이메일 찾기 성공, 미존재 정보, validation을 검증한다. |
+| MemberController | PATCH | `/api/members/me/update-password` | 완료 | 비밀번호 변경 성공, 현재 비밀번호 불일치, validation을 검증한다. |
+| MemberController | PATCH | `/api/members/me/update-email` | 완료 | 이메일 변경 성공, 인증 코드 실패, 중복 이메일을 검증한다. |
+| MemberController | GET | `/api/members/me/login-status` | 완료 | 로그인 상태 응답과 쿠키 없음 상태를 검증한다. |
+| MemberController | GET | `/api/members/me/recommend` | 완료 | 회원 추천 목록과 인증 필요 계약을 검증한다. |
+| MemberController | POST | `/api/members/withdrawal` | 완료 | 회원 탈퇴 성공, 재인증/상태 실패를 검증한다. |
+| NewsAdminController | GET | `/api/admin/news` | 완료 | 관리자 뉴스 목록, 익명 401, 비관리자 403을 검증한다. |
+| NewsAdminController | GET | `/api/admin/news/{newsId}` | 완료 | 관리자 뉴스 상세와 not found를 검증한다. |
+| NewsAdminController | POST | `/api/admin/news` | 완료 | 관리자 뉴스 생성, validation, 권한 실패를 검증한다. |
+| NewsAdminController | PATCH | `/api/admin/news/{newsId}` | 완료 | 관리자 뉴스 수정, validation, not found를 검증한다. |
+| NewsAdminController | DELETE | `/api/admin/news/{newsId}` | 완료 | 관리자 뉴스 삭제와 not found를 검증한다. |
+| NewsAdminController | GET | `/api/admin/news/members/{memberNickname}` | 완료 | 회원별 뉴스 관리자 조회와 회원 없음 실패를 검증한다. |
+| NewsController | GET | `/api/news` | 완료 | 공개 뉴스 목록과 페이징을 검증한다. |
+| NewsController | GET | `/api/news/me` | 완료 | 내 뉴스 목록의 인증 필요 계약을 검증한다. |
+| NewsController | GET | `/api/news/{newsId}` | 완료 | 뉴스 상세 공개 조회와 not found를 검증한다. |
+| NotificationController | GET | `/api/notifications` | 완료 | 알림 목록 인증 계약과 페이징을 검증한다. |
+| NotificationController | GET | `/api/notifications/preview` | 완료 | 알림 미리보기 인증 계약을 검증한다. |
+| NotificationController | PATCH | `/api/notifications/{notificationId}/read` | 완료 | 읽음 처리 성공, 소유권 403, not found를 검증한다. |
+| NotificationController | GET | `/api/notifications/settings` | 완료 | 알림 설정 조회 인증 계약을 검증한다. |
+| NotificationController | PATCH | `/api/notifications/settings/{settingType}` | 완료 | 알림 설정 변경, enum validation, 인증 실패를 검증한다. |
+| ChatHistoryController | GET | `/api/clubs/{clubId}/meetings/{meetingId}/teams/{teamId}/chat/messages` | 완료 | WebSocket이 아닌 REST 채팅 히스토리 조회이므로 접근 권한과 페이징을 검증한다. |
+| ReportController | POST | `/api/reports` | 완료 | 신고 생성, validation, 중복/대상 없음 실패를 검증한다. |
+| ReportController | GET | `/api/reports/me` | 완료 | 내 신고 목록의 인증 필요 계약을 검증한다. |

--- a/docs/api-test/exclusions.md
+++ b/docs/api-test/exclusions.md
@@ -1,0 +1,29 @@
+# API 테스트 제외 범위
+
+## 제외 원칙
+
+이번 테스트 범위는 HTTP REST API다. 컨트롤러 매핑이 존재하는 REST 엔드포인트는 인증/인가가 필요하더라도 테스트 대상에 포함한다. 반대로 프로토콜, 외부 시스템, 운영 인프라 자체를 검증해야 하는 항목은 API 테스트에서 제외하고 테스트 더블 또는 별도 테스트 계층으로 분리한다.
+
+## 제외 항목
+
+| 제외 항목 | 제외 이유 | 대체 검증 |
+| --- | --- | --- |
+| WebSocket/STOMP 실시간 연결 | RestAssured는 HTTP REST 요청/응답 검증 도구이고, STOMP 세션·구독·브로커 흐름은 테스트 방식이 다르다. | 별도 WebSocket/STOMP 통합 테스트에서 handshake, subscribe, publish를 검증한다. |
+| 실제 Redis 서버 연결 | API 테스트가 로컬 Redis 실행 여부에 의존하면 재현성이 떨어지고 CI에서 불안정해진다. | `TokenCacheService`, `RedisTemplate`, `StringRedisTemplate`을 테스트 더블로 둔다. |
+| 실제 메일 발송 | 테스트 실행 중 외부 SMTP로 메일을 보내면 비용, 속도, 계정 보안 문제가 생긴다. | 메일 서비스 테스트 더블을 사용하고, API는 요청/응답 및 이벤트 발생 경로만 검증한다. |
+| 실제 S3 presigned URL 생성/삭제 네트워크 호출 | AWS 자격 증명과 네트워크가 필요하며 API 동작 테스트의 관심사가 아니다. | `S3Service` 테스트 더블로 성공/실패 응답을 고정한다. |
+| 실제 알라딘 API 호출 | 외부 API 상태, rate limit, 네트워크에 따라 테스트 결과가 흔들린다. | 알라딘 호출 경계인 `RestTemplate` 또는 서비스 결과를 deterministic fixture로 고정한다. |
+| OAuth2 제공자 실제 로그인 플로우 | 구글/카카오/네이버 인증 화면과 콜백은 외부 인증 시스템 E2E에 가깝다. | 테스트 프로파일에는 더미 OAuth2 registration만 둔다. 자체 auth REST API와 JWT 필터 체인은 테스트한다. |
+| Flyway 마이그레이션 호환성 검증 | 운영 MySQL 마이그레이션 검증은 API 요청/응답 검증과 관심사가 다르다. | API 테스트는 Hibernate `create-drop`을 사용한다. 마이그레이션은 별도 DB 호환성 테스트에서 검증한다. |
+
+## 제외하지 않는 항목
+
+- 인증이 필요한 REST API
+- 관리자 REST API
+- REST 방식 채팅 히스토리 조회 API
+- 프로필 미완료 사용자 403
+- 비관리자 403
+- 잘못된 요청 400
+- 도메인 상태 오류와 not found 계열 실패
+
+즉, "외부 시스템 자체"는 제외하지만, 그 외부 시스템을 사용하는 REST API의 HTTP 계약은 테스트 더블을 통해 검증한다.

--- a/docs/api-test/test-rationale.md
+++ b/docs/api-test/test-rationale.md
@@ -1,0 +1,93 @@
+# API 테스트별 추가 이유
+
+## 문서 기준
+
+이 문서는 현재 추가된 RestAssured API 테스트가 왜 필요한지 테스트 메서드 단위로 설명한다. 세부 엔드포인트별 상태는 `coverage-matrix.md`를 기준으로 보고, 여기서는 테스트가 묶인 이유와 검증 의도를 기록한다.
+
+## ApiTestInfrastructureTest
+
+| 테스트 | 추가 이유 |
+| --- | --- |
+| `testProfileUsesH2AndDoesNotIncludeProductionProfiles` | API 테스트가 운영 프로파일, 운영 DB, Redis, S3, 메일 설정을 끌고 오지 않는지 먼저 고정해야 이후 실패 원인을 API 계약으로 해석할 수 있다. |
+| `healthEndpointIsCallableWithRestAssured` | `RANDOM_PORT` 서버와 RestAssured 연결이 실제 HTTP 경로로 동작하는지 확인하는 가장 작은 기준점이다. |
+| `authenticatedFixtureCanCallProfileCompletedApi` | 완료 프로필 JWT fixture가 실제 보안 필터를 통과하는지 확인한다. |
+| `anonymousRequestToAuthenticatedApiReturnsUnauthorized` | 인증 쿠키가 없는 요청이 401로 막히는 공통 보안 계약을 고정한다. |
+| `incompleteProfileFixtureIsBlockedBeforeProtectedApiExecution` | 프로필 미완료 사용자가 보호 API에서 403으로 차단되는 전역 필터 계약을 고정한다. |
+| `adminFixtureCanIssueJwtCookies` | 관리자 API 배치를 만들기 전에 `ROLE_ADMIN` JWT fixture가 정상 생성되는지 확인한다. |
+
+## AuthApiTest
+
+| 테스트 | 추가 이유 |
+| --- | --- |
+| `sendEmailVerificationSucceedsWithMailBoundaryMocked` | 실제 메일 발송 없이 이메일 인증 요청의 HTTP 성공 계약을 검증한다. |
+| `sendEmailVerificationRejectsInvalidEmail` | 이메일 형식 validation이 컨트롤러 진입 시 400으로 반환되는지 검증한다. |
+| `confirmEmailVerificationSucceedsWhenCodeMatches` | Redis 더블에 저장된 인증 코드와 요청 코드가 일치할 때 인증 완료 흐름을 검증한다. |
+| `confirmEmailVerificationRejectsWrongCode` | 잘못된 인증 코드가 가입 가능 상태로 넘어가지 않도록 실패 계약을 검증한다. |
+| `signUpSucceedsAfterEmailVerificationAndSetsJwtCookies` | 인증 완료 후 회원가입, AuthUser/Member 저장, JWT 쿠키 발급을 한 번에 검증한다. |
+| `signUpRejectsUnverifiedEmail` | 이메일 인증을 건너뛴 가입 시도를 차단한다. |
+| `signUpRejectsDuplicateEmail` | 중복 이메일 가입이 DB 제약과 서비스 검증으로 실패하는지 확인한다. |
+| `signUpRejectsInvalidPayload` | 가입 요청 body의 필수값/형식 validation을 고정한다. |
+| `loginSucceedsAndSetsJwtCookies` | 저장된 사용자 자격 증명으로 로그인하고 access/refresh 쿠키가 내려오는지 검증한다. |
+| `loginRejectsWrongPassword` | 비밀번호 불일치가 인증 성공으로 오인되지 않도록 실패 계약을 검증한다. |
+| `logoutClearsJwtCookiesWhenTokensExist` | JWT 쿠키 기반 로그아웃과 토큰 캐시 경계 호출 후 응답 쿠키 정리를 검증한다. |
+| `sendTempPasswordSucceedsForKnownEmail` | 가입된 이메일에 대한 임시 비밀번호 발급 HTTP 계약을 검증한다. |
+| `sendTempPasswordReturnsNotFoundForUnknownEmail` | 미가입 이메일에 대한 정보 노출 없는 실패 계약을 검증한다. |
+| `sendTempPasswordRejectsInvalidEmail` | 임시 비밀번호 요청의 이메일 validation을 고정한다. |
+
+## PublicMemberApiTest
+
+| 테스트 | 추가 이유 |
+| --- | --- |
+| `checkNicknameReturnsDuplicatedState` | 공개 닉네임 중복 확인 API가 DB 상태를 반영하는지 검증한다. |
+| `checkNicknameRejectsInvalidNickname` | query parameter validation이 누락되지 않도록 고정한다. |
+| `findEmailSucceedsForMatchingNameAndPhoneNumber` | 이름/전화번호 조합으로 이메일 찾기가 성공하는 기본 사용자 복구 흐름을 검증한다. |
+| `findEmailReturnsNotFoundForUnknownPersonalInfo` | 일치하는 회원이 없을 때 404 계약을 검증한다. |
+| `findEmailRejectsInvalidPayload` | 이메일 찾기 body validation을 고정한다. |
+| `protectedMemberApiReturnsUnauthorizedWithoutCookie` | 공개 회원 API와 보호 회원 API의 보안 경계가 섞이지 않도록 401을 확인한다. |
+
+## MemberApiTest
+
+| 테스트 | 추가 이유 |
+| --- | --- |
+| `additionalInfoCompletesIncompleteProfile` | 미완료 사용자가 허용된 추가 정보 API를 통해 완료 상태로 전환되는 핵심 온보딩 흐름을 검증한다. |
+| `profileReadAndUpdateSucceedForCompletedUser` | 완료 사용자의 내 프로필 조회/수정 성공 계약을 검증한다. |
+| `incompleteProfileCannotReadProtectedProfile` | 프로필 완료 필터가 보호 프로필 API를 사전에 차단하는지 검증한다. |
+| `followListAndUnfollowFlowSucceeds` | 팔로우 생성, 목록 조회, 언팔로우의 상태 전이를 검증한다. |
+| `selfFollowIsRejected` | 자기 자신 팔로우 금지 도메인 규칙을 검증한다. |
+| `followerDeleteFlowSucceeds` | 팔로워 삭제 API가 관계의 반대 방향을 올바르게 처리하는지 검증한다. |
+| `blockListAndUnblockFlowSucceeds` | 차단 생성, 목록 조회, 해제의 상태 전이를 검증한다. |
+| `selfBlockIsRejected` | 자기 자신 차단 금지 도메인 규칙을 검증한다. |
+| `otherProfileAndFollowListsAreReadable` | 다른 회원 공개 프로필과 팔로우 목록 조회 계약을 검증한다. |
+| `updatePasswordSucceedsAndRejectsWrongCurrentPassword` | 현재 비밀번호 확인과 새 비밀번호 반영 실패/성공 경계를 검증한다. |
+| `updateEmailSucceedsAfterVerification` | 이메일 인증 코드 확인 후 이메일 변경이 가능한지 검증한다. |
+| `loginStatusRecommendationFollowCountAndWithdrawalSucceed` | 로그인 상태, 회원 추천, 팔로우 수, 탈퇴처럼 회원 화면에서 반복 호출되는 단건 API들을 함께 고정한다. |
+
+## ClubMeetingNoticeApiTest
+
+| 테스트 | 추가 이유 |
+| --- | --- |
+| `clubManagementFlowCoversClubEndpoints` | 클럽 생성부터 가입, 멤버 관리, 수정, 삭제까지 클럽 관리 API의 대표 상태 전이를 검증한다. |
+| `bookshelfMeetingTopicReviewAndChatFlowCoversRestEndpoints` | 책장, 모임, 발제, 한줄평, 팀 편성, REST 채팅 히스토리 조회를 하나의 모임 흐름으로 검증한다. |
+| `noticeVoteAndCommentFlowCoversNoticeEndpoints` | 공지 작성, 투표, 댓글, 수정, 삭제가 클럽 권한과 함께 동작하는지 검증한다. |
+| `nonMemberCannotAccessMemberOnlyClubResources` | 클럽 멤버 전용 REST API가 비멤버 접근을 숨김/거부하는 계약을 검증한다. |
+| `authenticatedClubEndpointRequiresCookie` | 클럽 생성 같은 인증 필수 API가 익명 요청을 401로 차단하는지 검증한다. |
+
+## BookStoryNewsReportNotificationImageApiTest
+
+| 테스트 | 추가 이유 |
+| --- | --- |
+| `bookSearchDetailRecommendLikeAndLikedListsSucceed` | 알라딘 경계 더블, 추천 캐시 fallback, 도서 좋아요 토글, 내/타인 좋아요 목록, 401을 한 번에 검증한다. |
+| `bookStoryCrudListsLikeCommentAndFailuresSucceed` | 책 이야기 작성, 목록, 상세, 좋아요, 댓글, 수정/삭제, 소유권 403, validation을 실제 H2 상태 전이로 검증한다. |
+| `newsListMyListAndDetailUseH2Rows` | 공개 뉴스, 내 뉴스, 상세 조회가 H2에 저장된 게시 기간과 요청자 이메일을 기준으로 동작하는지 검증한다. |
+| `reportCreateListValidationAndBusinessFailuresSucceed` | 신고 생성, 내 신고 목록, 자기 자신 신고 금지, validation, 401을 검증한다. |
+| `notificationListPreviewReadAndSettingsSucceed` | 알림 목록/미리보기, 읽음 처리, 알림 설정 조회/토글, enum 오류, 401을 검증한다. |
+| `imageUploadUrlValidatesAuthenticationProfileAndFileType` | S3 네트워크 없이 presigned URL 발급 성공, 파일 형식 실패, 익명 401, 프로필 미완료 403을 검증한다. |
+
+## AdminApiTest
+
+| 테스트 | 추가 이유 |
+| --- | --- |
+| `memberAdminEndpointsRequireAdminAndReturnMemberData` | 관리자 회원 이메일 검색, 회원 목록, 회원 상세, 회원 없음 404, 익명 401, 비관리자 403을 검증한다. |
+| `clubAdminEndpointsCoverListDetailUpdateMembersAndSecurity` | 관리자 클럽 목록, 상세, 수정, 활성 멤버 조회, 회원별 클럽 조회, validation, not found, 401/403을 검증한다. |
+| `newsAdminEndpointsCoverCrudMemberLookupValidationAndSecurity` | 관리자 뉴스 생성, 목록, 상세, 수정, 회원별 조회, validation, not found, 삭제, 401/403을 검증한다. |
+| `bookStoryAdminEndpointsCoverListDetailDeleteCommentMemberLookupAndSecurity` | 관리자 책 이야기 목록, 상세, 회원별 조회, 댓글 삭제, 글 삭제, not found, 401/403을 검증한다. |

--- a/src/main/java/checkmo/authentication/internal/converter/AuthConverter.java
+++ b/src/main/java/checkmo/authentication/internal/converter/AuthConverter.java
@@ -8,7 +8,6 @@ import checkmo.authentication.web.dto.AuthResponseDTO;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import java.util.UUID;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthConverter {
@@ -30,6 +29,7 @@ public class AuthConverter {
                 .role(Role.USER)
                 .deactivatedAt(null)
                 .profileCompleted(false)
+                .nickName("")
                 .build();
     }
 
@@ -44,6 +44,7 @@ public class AuthConverter {
                 .role(Role.USER)
                 .deactivatedAt(null)
                 .profileCompleted(false)
+                .nickName("")
                 .build();
     }
 }

--- a/src/main/java/checkmo/authentication/web/controller/AuthController.java
+++ b/src/main/java/checkmo/authentication/web/controller/AuthController.java
@@ -15,11 +15,13 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Validated
 @Tag(name = "인증", description = "회원가입, 로그인, 로그아웃 API")
 public class AuthController {
 

--- a/src/main/java/checkmo/common/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/checkmo/common/apiPayload/exception/ExceptionAdvice.java
@@ -13,6 +13,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,7 +34,13 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
 
-        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+        return handleExceptionInternalArgs(
+                e,
+                HttpHeaders.EMPTY,
+                ErrorStatus._BAD_REQUEST,
+                request,
+                Map.of("constraint", errorMessage)
+        );
     }
 
     @Override
@@ -57,10 +65,22 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
-        e.printStackTrace();
+        log.error("Unhandled exception while processing API request", e);
 
         return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY,
                 ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());
+    }
+
+    @ExceptionHandler({AccessDeniedException.class, AuthorizationDeniedException.class})
+    public ResponseEntity<Object> accessDenied(Exception e, WebRequest request) {
+        return handleExceptionInternalFalse(
+                e,
+                ErrorStatus._FORBIDDEN,
+                HttpHeaders.EMPTY,
+                ErrorStatus._FORBIDDEN.getHttpStatus(),
+                request,
+                null
+        );
     }
 
     @ExceptionHandler(value = GeneralException.class)

--- a/src/main/java/checkmo/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/member/web/controller/MemberController.java
@@ -24,11 +24,13 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
+@Validated
 @Tag(name = "회원", description = "마이페이지, 프로필 관리, 팔로우, 모임 관리, 알림 설정 관련 API")
 public class MemberController {
 

--- a/src/test/java/checkmo/CheckmoApplicationTests.java
+++ b/src/test/java/checkmo/CheckmoApplicationTests.java
@@ -1,29 +1,39 @@
 package checkmo;
 
+import checkmo.book.internal.scheduler.BookRecommendationScheduler;
+import checkmo.bookStory.internal.scheduler.BookStoryViewScheduler;
+import checkmo.member.internal.scheduler.MemberCleanupScheduler;
+import checkmo.support.SpringTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.modulith.core.ApplicationModules;
 import org.springframework.modulith.docs.Documenter;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@SpringBootTest
+@SpringTest
 class CheckmoApplicationTests {
+
+    @MockitoBean
+    BookRecommendationScheduler bookRecommendationScheduler;
+
+    @MockitoBean
+    BookStoryViewScheduler bookStoryViewScheduler;
+
+    @MockitoBean
+    MemberCleanupScheduler memberCleanupScheduler;
 
     @DisplayName("각 모듈이 논리적으로 분리가 완료되었는지 Spring Modulith를 통해 확인합니다.")
     @Test
     void Spring_Modulith_Test() {
-        ApplicationModules modules = ApplicationModules.of(CheckmoApplication.class).verify();
-        System.out.println(modules);
+        ApplicationModules.of(CheckmoApplication.class).verify();
     }
 
     @Test
     void writeDocumentationSnippets() {
-
         ApplicationModules modules = ApplicationModules.of(CheckmoApplication.class);
         Documenter documenter = new Documenter(modules)
                 .writeModulesAsPlantUml()
                 .writeIndividualModulesAsPlantUml();
         documenter.writeModuleCanvases();
     }
-
 }

--- a/src/test/java/checkmo/admin/AdminApiTest.java
+++ b/src/test/java/checkmo/admin/AdminApiTest.java
@@ -1,6 +1,7 @@
 package checkmo.admin;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
@@ -189,7 +190,7 @@ class AdminApiTest extends ApiTestSupport {
                 .when().delete("/api/admin/news/{newsId}", newsId)
                 .then().statusCode(200);
 
-        org.assertj.core.api.Assertions.assertThat(newsRepository.findById(newsId.longValue())).isEmpty();
+        assertThat(newsRepository.findById(newsId.longValue())).isEmpty();
     }
 
     @Test
@@ -230,10 +231,12 @@ class AdminApiTest extends ApiTestSupport {
                 .when().delete("/api/admin/book-stories/{bookStoryId}/comments/{commentId}", story.getId(), comment.getId())
                 .then().statusCode(200)
                 .body("result", equalTo(comment.getId().intValue()));
+        assertThat(commentRepository.findById(comment.getId()).orElseThrow().isDeleted()).isTrue();
 
         given().cookie(accessTokenCookie(admin))
                 .when().delete("/api/admin/book-stories/{bookStoryId}", story.getId())
                 .then().statusCode(200);
+        assertThat(bookStoryRepository.findById(story.getId())).isEmpty();
 
         given().cookie(accessTokenCookie(admin))
                 .when().get("/api/admin/book-stories/{bookStoryId}", 999999)

--- a/src/test/java/checkmo/admin/AdminApiTest.java
+++ b/src/test/java/checkmo/admin/AdminApiTest.java
@@ -1,0 +1,296 @@
+package checkmo.admin;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+import checkmo.bookStory.internal.entity.BookStory;
+import checkmo.bookStory.internal.entity.BookStoryStatus;
+import checkmo.bookStory.internal.entity.Comment;
+import checkmo.bookStory.internal.repository.BookStoryRepository;
+import checkmo.bookStory.internal.repository.CommentRepository;
+import checkmo.clubManagement.internal.entity.Club;
+import checkmo.clubManagement.internal.entity.ClubContact;
+import checkmo.clubManagement.internal.entity.ClubInterestCategory;
+import checkmo.clubManagement.internal.entity.ClubMemberStatus;
+import checkmo.clubManagement.internal.entity.ClubParticipantType;
+import checkmo.clubManagement.internal.repository.ClubRepository;
+import checkmo.news.internal.repository.NewsRepository;
+import checkmo.support.ApiTestSupport;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+class AdminApiTest extends ApiTestSupport {
+
+    private static final String ISBN = "9791169213882";
+
+    @Autowired
+    ClubRepository clubRepository;
+
+    @Autowired
+    BookStoryRepository bookStoryRepository;
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    NewsRepository newsRepository;
+
+    @Test
+    void memberAdminEndpointsRequireAdminAndReturnMemberData() {
+        TestUser admin = createAdmin();
+        TestUser user = createUser();
+        TestUser nonAdmin = createUser();
+
+        given().cookie(accessTokenCookie(admin))
+                .queryParam("keyword", user.email().substring(0, 8))
+                .queryParam("limit", 10)
+                .when().get("/api/admin/members/emails")
+                .then().statusCode(200)
+                .body("result.emails.size()", greaterThanOrEqualTo(1));
+
+        given().cookie(accessTokenCookie(admin))
+                .queryParam("keyword", user.email())
+                .when().get("/api/admin/members")
+                .then().statusCode(200)
+                .body("result.memberList.size()", greaterThanOrEqualTo(1));
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/members/{memberNickName}", user.nickName())
+                .then().statusCode(200)
+                .body("result.email", equalTo(user.email()));
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/members/{memberNickName}", "unknown-member")
+                .then().statusCode(404);
+
+        given().cookie(accessTokenCookie(nonAdmin))
+                .when().get("/api/admin/members")
+                .then().statusCode(403);
+
+        given().when().get("/api/admin/members")
+                .then().statusCode(401);
+    }
+
+    @Test
+    void clubAdminEndpointsCoverListDetailUpdateMembersAndSecurity() {
+        TestUser admin = createAdmin();
+        TestUser owner = createUser();
+        TestUser nonAdmin = createUser();
+        Club club = createClub(owner, "admin-club-" + owner.id().substring(owner.id().length() - 4).toLowerCase());
+
+        given().cookie(accessTokenCookie(admin))
+                .queryParam("keyword", "admin-club")
+                .queryParam("page", 1)
+                .when().get("/api/admin/clubs")
+                .then().statusCode(200)
+                .body("result.clubs.size()", greaterThanOrEqualTo(1));
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/clubs/{clubId}", club.getId())
+                .then().statusCode(200)
+                .body("result.name", equalTo(club.getName()));
+
+        given().cookie(accessTokenCookie(admin))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(clubPayload(club.getName() + "-edit"))
+                .when().put("/api/admin/clubs/{clubId}", club.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/clubs/{clubId}/active-members", club.getId())
+                .then().statusCode(200)
+                .body("result.members.size()", equalTo(1));
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/clubs/members/{memberNickname}", owner.nickName())
+                .then().statusCode(200)
+                .body("result.clubList.size()", equalTo(1));
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/clubs/{clubId}", 999999)
+                .then().statusCode(404);
+
+        given().cookie(accessTokenCookie(admin))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("name", ""))
+                .when().put("/api/admin/clubs/{clubId}", club.getId())
+                .then().statusCode(400);
+
+        given().cookie(accessTokenCookie(nonAdmin))
+                .when().get("/api/admin/clubs")
+                .then().statusCode(403);
+
+        given().when().get("/api/admin/clubs")
+                .then().statusCode(401);
+    }
+
+    @Test
+    void newsAdminEndpointsCoverCrudMemberLookupValidationAndSecurity() {
+        TestUser admin = createAdmin();
+        TestUser requester = createUser();
+        TestUser nonAdmin = createUser();
+
+        Integer newsId = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(admin))
+                .body(newsPayload("관리자 소식", requester.email()))
+                .when().post("/api/admin/news")
+                .then().statusCode(200)
+                .extract().path("result");
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/news")
+                .then().statusCode(200)
+                .body("result.basicInfoList.size()", greaterThanOrEqualTo(1));
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/news/{newsId}", newsId)
+                .then().statusCode(200)
+                .body("result.title", equalTo("관리자 소식"));
+
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(admin))
+                .body(newsPayload("수정된 소식", requester.email()))
+                .when().patch("/api/admin/news/{newsId}", newsId)
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/news/members/{memberNickname}", requester.nickName())
+                .then().statusCode(200)
+                .body("result.basicInfoList.size()", greaterThanOrEqualTo(1));
+
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(admin))
+                .body(Map.of("title", ""))
+                .when().post("/api/admin/news")
+                .then().statusCode(400);
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/news/{newsId}", 999999)
+                .then().statusCode(404);
+
+        given().cookie(accessTokenCookie(nonAdmin))
+                .when().get("/api/admin/news")
+                .then().statusCode(403);
+
+        given().when().get("/api/admin/news")
+                .then().statusCode(401);
+
+        given().cookie(accessTokenCookie(admin))
+                .when().delete("/api/admin/news/{newsId}", newsId)
+                .then().statusCode(200);
+
+        org.assertj.core.api.Assertions.assertThat(newsRepository.findById(newsId.longValue())).isEmpty();
+    }
+
+    @Test
+    void bookStoryAdminEndpointsCoverListDetailDeleteCommentMemberLookupAndSecurity() {
+        TestUser admin = createAdmin();
+        TestUser author = createUser();
+        TestUser nonAdmin = createUser();
+        BookStory story = bookStoryRepository.save(BookStory.builder()
+                .memberId(author.id())
+                .bookId(ISBN)
+                .title("관리자 책 이야기")
+                .description("관리자 테스트용 책 이야기입니다.")
+                .status(BookStoryStatus.PUBLISHED)
+                .build());
+        Comment comment = commentRepository.save(Comment.builder()
+                .memberId(author.id())
+                .bookStory(story)
+                .content("관리자 삭제 대상 댓글")
+                .build());
+
+        given().cookie(accessTokenCookie(admin))
+                .queryParam("keyword", "관리자")
+                .when().get("/api/admin/book-stories")
+                .then().statusCode(200)
+                .body("result.basicInfoList.size()", greaterThanOrEqualTo(1));
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/book-stories/{bookStoryId}", story.getId())
+                .then().statusCode(200)
+                .body("result.bookStoryId", equalTo(story.getId().intValue()));
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/book-stories/members/{memberNickname}", author.nickName())
+                .then().statusCode(200)
+                .body("result.basicInfoList.size()", greaterThanOrEqualTo(1));
+
+        given().cookie(accessTokenCookie(admin))
+                .when().delete("/api/admin/book-stories/{bookStoryId}/comments/{commentId}", story.getId(), comment.getId())
+                .then().statusCode(200)
+                .body("result", equalTo(comment.getId().intValue()));
+
+        given().cookie(accessTokenCookie(admin))
+                .when().delete("/api/admin/book-stories/{bookStoryId}", story.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(admin))
+                .when().get("/api/admin/book-stories/{bookStoryId}", 999999)
+                .then().statusCode(404);
+
+        given().cookie(accessTokenCookie(nonAdmin))
+                .when().get("/api/admin/book-stories")
+                .then().statusCode(403);
+
+        given().when().get("/api/admin/book-stories")
+                .then().statusCode(401);
+    }
+
+    private Club createClub(TestUser owner, String clubName) {
+        Club club = Club.builder()
+                .name(clubName)
+                .description("관리자 테스트 클럽")
+                .profileImgUrl("https://example.com/club.png")
+                .isOpen(true)
+                .region("서울")
+                .participantTypes(new ArrayList<>(List.of(ClubParticipantType.ONLINE)))
+                .interestCategories(new HashSet<>(Set.of(ClubInterestCategory.COMPUTER_IT)))
+                .links(new ArrayList<>(List.of(ClubContact.builder()
+                        .link("https://example.com")
+                        .label("홈")
+                        .build())))
+                .build();
+        club.addOwner(owner.id(), LocalDateTime.now());
+        Club saved = clubRepository.save(club);
+        saved.getClubMembers().forEach(member -> member.updateStatus(ClubMemberStatus.OWNER));
+        return saved;
+    }
+
+    private Map<String, Object> clubPayload(String name) {
+        return Map.of(
+                "name", name,
+                "description", "관리자가 수정한 클럽 설명",
+                "profileImageUrl", "https://example.com/club-edit.png",
+                "open", true,
+                "region", "서울",
+                "category", List.of("COMPUTER_IT"),
+                "participantTypes", List.of("ONLINE"),
+                "links", List.of(Map.of("link", "https://example.com/edit", "label", "수정"))
+        );
+    }
+
+    private Map<String, Object> newsPayload(String title, String requesterEmail) {
+        return Map.of(
+                "title", title,
+                "requesterEmail", requesterEmail,
+                "content", "관리자 소식 본문입니다.",
+                "thumbnailUrl", "https://example.com/news.png",
+                "originalLink", "https://example.com/news",
+                "publishStartAt", LocalDate.now().minusDays(1).toString(),
+                "publishEndAt", LocalDate.now().plusDays(1).toString(),
+                "carousel", "GENERAL",
+                "imageUrls", List.of("https://example.com/news-1.png")
+        );
+    }
+}

--- a/src/test/java/checkmo/authentication/AuthApiTest.java
+++ b/src/test/java/checkmo/authentication/AuthApiTest.java
@@ -70,6 +70,22 @@ class AuthApiTest extends ApiTestSupport {
     }
 
     @Test
+    void confirmEmailVerificationRejectsExpiredCode() {
+        String email = "expired-code@example.com";
+        when(redisHashOperations.get("verification:" + email, "code")).thenReturn(null);
+        when(redisHashOperations.get("verification:" + email, "verified")).thenReturn(null);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("email", email, "verificationCode", "123456"))
+                .when()
+                .post("/api/auth/email-verification/confirm")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
     void signUpSucceedsAfterEmailVerificationAndSetsJwtCookies() {
         String email = "signup-success@example.com";
         when(redisHashOperations.get("verification:" + email, "verified")).thenReturn(true);
@@ -171,8 +187,8 @@ class AuthApiTest extends ApiTestSupport {
                 .extract();
 
         assertThat(response.headers().getValues("Set-Cookie"))
-                .anyMatch(header -> header.startsWith("accessToken="))
-                .anyMatch(header -> header.startsWith("refreshToken="));
+                .anyMatch(header -> header.startsWith("accessToken=") && header.contains("Max-Age=0"))
+                .anyMatch(header -> header.startsWith("refreshToken=") && header.contains("Max-Age=0"));
     }
 
     @Test

--- a/src/test/java/checkmo/authentication/AuthApiTest.java
+++ b/src/test/java/checkmo/authentication/AuthApiTest.java
@@ -1,0 +1,218 @@
+package checkmo.authentication;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+import checkmo.support.ApiTestSupport;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+class AuthApiTest extends ApiTestSupport {
+
+    @Test
+    void sendEmailVerificationSucceedsWithMailBoundaryMocked() {
+        given()
+                .queryParam("email", "new-user@example.com")
+                .when()
+                .post("/api/auth/email-verification")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true))
+                .body("result", equalTo("인증번호가 이메일로 발송되었습니다."));
+    }
+
+    @Test
+    void sendEmailVerificationRejectsInvalidEmail() {
+        given()
+                .queryParam("email", "not-an-email")
+                .when()
+                .post("/api/auth/email-verification")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void confirmEmailVerificationSucceedsWhenCodeMatches() {
+        String email = "verified@example.com";
+        when(redisHashOperations.get("verification:" + email, "code")).thenReturn("123456");
+        when(redisHashOperations.get("verification:" + email, "verified")).thenReturn(false);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("email", email, "verificationCode", "123456"))
+                .when()
+                .post("/api/auth/email-verification/confirm")
+                .then()
+                .statusCode(200)
+                .body("result", equalTo(true));
+    }
+
+    @Test
+    void confirmEmailVerificationRejectsWrongCode() {
+        String email = "wrong-code@example.com";
+        when(redisHashOperations.get("verification:" + email, "code")).thenReturn("123456");
+        when(redisHashOperations.get("verification:" + email, "verified")).thenReturn(false);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("email", email, "verificationCode", "999999"))
+                .when()
+                .post("/api/auth/email-verification/confirm")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void signUpSucceedsAfterEmailVerificationAndSetsJwtCookies() {
+        String email = "signup-success@example.com";
+        when(redisHashOperations.get("verification:" + email, "verified")).thenReturn(true);
+
+        ExtractableResponse<Response> response = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("email", email, "password", "Pass123!"))
+                .when()
+                .post("/api/auth/signup")
+                .then()
+                .statusCode(200)
+                .body("result.email", equalTo(email))
+                .body("result.profileCompleted", equalTo(false))
+                .extract();
+
+        assertJwtCookiesWereSet(response);
+    }
+
+    @Test
+    void signUpRejectsUnverifiedEmail() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("email", "not-verified@example.com", "password", "Pass123!"))
+                .when()
+                .post("/api/auth/signup")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void signUpRejectsDuplicateEmail() {
+        TestUser existing = createUser();
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("email", existing.email(), "password", "Pass123!"))
+                .when()
+                .post("/api/auth/signup")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void signUpRejectsInvalidPayload() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("email", "bad-email", "password", "short"))
+                .when()
+                .post("/api/auth/signup")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void loginSucceedsAndSetsJwtCookies() {
+        TestUser user = createUserWithPassword("Pass123!");
+
+        ExtractableResponse<Response> response = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("identifier", user.email(), "password", "Pass123!"))
+                .when()
+                .post("/api/auth/login")
+                .then()
+                .statusCode(200)
+                .body("result", equalTo("로그인에 성공했습니다."))
+                .extract();
+
+        assertJwtCookiesWereSet(response);
+    }
+
+    @Test
+    void loginRejectsWrongPassword() {
+        TestUser user = createUserWithPassword("Pass123!");
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("identifier", user.email(), "password", "Wrong1!"))
+                .when()
+                .post("/api/auth/login")
+                .then()
+                .statusCode(401)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void logoutClearsJwtCookiesWhenTokensExist() {
+        TestUser user = createUser();
+
+        ExtractableResponse<Response> response = given()
+                .cookie(accessTokenCookie(user))
+                .cookie(refreshTokenCookie(user))
+                .when()
+                .post("/api/auth/logout")
+                .then()
+                .statusCode(200)
+                .extract();
+
+        assertThat(response.headers().getValues("Set-Cookie"))
+                .anyMatch(header -> header.startsWith("accessToken="))
+                .anyMatch(header -> header.startsWith("refreshToken="));
+    }
+
+    @Test
+    void sendTempPasswordSucceedsForKnownEmail() {
+        TestUser user = createUser();
+
+        given()
+                .queryParam("email", user.email())
+                .when()
+                .post("/api/auth/temp-password")
+                .then()
+                .statusCode(200)
+                .body("result", equalTo("임시 비밀번호가 이메일로 발송되었습니다."));
+    }
+
+    @Test
+    void sendTempPasswordReturnsNotFoundForUnknownEmail() {
+        given()
+                .queryParam("email", "missing@example.com")
+                .when()
+                .post("/api/auth/temp-password")
+                .then()
+                .statusCode(404)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void sendTempPasswordRejectsInvalidEmail() {
+        given()
+                .queryParam("email", "missing")
+                .when()
+                .post("/api/auth/temp-password")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    private void assertJwtCookiesWereSet(ExtractableResponse<Response> response) {
+        assertThat(response.headers().getValues("Set-Cookie"))
+                .anyMatch(header -> header.startsWith("accessToken=") && header.contains("HttpOnly"))
+                .anyMatch(header -> header.startsWith("refreshToken=") && header.contains("HttpOnly"));
+    }
+}

--- a/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
+++ b/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
@@ -1,6 +1,7 @@
 package checkmo.book;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -254,7 +255,12 @@ class BookStoryNewsReportNotificationImageApiTest extends ApiTestSupport {
         given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(accessTokenCookie(author))
-                .body(Map.of("isbn", "bad", "title", "검증 실패", "status", "PUBLISHED"))
+                .body(Map.of(
+                        "isbn", "bad",
+                        "title", "검증 실패",
+                        "description", "ISBN 검증 실패를 확인할 설명입니다.",
+                        "status", "PUBLISHED"
+                ))
                 .when()
                 .post("/api/book-stories")
                 .then()
@@ -333,7 +339,7 @@ class BookStoryNewsReportNotificationImageApiTest extends ApiTestSupport {
         given().when().get("/api/reports/me")
                 .then().statusCode(401);
 
-        org.assertj.core.api.Assertions.assertThat(reportRepository.findAll()).hasSize(1);
+        assertThat(reportRepository.findAll()).hasSize(1);
     }
 
     @Test

--- a/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
+++ b/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
@@ -1,0 +1,432 @@
+package checkmo.book;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import checkmo.book.internal.service.query.AladinApiService;
+import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import checkmo.bookStory.internal.entity.BookStoryStatus;
+import checkmo.bookStory.internal.repository.BookStoryRepository;
+import checkmo.bookStory.internal.repository.CommentRepository;
+import checkmo.clubManagement.ClubManagementAPI;
+import checkmo.infra.s3.internal.entity.FileUploadType;
+import checkmo.infra.s3.internal.exception.S3ErrorStatus;
+import checkmo.infra.s3.internal.exception.S3InfraException;
+import checkmo.infra.s3.web.dto.S3ResponseDTO;
+import checkmo.news.internal.entity.News;
+import checkmo.news.internal.entity.NewsCarousel;
+import checkmo.news.internal.repository.NewsRepository;
+import checkmo.notification.internal.entity.Notification;
+import checkmo.notification.internal.entity.Notification.NotificationType;
+import checkmo.notification.internal.entity.NotificationSetting;
+import checkmo.notification.internal.repository.NotificationRepository;
+import checkmo.notification.internal.repository.NotificationSettingRepository;
+import checkmo.report.internal.repository.ReportRepository;
+import checkmo.support.ApiTestSupport;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class BookStoryNewsReportNotificationImageApiTest extends ApiTestSupport {
+
+    private static final String ISBN = "9791169213882";
+
+    @MockitoBean
+    AladinApiService aladinApiService;
+
+    @MockitoBean
+    ClubManagementAPI clubManagementAPI;
+
+    @Autowired
+    BookStoryRepository bookStoryRepository;
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    NewsRepository newsRepository;
+
+    @Autowired
+    ReportRepository reportRepository;
+
+    @Autowired
+    NotificationRepository notificationRepository;
+
+    @Autowired
+    NotificationSettingRepository notificationSettingRepository;
+
+    @BeforeEach
+    void setUpDomainApiDoubles() {
+        DetailInfo detail = bookDetail(ISBN);
+        BookResponseDTO.BookList oneBookList = BookResponseDTO.BookList.builder()
+                .detailInfoList(List.of(detail))
+                .currentPage(1)
+                .hasNext(false)
+                .build();
+
+        when(aladinApiService.searchBooks(eq("자바"), eq(1), anyString())).thenReturn(oneBookList);
+        when(aladinApiService.retrieveBookDetailInfo(ISBN)).thenReturn(detail);
+        when(aladinApiService.retrieveRecommendedBooks()).thenReturn(BookResponseDTO.BookList.builder()
+                .detailInfoList(IntStream.rangeClosed(1, 28)
+                        .mapToObj(index -> bookDetail("979116921%04d".formatted(index)))
+                        .toList())
+                .currentPage(1)
+                .hasNext(false)
+                .build());
+        when(aladinApiService.applyLikedByMe(any(BookResponseDTO.BookList.class), any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        when(clubManagementAPI.fetchClubNamesByClubIds(anyList())).thenReturn(Map.of(77L, "테스트 독서모임"));
+        when(s3Service.generatePresignedUploadUrl("profile.png", "image/png", FileUploadType.PROFILE))
+                .thenReturn(S3ResponseDTO.PresignedUrl.builder()
+                        .presignedUrl("https://upload.example.com/profile.png")
+                        .imageUrl("https://cdn.example.com/profile.png")
+                        .build());
+        when(s3Service.generatePresignedUploadUrl("profile.txt", "text/plain", FileUploadType.PROFILE))
+                .thenThrow(new S3InfraException(S3ErrorStatus.INVALID_FILE_TYPE));
+    }
+
+    @Test
+    void bookSearchDetailRecommendLikeAndLikedListsSucceed() {
+        TestUser user = createUser();
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .queryParam("keyword", "자바")
+                .queryParam("page", 1)
+                .when()
+                .get("/api/books/search")
+                .then()
+                .statusCode(200)
+                .body("result.detailInfoList[0].isbn", equalTo(ISBN));
+
+        given()
+                .when()
+                .get("/api/books/{isbn}", ISBN)
+                .then()
+                .statusCode(200)
+                .body("result.isbn", equalTo(ISBN));
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/books/recommend")
+                .then()
+                .statusCode(200)
+                .body("result.detailInfoList.size()", equalTo(4));
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .post("/api/books/{isbn}/like", ISBN)
+                .then()
+                .statusCode(200)
+                .body("result.liked", equalTo(true));
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/books/me/likes")
+                .then()
+                .statusCode(200)
+                .body("result.books[0].isbn", equalTo(ISBN));
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/books/{memberNickname}/likes", user.nickName())
+                .then()
+                .statusCode(200)
+                .body("result.books[0].likedByMe", equalTo(true));
+
+        given()
+                .when()
+                .post("/api/books/{isbn}/like", ISBN)
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    void bookStoryCrudListsLikeCommentAndFailuresSucceed() {
+        TestUser author = createUser();
+        TestUser other = createUser();
+        Long clubId = 77L;
+        when(clubManagementAPI.validateAndFetchActiveClubMemberId(eq(clubId), eq(author.id()))).thenReturn(1L);
+        when(clubManagementAPI.fetchActiveMemberIds(clubId)).thenReturn(List.of(author.id()));
+
+        Number storyIdNumber = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(author))
+                .body(Map.of(
+                        "isbn", ISBN,
+                        "title", "책 이야기",
+                        "description", "책 이야기를 충분히 작성합니다.",
+                        "status", "PUBLISHED"
+                ))
+                .when()
+                .post("/api/book-stories")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("result");
+        Long storyId = storyIdNumber.longValue();
+
+        given().when().get("/api/book-stories")
+                .then().statusCode(200).body("result.basicInfoList.size()", greaterThanOrEqualTo(1));
+        given().cookie(accessTokenCookie(author)).when().get("/api/book-stories/me")
+                .then().statusCode(200).body("result.basicInfoList.size()", equalTo(1));
+        given().cookie(accessTokenCookie(author)).when().get("/api/book-stories/following")
+                .then().statusCode(200);
+        given().cookie(accessTokenCookie(author)).when().get("/api/book-stories/members/{nickname}", author.nickName())
+                .then().statusCode(200).body("result.basicInfoList.size()", equalTo(1));
+        given().cookie(accessTokenCookie(author)).when().get("/api/book-stories/clubs/{clubId}", clubId)
+                .then().statusCode(200).body("result.basicInfoList.size()", equalTo(1));
+        given().cookie(accessTokenCookie(author)).when().get("/api/book-stories/search/{bookId}", ISBN)
+                .then().statusCode(200).body("result.basicInfoList.size()", equalTo(1));
+        given().cookie(accessTokenCookie(author)).when().get("/api/book-stories/{bookStoryId}", storyId)
+                .then().statusCode(200).body("result.bookStoryId", equalTo(storyId.intValue()));
+
+        given().cookie(accessTokenCookie(other)).when().post("/api/book-stories/{bookStoryId}/like", storyId)
+                .then().statusCode(200).body("message", equalTo("좋아요가 추가되었습니다."));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(other))
+                .body(Map.of("content", "좋은 글입니다."))
+                .when()
+                .post("/api/book-stories/{bookStoryId}/comments", storyId)
+                .then()
+                .statusCode(200);
+        Long commentId = commentRepository.findAll().getFirst().getId();
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(other))
+                .body(Map.of("content", "수정 댓글입니다."))
+                .when()
+                .patch("/api/book-stories/{bookStoryId}/comments/{commentId}", storyId, commentId)
+                .then()
+                .statusCode(200);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(author))
+                .body(Map.of(
+                        "isbn", ISBN,
+                        "title", "수정된 책 이야기",
+                        "description", "수정된 내용을 충분히 작성합니다.",
+                        "status", "PUBLISHED"
+                ))
+                .when()
+                .patch("/api/book-stories/{bookStoryId}", storyId)
+                .then()
+                .statusCode(200);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(other))
+                .body(Map.of("title", "권한 없음", "description", "권한 없음", "status", "PUBLISHED"))
+                .when()
+                .patch("/api/book-stories/{bookStoryId}", storyId)
+                .then()
+                .statusCode(403);
+
+        given().cookie(accessTokenCookie(other))
+                .when().delete("/api/book-stories/{bookStoryId}/comments/{commentId}", storyId, commentId)
+                .then().statusCode(200);
+        given().cookie(accessTokenCookie(author))
+                .when().delete("/api/book-stories/{bookStoryId}", storyId)
+                .then().statusCode(200);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(author))
+                .body(Map.of("isbn", "bad", "title", "검증 실패", "status", "PUBLISHED"))
+                .when()
+                .post("/api/book-stories")
+                .then()
+                .statusCode(400);
+    }
+
+    @Test
+    void newsListMyListAndDetailUseH2Rows() {
+        TestUser user = createUser();
+        News news = newsRepository.save(News.builder()
+                .title("서비스 소식")
+                .requesterEmail(user.email())
+                .content("공개되는 소식 본문입니다.")
+                .thumbnailUrl("https://example.com/thumb.png")
+                .originalLink("https://example.com/news")
+                .publishStartAt(LocalDate.now().minusDays(1))
+                .publishEndAt(LocalDate.now().plusDays(1))
+                .carousel(NewsCarousel.GENERAL)
+                .build());
+        news.replaceImages(List.of("https://example.com/news-1.png"));
+        newsRepository.save(news);
+
+        given().when().get("/api/news")
+                .then().statusCode(200).body("result.basicInfoList[0].newsId", equalTo(news.getId().intValue()));
+        given().cookie(accessTokenCookie(user)).when().get("/api/news/me")
+                .then().statusCode(200).body("result.basicInfoList[0].newsId", equalTo(news.getId().intValue()));
+        given().when().get("/api/news/{newsId}", news.getId())
+                .then().statusCode(200).body("result.title", equalTo("서비스 소식"));
+        given().when().get("/api/news/{newsId}", 999999)
+                .then().statusCode(404);
+    }
+
+    @Test
+    void reportCreateListValidationAndBusinessFailuresSucceed() {
+        TestUser reporter = createUser();
+        TestUser target = createUser();
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(reporter))
+                .body(Map.of(
+                        "targetType", "MEMBER",
+                        "targetId", target.nickName(),
+                        "reason", "INSULT",
+                        "content", "부적절한 표현이 있습니다."
+                ))
+                .when()
+                .post("/api/reports")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true));
+
+        given().cookie(accessTokenCookie(reporter))
+                .when().get("/api/reports/me")
+                .then().statusCode(200)
+                .body("result.reports[0].targetId", equalTo(target.nickName()));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(reporter))
+                .body(Map.of("targetType", "MEMBER", "targetId", reporter.nickName(), "reason", "GENERAL"))
+                .when()
+                .post("/api/reports")
+                .then()
+                .statusCode(400);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(reporter))
+                .body(Map.of("targetType", "MEMBER", "targetId", target.nickName()))
+                .when()
+                .post("/api/reports")
+                .then()
+                .statusCode(400);
+
+        given().when().get("/api/reports/me")
+                .then().statusCode(401);
+
+        org.assertj.core.api.Assertions.assertThat(reportRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    void notificationListPreviewReadAndSettingsSucceed() {
+        TestUser receiver = createUser();
+        TestUser sender = createUser();
+        notificationSettingRepository.save(NotificationSetting.builder()
+                .memberId(receiver.id())
+                .build());
+        Notification notification = notificationRepository.save(Notification.builder()
+                .notificationType(NotificationType.FOLLOW)
+                .sourceId(100L)
+                .receiverId(receiver.id())
+                .senderId(sender.id())
+                .build());
+
+        given().cookie(accessTokenCookie(receiver))
+                .when().get("/api/notifications")
+                .then().statusCode(200)
+                .body("result.notifications[0].notificationId", equalTo(notification.getId().intValue()));
+        given().cookie(accessTokenCookie(receiver))
+                .when().get("/api/notifications/preview")
+                .then().statusCode(200)
+                .body("result.notifications[0].read", equalTo(false));
+        given().cookie(accessTokenCookie(receiver))
+                .when().patch("/api/notifications/{notificationId}/read", notification.getId())
+                .then().statusCode(200);
+        given().cookie(accessTokenCookie(receiver))
+                .when().get("/api/notifications/settings")
+                .then().statusCode(200)
+                .body("result.newFollower", equalTo(true));
+        given().cookie(accessTokenCookie(receiver))
+                .when().patch("/api/notifications/settings/{settingType}", "NEW_FOLLOWER")
+                .then().statusCode(200);
+        given().cookie(accessTokenCookie(receiver))
+                .when().patch("/api/notifications/settings/{settingType}", "UNKNOWN")
+                .then().statusCode(400);
+
+        given().when().get("/api/notifications")
+                .then().statusCode(401);
+    }
+
+    @Test
+    void imageUploadUrlValidatesAuthenticationProfileAndFileType() {
+        TestUser user = createUser();
+        TestUser incomplete = createIncompleteUser();
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(user))
+                .body(Map.of("originalFileName", "profile.png", "contentType", "image/png"))
+                .when()
+                .post("/api/image/{type}/upload-url", "PROFILE")
+                .then()
+                .statusCode(200)
+                .body("result.imageUrl", equalTo("https://cdn.example.com/profile.png"));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(user))
+                .body(Map.of("originalFileName", "profile.txt", "contentType", "text/plain"))
+                .when()
+                .post("/api/image/{type}/upload-url", "PROFILE")
+                .then()
+                .statusCode(400);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("originalFileName", "profile.png", "contentType", "image/png"))
+                .when()
+                .post("/api/image/{type}/upload-url", "PROFILE")
+                .then()
+                .statusCode(401);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(incomplete))
+                .body(Map.of("originalFileName", "profile.png", "contentType", "image/png"))
+                .when()
+                .post("/api/image/{type}/upload-url", "PROFILE")
+                .then()
+                .statusCode(403);
+    }
+
+    private DetailInfo bookDetail(String isbn) {
+        return DetailInfo.builder()
+                .isbn(isbn)
+                .title("테스트 책 " + isbn.substring(isbn.length() - 4))
+                .author("테스트 저자")
+                .imgUrl("https://example.com/book.png")
+                .publisher("테스트 출판사")
+                .description("테스트 설명")
+                .link("https://example.com/books/" + isbn)
+                .build();
+    }
+}

--- a/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
+++ b/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 class ClubMeetingNoticeApiTest extends ApiTestSupport {
 
@@ -58,14 +57,11 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
     @Autowired
     TeamChatMessageRepository teamChatMessageRepository;
 
-    @Autowired
-    JdbcTemplate jdbcTemplate;
-
     @Test
     void clubManagementFlowCoversClubEndpoints() {
         TestUser owner = createUser();
         TestUser member = createUser();
-        Club club = createClub(owner, "club" + owner.id().substring(owner.id().length() - 4).toLowerCase());
+        Club club = createClub(owner, "club" + uniqueSuffix(owner));
 
         given().cookie(accessTokenCookie(owner))
                 .queryParam("clubName", club.getName())
@@ -136,7 +132,7 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
     @Test
     void bookshelfMeetingTopicReviewAndChatFlowCoversRestEndpoints() {
         TestUser owner = createUser();
-        Club club = createClub(owner, "bookshelf" + owner.id().substring(owner.id().length() - 4).toLowerCase());
+        Club club = createClub(owner, "bookshelf" + uniqueSuffix(owner));
         Meeting meeting = createMeeting(owner, club.getId());
         ClubMember ownerClubMember = clubMemberRepository.findByClubIdAndMemberId(club.getId(), owner.id()).orElseThrow();
 
@@ -250,15 +246,18 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
     @Test
     void noticeVoteAndCommentFlowCoversNoticeEndpoints() {
         TestUser owner = createUser();
-        Club club = createClub(owner, "notice" + owner.id().substring(owner.id().length() - 4).toLowerCase());
+        Club club = createClub(owner, "notice" + uniqueSuffix(owner));
 
         given().cookie(accessTokenCookie(owner))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(noticePayload())
                 .when().post("/api/clubs/{clubId}/notices", club.getId())
                 .then().statusCode(200);
-        Notice notice = noticeRepository.findAll().getFirst();
-        Long voteId = jdbcTemplate.queryForObject("select vote_id from notice where id = ?", Long.class, notice.getId());
+        Notice notice = noticeRepository.findTop1ByClubIdOrderByCreatedAtDescIdDesc(club.getId()).orElseThrow();
+        Long voteId = noticeRepository.findWithVoteAndClubMemberVotesByIdAndClubId(notice.getId(), club.getId())
+                .orElseThrow()
+                .getVote()
+                .getId();
 
         given().when().get("/api/clubs/{clubId}/notices/latest", club.getId())
                 .then().statusCode(200);
@@ -319,7 +318,7 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
     void nonMemberCannotAccessMemberOnlyClubResources() {
         TestUser owner = createUser();
         TestUser outsider = createUser();
-        Club club = createClub(owner, "forbidden" + owner.id().substring(owner.id().length() - 4).toLowerCase());
+        Club club = createClub(owner, "forbidden" + uniqueSuffix(owner));
 
         given().cookie(accessTokenCookie(outsider))
                 .when().get("/api/clubs/{clubId}/bookshelves", club.getId())
@@ -340,14 +339,18 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
                 .body(clubDetailPayload(name))
                 .when().post("/api/clubs")
                 .then().statusCode(200);
-        return clubRepository.findAll().getFirst();
+        return clubRepository.findAll().stream()
+                .filter(club -> club.getName().equals(name))
+                .findFirst()
+                .orElseThrow();
     }
 
     private Meeting createMeeting(TestUser owner, Long clubId) {
+        String title = "첫책장-" + uniqueSuffix(owner);
         given().cookie(accessTokenCookie(owner))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(Map.of(
-                        "title", "첫책장",
+                        "title", title,
                         "meetingTime", LocalDateTime.now().plusDays(1).toString(),
                         "location", "온라인",
                         "generation", 1,
@@ -356,7 +359,14 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
                 ))
                 .when().post("/api/clubs/{clubId}/bookshelves", clubId)
                 .then().statusCode(200);
-        return meetingRepository.findAllByClubId(clubId).getFirst();
+        return meetingRepository.findAllByClubId(clubId).stream()
+                .filter(meeting -> meeting.getTitle().equals(title))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private String uniqueSuffix(TestUser user) {
+        return user.id().substring(user.id().length() - 4).toLowerCase();
     }
 
     private Map<String, Object> clubDetailPayload(String name) {

--- a/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
+++ b/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
@@ -1,0 +1,391 @@
+package checkmo.club;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import checkmo.clubManagement.internal.entity.Club;
+import checkmo.clubManagement.internal.entity.ClubMember;
+import checkmo.clubManagement.internal.repository.ClubMemberRepository;
+import checkmo.clubManagement.internal.repository.ClubRepository;
+import checkmo.clubMeeting.internal.entity.BookReview;
+import checkmo.clubMeeting.internal.entity.Meeting;
+import checkmo.clubMeeting.internal.entity.Team;
+import checkmo.clubMeeting.internal.entity.Topic;
+import checkmo.clubMeeting.internal.repository.BookReviewRepository;
+import checkmo.clubMeeting.internal.repository.MeetingRepository;
+import checkmo.clubMeeting.internal.repository.TeamRepository;
+import checkmo.clubMeeting.internal.repository.TopicRepository;
+import checkmo.clubNotice.internal.entity.Notice;
+import checkmo.clubNotice.internal.repository.NoticeCommentRepository;
+import checkmo.clubNotice.internal.repository.NoticeRepository;
+import checkmo.realtime.internal.entity.TeamChatMessage;
+import checkmo.realtime.internal.repository.TeamChatMessageRepository;
+import checkmo.support.ApiTestSupport;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class ClubMeetingNoticeApiTest extends ApiTestSupport {
+
+    @Autowired
+    ClubRepository clubRepository;
+
+    @Autowired
+    ClubMemberRepository clubMemberRepository;
+
+    @Autowired
+    MeetingRepository meetingRepository;
+
+    @Autowired
+    TopicRepository topicRepository;
+
+    @Autowired
+    BookReviewRepository bookReviewRepository;
+
+    @Autowired
+    TeamRepository teamRepository;
+
+    @Autowired
+    NoticeRepository noticeRepository;
+
+    @Autowired
+    NoticeCommentRepository noticeCommentRepository;
+
+    @Autowired
+    TeamChatMessageRepository teamChatMessageRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Test
+    void clubManagementFlowCoversClubEndpoints() {
+        TestUser owner = createUser();
+        TestUser member = createUser();
+        Club club = createClub(owner, "club" + owner.id().substring(owner.id().length() - 4).toLowerCase());
+
+        given().cookie(accessTokenCookie(owner))
+                .queryParam("clubName", club.getName())
+                .when().get("/api/clubs/check-name")
+                .then().statusCode(200).body("result", equalTo(true));
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/search")
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/recommendations")
+                .then().statusCode(200);
+
+        given().when().get("/api/clubs/{clubId}/home", club.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}", club.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(member))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("joinMessage", "함께 읽고 싶습니다."))
+                .when().post("/api/clubs/{clubId}/join", club.getId())
+                .then().statusCode(200);
+
+        ClubMember joinedMember = clubMemberRepository.findByClubIdAndMemberId(club.getId(), member.id()).orElseThrow();
+
+        given().cookie(accessTokenCookie(owner))
+                .queryParam("status", "ACTIVE")
+                .when().get("/api/clubs/{clubId}/members", club.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("command", "CHANGE_ROLE", "status", "STAFF"))
+                .when().patch("/api/clubs/{clubId}/members/{clubMemberId}", club.getId(), joinedMember.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(member))
+                .when().get("/api/clubs/{clubId}/me", club.getId())
+                .then().statusCode(200);
+
+        given().queryParam("memberNickname", member.nickName())
+                .when().get("/api/clubs")
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(member))
+                .when().get("/api/me/clubs")
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(clubDetailPayload(club.getName() + "-edit"))
+                .when().put("/api/clubs/{clubId}", club.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().delete("/api/clubs/{clubId}/leave", club.getId())
+                .then().statusCode(403);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().delete("/api/clubs/{clubId}", club.getId())
+                .then().statusCode(200);
+    }
+
+    @Test
+    void bookshelfMeetingTopicReviewAndChatFlowCoversRestEndpoints() {
+        TestUser owner = createUser();
+        Club club = createClub(owner, "bookshelf" + owner.id().substring(owner.id().length() - 4).toLowerCase());
+        Meeting meeting = createMeeting(owner, club.getId());
+        ClubMember ownerClubMember = clubMemberRepository.findByClubIdAndMemberId(club.getId(), owner.id()).orElseThrow();
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/bookshelves", club.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/bookshelves/{meetingId}", club.getId(), meeting.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/bookshelves/{meetingId}/edit", club.getId(), meeting.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of(
+                        "title", "수정책장",
+                        "meetingTime", LocalDateTime.now().plusDays(2).toString(),
+                        "location", "온라인",
+                        "generation", 2,
+                        "tag", "수정"
+                ))
+                .when().patch("/api/clubs/{clubId}/bookshelves/{meetingId}", club.getId(), meeting.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/meetings/next", club.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/meetings/{meetingId}", club.getId(), meeting.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("description", "첫 번째 발제"))
+                .when().post("/api/clubs/{clubId}/bookshelves/{meetingId}/topics", club.getId(), meeting.getId())
+                .then().statusCode(200);
+        Topic topic = topicRepository.findAllByMeetingIdOrderByIdDesc(meeting.getId()).getFirst();
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/bookshelves/{meetingId}/topics", club.getId(), meeting.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("description", "수정된 발제"))
+                .when().patch("/api/clubs/{clubId}/bookshelves/{meetingId}/topics/{topicId}", club.getId(), meeting.getId(), topic.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("description", "좋았습니다", "rate", 4.5))
+                .when().post("/api/clubs/{clubId}/bookshelves/{meetingId}/reviews", club.getId(), meeting.getId())
+                .then().statusCode(200);
+        BookReview review = bookReviewRepository.findAll().getFirst();
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/bookshelves/{meetingId}/reviews", club.getId(), meeting.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("description", "수정 한줄평", "rate", 5.0))
+                .when().patch("/api/clubs/{clubId}/bookshelves/{meetingId}/reviews/{reviewId}", club.getId(), meeting.getId(), review.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/meetings/{meetingId}/members", club.getId(), meeting.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("teamMemberList", List.of(Map.of("teamNumber", 1, "clubMemberIds", List.of(ownerClubMember.getId())))))
+                .when().put("/api/clubs/{clubId}/meetings/{meetingId}/teams", club.getId(), meeting.getId())
+                .then().statusCode(200);
+        Team team = teamRepository.findAllByMeetingIdOrderByTeamNumberAsc(meeting.getId()).getFirst();
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/meetings/{meetingId}/teams/{teamId}/topics", club.getId(), meeting.getId(), team.getId())
+                .then().statusCode(200);
+
+        teamChatMessageRepository.save(TeamChatMessage.builder()
+                .clubId(club.getId())
+                .meetingId(meeting.getId())
+                .teamId(team.getId())
+                .senderMemberId(owner.id())
+                .content("안녕하세요")
+                .sentAt(LocalDateTime.now())
+                .build());
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/meetings/{meetingId}/teams/{teamId}/chat/messages", club.getId(), meeting.getId(), team.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().delete("/api/clubs/{clubId}/bookshelves/{meetingId}/reviews/{reviewId}", club.getId(), meeting.getId(), review.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().delete("/api/clubs/{clubId}/bookshelves/{meetingId}/topics/{topicId}", club.getId(), meeting.getId(), topic.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().delete("/api/clubs/{clubId}/bookshelves/{meetingId}", club.getId(), meeting.getId())
+                .then().statusCode(200);
+    }
+
+    @Test
+    void noticeVoteAndCommentFlowCoversNoticeEndpoints() {
+        TestUser owner = createUser();
+        Club club = createClub(owner, "notice" + owner.id().substring(owner.id().length() - 4).toLowerCase());
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(noticePayload())
+                .when().post("/api/clubs/{clubId}/notices", club.getId())
+                .then().statusCode(200);
+        Notice notice = noticeRepository.findAll().getFirst();
+        Long voteId = jdbcTemplate.queryForObject("select vote_id from notice where id = ?", Long.class, notice.getId());
+
+        given().when().get("/api/clubs/{clubId}/notices/latest", club.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/notices", club.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/notices/{noticeId}", club.getId(), notice.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("selectedItemNumbers", List.of(1)))
+                .when().post("/api/clubs/{clubId}/notices/{noticeId}/votes/{voteId}", club.getId(), notice.getId(), voteId)
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("content", "댓글"))
+                .when().post("/api/clubs/{clubId}/notices/{noticeId}/comments", club.getId(), notice.getId())
+                .then().statusCode(200);
+        Long commentId = noticeCommentRepository.findAll().getFirst().getId();
+
+        given().cookie(accessTokenCookie(owner))
+                .when().get("/api/clubs/{clubId}/notices/{noticeId}/comments", club.getId(), notice.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("content", "수정댓글"))
+                .when().patch("/api/clubs/{clubId}/notices/{noticeId}/comments/{commentId}", club.getId(), notice.getId(), commentId)
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of(
+                        "title", "수정 공지",
+                        "content", "수정 내용",
+                        "isPinned", false,
+                        "imageUrls", List.of(),
+                        "vote", Map.of("deadline", LocalDateTime.now().plusDays(2).toString())
+                ))
+                .when().patch("/api/clubs/{clubId}/notices/{noticeId}", club.getId(), notice.getId())
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().delete("/api/clubs/{clubId}/notices/{noticeId}/comments/{commentId}", club.getId(), notice.getId(), commentId)
+                .then().statusCode(200);
+
+        given().cookie(accessTokenCookie(owner))
+                .when().delete("/api/clubs/{clubId}/notices/{noticeId}", club.getId(), notice.getId())
+                .then().statusCode(200);
+    }
+
+    @Test
+    void nonMemberCannotAccessMemberOnlyClubResources() {
+        TestUser owner = createUser();
+        TestUser outsider = createUser();
+        Club club = createClub(owner, "forbidden" + owner.id().substring(owner.id().length() - 4).toLowerCase());
+
+        given().cookie(accessTokenCookie(outsider))
+                .when().get("/api/clubs/{clubId}/bookshelves", club.getId())
+                .then().statusCode(404);
+    }
+
+    @Test
+    void authenticatedClubEndpointRequiresCookie() {
+        given().contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(clubDetailPayload("no-auth-club"))
+                .when().post("/api/clubs")
+                .then().statusCode(401);
+    }
+
+    private Club createClub(TestUser owner, String name) {
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(clubDetailPayload(name))
+                .when().post("/api/clubs")
+                .then().statusCode(200);
+        return clubRepository.findAll().getFirst();
+    }
+
+    private Meeting createMeeting(TestUser owner, Long clubId) {
+        given().cookie(accessTokenCookie(owner))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of(
+                        "title", "첫책장",
+                        "meetingTime", LocalDateTime.now().plusDays(1).toString(),
+                        "location", "온라인",
+                        "generation", 1,
+                        "tag", "소설",
+                        "isbn", "9781234567890"
+                ))
+                .when().post("/api/clubs/{clubId}/bookshelves", clubId)
+                .then().statusCode(200);
+        return meetingRepository.findAllByClubId(clubId).getFirst();
+    }
+
+    private Map<String, Object> clubDetailPayload(String name) {
+        return Map.of(
+                "name", name,
+                "description", "테스트 독서 모임",
+                "open", true,
+                "region", "서울",
+                "category", List.of("COMPUTER_IT"),
+                "participantTypes", List.of("ONLINE")
+        );
+    }
+
+    private Map<String, Object> noticePayload() {
+        return Map.of(
+                "title", "공지",
+                "content", "공지 내용",
+                "isPinned", false,
+                "imageUrls", List.of(),
+                "vote", Map.of(
+                        "title", "투표",
+                        "content", "투표 내용",
+                        "item1", "찬성",
+                        "item2", "반대",
+                        "anonymity", false,
+                        "duplication", false,
+                        "startTime", LocalDateTime.now().minusHours(1).toString(),
+                        "deadline", LocalDateTime.now().plusDays(1).toString()
+                )
+        );
+    }
+}

--- a/src/test/java/checkmo/member/MemberApiTest.java
+++ b/src/test/java/checkmo/member/MemberApiTest.java
@@ -185,21 +185,29 @@ class MemberApiTest extends ApiTestSupport {
                 .when()
                 .get("/api/members/{memberNickname}", target.nickName())
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .body("result.nickname", equalTo(target.nickName()))
+                .body("result.following", equalTo(false))
+                .body("result.followerCount", equalTo(0))
+                .body("result.followingCount", equalTo(0));
 
         given()
                 .cookie(accessTokenCookie(me))
                 .when()
                 .get("/api/members/{memberNickname}/followings", target.nickName())
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .body("result.followList.size()", equalTo(0))
+                .body("result.hasNext", equalTo(false));
 
         given()
                 .cookie(accessTokenCookie(me))
                 .when()
                 .get("/api/members/{memberNickname}/followers", target.nickName())
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .body("result.followList.size()", equalTo(0))
+                .body("result.hasNext", equalTo(false));
     }
 
     @Test
@@ -273,14 +281,17 @@ class MemberApiTest extends ApiTestSupport {
                 .when()
                 .get("/api/members/me/recommend")
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .body("result.friends.size()", equalTo(0));
 
         given()
                 .cookie(accessTokenCookie(user))
                 .when()
                 .get("/api/members/me/follow-count")
                 .then()
-                .statusCode(200);
+                .statusCode(200)
+                .body("result.followerCount", equalTo(0))
+                .body("result.followingCount", equalTo(0));
 
         given()
                 .cookie(accessTokenCookie(user))

--- a/src/test/java/checkmo/member/MemberApiTest.java
+++ b/src/test/java/checkmo/member/MemberApiTest.java
@@ -1,0 +1,293 @@
+package checkmo.member;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+import checkmo.support.ApiTestSupport;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+class MemberApiTest extends ApiTestSupport {
+
+    @Test
+    void additionalInfoCompletesIncompleteProfile() {
+        TestUser user = createIncompleteUser();
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(user))
+                .body(Map.of(
+                        "nickname", "complete" + user.id().substring(user.id().length() - 4).toLowerCase(),
+                        "name", "완료",
+                        "phoneNumber", "010-1234-5678",
+                        "description", "소개",
+                        "categories", List.of("COMPUTER_IT")
+                ))
+                .when()
+                .post("/api/members/additional-info")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true));
+    }
+
+    @Test
+    void profileReadAndUpdateSucceedForCompletedUser() {
+        TestUser user = createUser();
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/members/me")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(user))
+                .body(Map.of(
+                        "description", "수정소개",
+                        "phoneNumber", "010-1111-2222",
+                        "categories", List.of("COMPUTER_IT", "ESSAY")
+                ))
+                .when()
+                .patch("/api/members/me")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true));
+    }
+
+    @Test
+    void incompleteProfileCannotReadProtectedProfile() {
+        TestUser user = createIncompleteUser();
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/members/me")
+                .then()
+                .statusCode(403)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void followListAndUnfollowFlowSucceeds() {
+        TestUser me = createUser();
+        TestUser target = createUser();
+
+        given()
+                .cookie(accessTokenCookie(me))
+                .when()
+                .post("/api/members/{memberNickname}/following", target.nickName())
+                .then()
+                .statusCode(200);
+
+        given()
+                .cookie(accessTokenCookie(me))
+                .when()
+                .get("/api/members/me/following")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true));
+
+        given()
+                .cookie(accessTokenCookie(me))
+                .when()
+                .delete("/api/members/{memberNickname}/following", target.nickName())
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void selfFollowIsRejected() {
+        TestUser user = createUser();
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .post("/api/members/{memberNickname}/following", user.nickName())
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void followerDeleteFlowSucceeds() {
+        TestUser me = createUser();
+        TestUser follower = createUser();
+
+        given()
+                .cookie(accessTokenCookie(follower))
+                .when()
+                .post("/api/members/{memberNickname}/following", me.nickName())
+                .then()
+                .statusCode(200);
+
+        given()
+                .cookie(accessTokenCookie(me))
+                .when()
+                .delete("/api/members/{memberNickname}/follower", follower.nickName())
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void blockListAndUnblockFlowSucceeds() {
+        TestUser me = createUser();
+        TestUser target = createUser();
+
+        given()
+                .cookie(accessTokenCookie(me))
+                .when()
+                .post("/api/members/{memberNickname}/block", target.nickName())
+                .then()
+                .statusCode(200);
+
+        given()
+                .cookie(accessTokenCookie(me))
+                .when()
+                .get("/api/members/me/blocks")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true));
+
+        given()
+                .cookie(accessTokenCookie(me))
+                .when()
+                .delete("/api/members/{memberNickname}/block", target.nickName())
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void selfBlockIsRejected() {
+        TestUser user = createUser();
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .post("/api/members/{memberNickname}/block", user.nickName())
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void otherProfileAndFollowListsAreReadable() {
+        TestUser me = createUser();
+        TestUser target = createUser();
+
+        given()
+                .cookie(accessTokenCookie(me))
+                .when()
+                .get("/api/members/{memberNickname}", target.nickName())
+                .then()
+                .statusCode(200);
+
+        given()
+                .cookie(accessTokenCookie(me))
+                .when()
+                .get("/api/members/{memberNickname}/followings", target.nickName())
+                .then()
+                .statusCode(200);
+
+        given()
+                .cookie(accessTokenCookie(me))
+                .when()
+                .get("/api/members/{memberNickname}/followers", target.nickName())
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void updatePasswordSucceedsAndRejectsWrongCurrentPassword() {
+        TestUser user = createUserWithPassword("Pass123!");
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(user))
+                .body(Map.of(
+                        "currentPassword", "Pass123!",
+                        "newPassword", "Next123!",
+                        "confirmPassword", "Next123!"
+                ))
+                .when()
+                .patch("/api/members/me/update-password")
+                .then()
+                .statusCode(200);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(user))
+                .body(Map.of(
+                        "currentPassword", "bad123!",
+                        "newPassword", "Other123!",
+                        "confirmPassword", "Other123!"
+                ))
+                .when()
+                .patch("/api/members/me/update-password")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void updateEmailSucceedsAfterVerification() {
+        TestUser user = createUserWithPassword("Pass123!");
+        String newEmail = "changed-" + user.id().substring(user.id().length() - 4).toLowerCase() + "@example.com";
+        when(redisHashOperations.get("verification:" + newEmail, "code")).thenReturn("123456");
+        when(redisHashOperations.get("verification:" + newEmail, "verified")).thenReturn(false);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(user))
+                .body(Map.of(
+                        "currentEmail", user.email(),
+                        "newEmail", newEmail,
+                        "verificationCode", "123456"
+                ))
+                .when()
+                .patch("/api/members/me/update-email")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true));
+    }
+
+    @Test
+    void loginStatusRecommendationFollowCountAndWithdrawalSucceed() {
+        TestUser user = createUser();
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/members/me/login-status")
+                .then()
+                .statusCode(200)
+                .body("result.provider", equalTo("LOCAL"));
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/members/me/recommend")
+                .then()
+                .statusCode(200);
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/members/me/follow-count")
+                .then()
+                .statusCode(200);
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .cookie(refreshTokenCookie(user))
+                .when()
+                .post("/api/members/withdrawal")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/src/test/java/checkmo/member/PublicMemberApiTest.java
+++ b/src/test/java/checkmo/member/PublicMemberApiTest.java
@@ -24,7 +24,7 @@ class PublicMemberApiTest extends ApiTestSupport {
     }
 
     @Test
-    void checkNicknameRejectsInvalidNickname() {
+    void checkNicknameRejectsHangulNickname() {
         given()
                 .queryParam("nickname", "한글닉네임")
                 .when()

--- a/src/test/java/checkmo/member/PublicMemberApiTest.java
+++ b/src/test/java/checkmo/member/PublicMemberApiTest.java
@@ -1,0 +1,83 @@
+package checkmo.member;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import checkmo.support.ApiTestSupport;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+class PublicMemberApiTest extends ApiTestSupport {
+
+    @Test
+    void checkNicknameReturnsDuplicatedState() {
+        TestUser user = createUser();
+
+        given()
+                .queryParam("nickname", user.nickName())
+                .when()
+                .post("/api/members/check-nickname")
+                .then()
+                .statusCode(200)
+                .body("result", equalTo(true));
+    }
+
+    @Test
+    void checkNicknameRejectsInvalidNickname() {
+        given()
+                .queryParam("nickname", "한글닉네임")
+                .when()
+                .post("/api/members/check-nickname")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void findEmailSucceedsForMatchingNameAndPhoneNumber() {
+        createUser();
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("name", "테스트", "phoneNumber", "01012345678"))
+                .when()
+                .post("/api/members/find-email")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true));
+    }
+
+    @Test
+    void findEmailReturnsNotFoundForUnknownPersonalInfo() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("name", "없음", "phoneNumber", "01000000000"))
+                .when()
+                .post("/api/members/find-email")
+                .then()
+                .statusCode(404)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void findEmailRejectsInvalidPayload() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("name", "", "phoneNumber", ""))
+                .when()
+                .post("/api/members/find-email")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void protectedMemberApiReturnsUnauthorizedWithoutCookie() {
+        given()
+                .when()
+                .get("/api/members/me")
+                .then()
+                .statusCode(401);
+    }
+}

--- a/src/test/java/checkmo/support/ApiTest.java
+++ b/src/test/java/checkmo/support/ApiTest.java
@@ -1,0 +1,22 @@
+package checkmo.support;
+
+import checkmo.CheckmoApplication;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+
+@Tag("integration")
+@Inherited
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ActiveProfiles("test")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest(classes = CheckmoApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public @interface ApiTest {
+}

--- a/src/test/java/checkmo/support/ApiTestInfrastructureTest.java
+++ b/src/test/java/checkmo/support/ApiTestInfrastructureTest.java
@@ -1,0 +1,81 @@
+package checkmo.support;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+
+class ApiTestInfrastructureTest extends ApiTestSupport {
+
+    @Autowired
+    DataSource dataSource;
+
+    @Autowired
+    Environment environment;
+
+    @Test
+    void testProfileUsesH2AndDoesNotIncludeProductionProfiles() throws Exception {
+        assertThat(environment.getActiveProfiles()).contains("test");
+        assertThat(environment.getActiveProfiles())
+                .doesNotContain("prod", "redis", "aladin", "mail", "jwt", "oauth2", "s3");
+        assertThat(environment.getProperty("spring.flyway.enabled")).isEqualTo("false");
+
+        try (var connection = dataSource.getConnection()) {
+            assertThat(connection.getMetaData().getDatabaseProductName()).containsIgnoringCase("H2");
+        }
+    }
+
+    @Test
+    void healthEndpointIsCallableWithRestAssured() {
+        given()
+                .when()
+                .get("/health")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void authenticatedFixtureCanCallProfileCompletedApi() {
+        TestUser user = createUser();
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/members/me/follow-count")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    void anonymousRequestToAuthenticatedApiReturnsUnauthorized() {
+        given()
+                .when()
+                .get("/api/members/me/follow-count")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    void incompleteProfileFixtureIsBlockedBeforeProtectedApiExecution() {
+        TestUser user = createIncompleteUser();
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/members/me/follow-count")
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    void adminFixtureCanIssueJwtCookies() {
+        TestUser admin = createAdmin();
+
+        assertThat(admin.role()).isEqualTo(checkmo.authentication.internal.entity.Role.ADMIN);
+        assertThat(accessTokenCookie(admin).getValue()).isNotBlank();
+        assertThat(refreshTokenCookie(admin).getValue()).isNotBlank();
+    }
+}

--- a/src/test/java/checkmo/support/ApiTestSupport.java
+++ b/src/test/java/checkmo/support/ApiTestSupport.java
@@ -1,0 +1,251 @@
+package checkmo.support;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import checkmo.authentication.internal.entity.AuthUser;
+import checkmo.authentication.internal.entity.Role;
+import checkmo.authentication.internal.repository.AuthRepository;
+import checkmo.authentication.internal.security.jwt.JwtToken;
+import checkmo.authentication.internal.security.jwt.JwtTokenProvider;
+import checkmo.authentication.internal.security.jwt.TokenCacheService;
+import checkmo.book.BookAPI;
+import checkmo.book.BookExternalDTO;
+import checkmo.book.internal.scheduler.BookRecommendationScheduler;
+import checkmo.bookStory.internal.scheduler.BookStoryViewScheduler;
+import checkmo.infra.email.internal.service.EmailSender;
+import checkmo.infra.s3.internal.service.S3Service;
+import checkmo.member.internal.entity.Member;
+import checkmo.member.internal.repository.MemberRepository;
+import checkmo.member.internal.scheduler.MemberCleanupScheduler;
+import io.restassured.RestAssured;
+import io.restassured.http.Cookie;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.client.RestTemplate;
+
+@ApiTest
+public abstract class ApiTestSupport {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    protected AuthRepository authRepository;
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    protected PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    protected TokenCacheService tokenCacheService;
+
+    @MockitoBean
+    protected RestTemplate restTemplate;
+
+    @MockitoBean
+    protected RedisTemplate<String, Object> redisTemplate;
+
+    @MockitoBean
+    protected StringRedisTemplate stringRedisTemplate;
+
+    @MockitoBean
+    protected EmailSender emailSender;
+
+    @MockitoBean
+    protected S3Service s3Service;
+
+    @MockitoBean
+    protected BookAPI bookAPI;
+
+    @MockitoBean
+    protected CacheManager cacheManager;
+
+    @MockitoBean
+    BookRecommendationScheduler bookRecommendationScheduler;
+
+    @MockitoBean
+    BookStoryViewScheduler bookStoryViewScheduler;
+
+    @MockitoBean
+    MemberCleanupScheduler memberCleanupScheduler;
+
+    protected ValueOperations<String, Object> redisValueOperations;
+    protected HashOperations<String, Object, Object> redisHashOperations;
+    protected ValueOperations<String, String> stringRedisValueOperations;
+    private final Map<String, Cache> testCaches = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    void setUpApiTestSupport() {
+        RestAssured.port = port;
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+        redisValueOperations = mock();
+        redisHashOperations = mock();
+        stringRedisValueOperations = mock();
+
+        when(redisTemplate.opsForValue()).thenReturn(redisValueOperations);
+        when(redisTemplate.opsForHash()).thenReturn(redisHashOperations);
+        when(redisTemplate.hasKey(anyString())).thenReturn(false);
+        when(redisTemplate.expire(anyString(), org.mockito.ArgumentMatchers.any(Duration.class))).thenReturn(true);
+        when(stringRedisTemplate.opsForValue()).thenReturn(stringRedisValueOperations);
+        when(stringRedisTemplate.hasKey(anyString())).thenReturn(false);
+        when(cacheManager.getCache(anyString()))
+                .thenAnswer(invocation -> testCaches.computeIfAbsent(
+                        invocation.getArgument(0),
+                        name -> new ConcurrentMapCache(name, false)
+                ));
+        when(bookAPI.fetchOrCreateBook(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(bookAPI.fetchBookBasicInfo(anyString())).thenAnswer(invocation -> {
+            String bookId = invocation.getArgument(0);
+            return BookExternalDTO.BasicInfo.builder()
+                    .bookId(bookId)
+                    .title("테스트 책")
+                    .author("테스트 저자")
+                    .imgUrl("https://example.com/book.png")
+                    .build();
+        });
+        when(bookAPI.fetchBookDetailInfo(anyString())).thenAnswer(invocation -> {
+            String bookId = invocation.getArgument(0);
+            return BookExternalDTO.DetailInfo.builder()
+                    .bookId(bookId)
+                    .title("테스트 책")
+                    .author("테스트 저자")
+                    .imgUrl("https://example.com/book.png")
+                    .publisher("테스트 출판사")
+                    .description("테스트 설명")
+                    .build();
+        });
+        when(bookAPI.fetchBookBasicInfoByBookIds(org.mockito.ArgumentMatchers.anyList())).thenAnswer(invocation -> {
+            List<String> bookIds = invocation.getArgument(0);
+            return bookIds.stream().collect(Collectors.toMap(
+                    bookId -> bookId,
+                    bookId -> BookExternalDTO.BasicInfo.builder()
+                            .bookId(bookId)
+                            .title("테스트 책")
+                            .author("테스트 저자")
+                            .imgUrl("https://example.com/book.png")
+                            .build()
+            ));
+        });
+
+        when(tokenCacheService.isAccessTokenBlacklisted(anyString())).thenReturn(false);
+        when(tokenCacheService.getRefreshToken(anyString())).thenReturn(null);
+        when(tokenCacheService.saveRefreshToken(anyString(), anyString())).thenAnswer(invocation -> invocation.getArgument(1));
+        when(tokenCacheService.saveBlacklistToken(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+        doNothing().when(tokenCacheService).deleteRefreshToken(anyString());
+    }
+
+    @AfterEach
+    void tearDownApiTestSupport() {
+        RestAssured.reset();
+        jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY FALSE");
+        jdbcTemplate.queryForList(
+                        "select table_name from information_schema.tables where lower(table_schema) = 'public'",
+                        String.class
+                )
+                .forEach(tableName -> jdbcTemplate.execute("delete from " + tableName));
+        jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY TRUE");
+    }
+
+    protected TestUser createUser() {
+        return createUser(Role.USER, true);
+    }
+
+    protected TestUser createIncompleteUser() {
+        return createUser(Role.USER, false);
+    }
+
+    protected TestUser createAdmin() {
+        return createUser(Role.ADMIN, true);
+    }
+
+    protected TestUser createUserWithPassword(String rawPassword) {
+        return createUser(Role.USER, true, rawPassword);
+    }
+
+    private TestUser createUser(Role role, boolean profileCompleted) {
+        return createUser(role, profileCompleted, "Pass123!");
+    }
+
+    private TestUser createUser(Role role, boolean profileCompleted, String rawPassword) {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String id = role == Role.USER ? "LOCAL_" + suffix : role.name().toLowerCase() + "-" + suffix;
+        String email = id + "@example.com";
+        String nickName = role.name().toLowerCase() + suffix;
+
+        AuthUser authUser = AuthUser.builder()
+                .id(id)
+                .email(email)
+                .password(passwordEncoder.encode(rawPassword))
+                .role(role)
+                .profileCompleted(profileCompleted)
+                .nickName(nickName)
+                .build();
+        authRepository.save(authUser);
+
+        Member member = Member.builder()
+                .id(id)
+                .email(email)
+                .name("테스트")
+                .phoneNumber("01012345678")
+                .nickName(profileCompleted ? nickName : "")
+                .description("api test fixture")
+                .build();
+        memberRepository.save(member);
+
+        JwtToken token = jwtTokenProvider.generateToken(jwtTokenProvider.getAuthenticationFromMemberId(id));
+        return new TestUser(id, email, nickName, role, profileCompleted, token.getAccessToken(), token.getRefreshToken());
+    }
+
+    protected Cookie accessTokenCookie(TestUser user) {
+        return new Cookie.Builder("accessToken", user.accessToken())
+                .setPath("/")
+                .build();
+    }
+
+    protected Cookie refreshTokenCookie(TestUser user) {
+        return new Cookie.Builder("refreshToken", user.refreshToken())
+                .setPath("/")
+                .build();
+    }
+
+    protected record TestUser(
+            String id,
+            String email,
+            String nickName,
+            Role role,
+            boolean profileCompleted,
+            String accessToken,
+            String refreshToken
+    ) {
+    }
+}

--- a/src/test/java/checkmo/support/ApiTestSupport.java
+++ b/src/test/java/checkmo/support/ApiTestSupport.java
@@ -169,11 +169,20 @@ public abstract class ApiTestSupport {
         RestAssured.reset();
         jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY FALSE");
         jdbcTemplate.queryForList(
-                        "select table_name from information_schema.tables where lower(table_schema) = 'public'",
+                        """
+                                select table_name
+                                from information_schema.tables
+                                where lower(table_schema) = 'public'
+                                  and table_type in ('BASE TABLE', 'TABLE')
+                                """,
                         String.class
                 )
-                .forEach(tableName -> jdbcTemplate.execute("delete from " + tableName));
+                .forEach(tableName -> jdbcTemplate.execute("delete from " + quoteIdentifier(tableName)));
         jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY TRUE");
+    }
+
+    private String quoteIdentifier(String identifier) {
+        return "\"" + identifier.replace("\"", "\"\"") + "\"";
     }
 
     protected TestUser createUser() {

--- a/src/test/java/checkmo/support/SpringTest.java
+++ b/src/test/java/checkmo/support/SpringTest.java
@@ -1,0 +1,22 @@
+package checkmo.support;
+
+import checkmo.CheckmoApplication;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+
+@Tag("integration")
+@Inherited
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ActiveProfiles("test")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest(classes = CheckmoApplication.class, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public @interface SpringTest {
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,108 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:checkmo_test_${random.uuid};MODE=MySQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: false
+
+  flyway:
+    enabled: false
+
+  sql:
+    init:
+      mode: never
+
+  cache:
+    type: simple
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      database: 0
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-google-client-id
+            client-secret: test-google-client-secret
+            scope:
+              - email
+              - profile
+            redirect-uri: "http://localhost/login/oauth2/code/google"
+            authorization-grant-type: authorization_code
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
+
+events:
+  retry:
+    enabled: false
+
+app:
+  oauth2:
+    redirect:
+      base-uri: http://localhost:3000
+
+jwt:
+  secret: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+  token-validity:
+    access-token: 7200000
+    refresh-token: 1209600000
+
+mail:
+  smtp:
+    host: localhost
+    port: 2525
+    timeout: 1000
+    connection-timeout: 1000
+    write-timeout: 1000
+    starttls-enable: false
+  auth:
+    username: test@example.com
+    password: test-password
+    enable: false
+
+aladin:
+  api:
+    url:
+      base: http://localhost
+      item-search: /ItemSearch.aspx
+      item-lookup: /ItemLookUp.aspx
+      item-list: /ItemList.aspx
+    auth:
+      ttb-key: test-ttb-key
+      version: 20131101
+    search:
+      search-query-type: Keyword
+      recommend-query-type: BlogBest
+      search-target: Book
+      output: xml
+      max-results: 10
+      item-id-type: ISBN13
+      timeout-ms: 1000
+
+cloud:
+  aws:
+    region:
+      name: ap-northeast-2
+    credentials:
+      accessKey: test-access-key
+      secretKey: test-secret-key
+    s3:
+      bucket: test-bucket
+      presigned-url-expiration: 10m

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  modulith:
+    events:
+      completion-mode: DELETE
+  profiles:
+    active: test
+
+server:
+  forward-headers-strategy: NATIVE
+
+springdoc:
+  use-fqn: true
+
+realtime:
+  websocket:
+    allowed-origins:
+      - http://localhost:3000


### PR DESCRIPTION
## 🚀 변경사항
- RestAssured + H2 기반 API 통합 테스트 인프라 추가
- 인증/회원/클럽/도서/독서기록/알림/신고/이미지/관리자 API 테스트 추가
- API 테스트 범위, 제외 사유, 커버리지 매트릭스 문서화
- 테스트에서 발견된 검증/인가 응답 처리 보정

## 🔗 관련 이슈
- Closes #212

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
- `./gradlew --no-daemon --no-watch-fs --max-workers=1 test` 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded comprehensive API test coverage for authentication, member profiles, club management, book stories, news, notifications, and admin operations, validating success paths and error scenarios including authentication/authorization failures and input validation.
  * Enhanced test infrastructure with improved setup/teardown for deterministic testing against in-memory database.

* **Bug Fixes**
  * Improved authorization error handling to properly return 403 Forbidden responses for access-denied scenarios.

* **Documentation**
  * Added detailed guides for API test execution, coverage matrix, component exclusion rationale, and per-test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->