### PR TITLE
docs: LazyCodex/OmO 작업 규칙 및 프로젝트 지식 베이스 추가

### DIFF
--- a/.omo/rules/domain-conventions.md
+++ b/.omo/rules/domain-conventions.md
@@ -1,0 +1,57 @@
+# Domain Conventions
+
+## Module List
+
+Primary modules in this repo:
+
+- `authentication`
+- `book`
+- `bookStory`
+- `clubManagement`
+- `clubMeeting`
+- `clubNotice`
+- `common`
+- `infra`
+- `member`
+- `news`
+- `notification`
+- `realtime`
+- `report`
+
+## Module Shape
+
+- Top-level files are public contracts: `*API`, `*ExternalDTO`, `*Event`, module annotations, and `package-info.java`.
+- `internal` contains domain implementation and persistence details.
+- `web` contains HTTP adapters and web DTOs.
+- `common` is declared as an open module and is the shared utility/base surface.
+
+## Naming
+
+- `QueryService` and query facade methods start with `retrieve`.
+- Public API fetch methods start with `fetch`.
+- DTO container classes end with `RequestDTO` or `ResponseDTO`.
+- Nested DTO types do not repeat `Request`, `Response`, `DTO`, or `Dto`.
+- Map-returning method names end with `By<Key>` or `By<Keys>` to describe the key.
+- State-flip methods start with `toggle`.
+
+## Service And Facade Roles
+
+- Services are concrete classes; avoid service interfaces unless the project already has a clear local reason.
+- Services keep entity lookup and business rules.
+- Facades compose services, public APIs, converters, paging, filtering, and DTO assembly.
+- Converters keep DTO/entity mapping out of services.
+
+## Cross-Module Work
+
+- First check the caller's `allowedDependencies`.
+- Prefer an existing public API/event before widening a dependency.
+- If a new public API is needed, expose the smallest stable DTO that avoids leaking internals.
+- If an event is needed, put the event at module top level and make listeners idempotent when retries are possible.
+- Do not return entities, repositories, services, facades, or web DTOs across module boundaries.
+
+## Database
+
+- Flyway migrations live in `src/main/resources/db/migration`.
+- Same-module entity relationships may use JPA object mapping.
+- Cross-module relationships store IDs and compose data through APIs at the application layer.
+- QueryDSL generated classes are generated under the project's Gradle configuration; inspect `build.gradle` before changing generated paths.

--- a/.omo/rules/security.md
+++ b/.omo/rules/security.md
@@ -1,0 +1,32 @@
+# Security Rules
+
+## Secrets
+
+- `.env` exists at the repository root and is gitignored.
+- Do not read, print, summarize, or copy `.env` contents.
+- If a task needs environment context, check only whether the file exists and ask for the specific non-secret value if truly required.
+- Do not expose GitHub Actions secrets, AWS credentials, JWT secrets, OAuth credentials, mail credentials, S3 credentials, Redis passwords, or database passwords in logs or docs.
+
+## Spring Configuration
+
+- New config goes into `src/main/resources/application-<profile>.yml`, then is included deliberately from `application.yml`.
+- Do not add secrets directly to `application.yml` or committed profile files.
+- `spring-dotenv` is part of the current runtime; treat it as an existing project choice, not permission to inspect local secrets.
+
+## Authentication And Authorization
+
+- Authentication uses OAuth2/JWT and `authentication` module internals.
+- Cross-module code should use public authentication contracts or annotations; do not reach into `authentication/internal` from another module.
+- Tests should create JWT/cookies through `ApiTestSupport`, not by hardcoding token internals in each test.
+
+## Infrastructure
+
+- Deployment flows use ECR, EC2, nginx, S3, mail, Redis, and MySQL-related settings.
+- `.github/workflows/release.yml` writes the GitHub secret `ENV_FILE` into `.env` on CI; never mirror that value locally in documentation.
+- `compose-dev.yml` contains local development defaults; do not treat them as production secrets.
+
+## Anti-Patterns
+
+- Do not paste redacted-looking secrets that came from a real file; omit the value entirely.
+- Do not commit generated local config, IDE secrets, or runtime state.
+- Do not add logging of request headers/cookies/tokens outside test failure diagnostics already provided by RestAssured.

--- a/.omo/rules/spring-modulith.md
+++ b/.omo/rules/spring-modulith.md
@@ -1,0 +1,42 @@
+# Spring Modulith Rules
+
+## Boundary Source Of Truth
+
+- Every top-level package under `src/main/java/checkmo` is a Spring Modulith application module.
+- Each module's `package-info.java` declares its `@ApplicationModule` and `allowedDependencies`.
+- `src/test/java/checkmo/CheckmoApplicationTests.java` verifies the module graph with `ApplicationModules.of(CheckmoApplication.class).verify()`.
+
+## Public Surface
+
+- Cross-module synchronous calls go through top-level `*API.java`.
+- Cross-module shared data uses top-level `*ExternalDTO.java`.
+- Cross-module asynchronous side effects use top-level `*Event.java` and Spring events.
+- API implementations live inside the owning module's `internal` package.
+
+## Private Surface
+
+- `internal` is private implementation: service, repository, entity, converter, listener, exception, scheduler, validation, and API implementation code.
+- `web` is private adapter code: controllers and web request/response DTOs.
+- Production code in one module must not import another module's `internal` or `web` package.
+
+## Persistence Coupling
+
+- Same-module JPA relationships are allowed when they fit the domain.
+- Cross-module entity object references are forbidden; store foreign module IDs instead.
+- If read-side composition needs foreign module data, fetch it through the foreign module's public API.
+
+## Events
+
+- Use events when the publishing module should not know which module reacts.
+- Include a stable event/source ID when retry or duplicate delivery is possible.
+- Event listeners that create side effects must be idempotent.
+- Existing docs describe retry behavior in `docs/02_spring_modulith.md`; check that before changing event retry logic.
+
+## Verification
+
+```bash
+./gradlew test --tests checkmo.CheckmoApplicationTests
+./gradlew test
+```
+
+Run the targeted Modulith test after any package move, new dependency, public API change, or event contract change.

--- a/.omo/rules/testing.md
+++ b/.omo/rules/testing.md
@@ -1,0 +1,38 @@
+# Testing Rules
+
+## Default Strategy
+
+- Default verification command is `./gradlew test`.
+- For narrow changes, run the closest targeted test first, then widen only as risk grows.
+- For module-boundary or package dependency changes, run `./gradlew test --tests checkmo.CheckmoApplicationTests`.
+- For API harness or fixture changes, run `./gradlew test --tests checkmo.support.ApiTestInfrastructureTest` before broader API tests.
+
+## Test Surfaces
+
+- REST API tests use `ApiTestSupport`, `@ApiTest`, RestAssured, a random port, and the actual Spring Security/JWT filter chain.
+- Non-HTTP Spring integration tests use `@SpringTest`.
+- `@ApiTest` and `@SpringTest` both carry `@Tag("integration")` and `@ActiveProfiles("test")`.
+- Test profile config is under `src/test/resources`.
+
+## Data And Boundaries
+
+- H2 is the active integration-test database and runs close to MySQL mode.
+- API tests mock Redis, S3, mail, scheduler, and selected external API boundaries through `ApiTestSupport`.
+- `ApiTestSupport` clears H2 tables after each test; add cleanup only when introducing tables outside that path.
+- No active Testcontainers suite exists in this repo; docs mention it only as a future migration-compatibility layer.
+
+## Commands
+
+```bash
+./gradlew test --tests checkmo.CheckmoApplicationTests
+./gradlew test --tests checkmo.support.ApiTestInfrastructureTest
+./gradlew test --tests '*Api*'
+./gradlew test
+```
+
+## Anti-Patterns
+
+- Do not use production profiles or real `.env` secrets in tests.
+- Do not bypass the shared test harness for API tests without a clear reason.
+- Do not remove assertions or weaken fixtures to make a suite green.
+- Do not turn external services into required local dependencies for ordinary API tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,6 @@
 # PROJECT KNOWLEDGE BASE
 
-Generated: 2026-06-10 14:05:27 KST
-Commit: cc0a6df9
-Branch: chore/220/lazycodex
+Initialized for issue #220.
 
 ## OVERVIEW
 
@@ -82,7 +80,6 @@ checkmo/
 
 ## NOTES
 
-- Current local branch for this setup work is `chore/220/lazycodex`.
 - `.env` exists at the repository root and is ignored by git.
 - `.github/workflows/release.yml` deploys on push to `develop` through ECR + SCP/SSH, despite the workflow name mentioning CodeDeploy.
 - CodeDeploy files also exist (`appspec.yml`, `scripts/codedeploy/*`) and use a different deployment directory than the GitHub Actions SSH path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# PROJECT KNOWLEDGE BASE
+
+Generated: 2026-06-10 14:05:27 KST
+Commit: cc0a6df9
+Branch: chore/220/lazycodex
+
+## OVERVIEW
+
+Checkmo is a Java 21 / Spring Boot 3.5.3 backend organized as a Spring Modulith monolith. Domain modules communicate through public APIs, external DTOs, and events; `internal` and `web` packages are module-private surfaces.
+
+## STRUCTURE
+
+```text
+checkmo/
+├── src/main/java/checkmo/      # Spring Modulith modules and application entry points
+├── src/test/java/checkmo/      # H2 + RestAssured integration harness and Modulith verification
+├── src/main/resources/         # profile-composed Spring config and Flyway migrations
+├── docs/                       # architecture, Modulith, conventions, API-test rationale
+├── .omo/rules/                 # LazyCodex project rules
+├── .omx/                       # existing workflow state and previous plans
+├── .claude/                    # Claude-local agent/tool settings
+├── .github/                    # issue/PR templates and develop deployment workflow
+├── compose.yml                 # production app/nginx/certbot stack
+├── compose-dev.yml             # local MySQL/Redis infra
+└── build.gradle                # Java 21, Spring Boot, Modulith, QueryDSL, Flyway, tests
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Modulith boundaries | `src/main/java/checkmo/*/package-info.java` | `@ApplicationModule` and `allowedDependencies` are the source of truth. |
+| Public module surface | `src/main/java/checkmo/<module>/*API.java`, `*ExternalDTO.java`, `*Event.java` | Keep external contracts at module top level. |
+| Internal implementation | `src/main/java/checkmo/<module>/internal` | Do not import from another module's `internal`. |
+| Web adapters | `src/main/java/checkmo/<module>/web` | Controllers and request/response DTOs stay adapter-facing. |
+| Modulith verification | `src/test/java/checkmo/CheckmoApplicationTests.java` | Runs `ApplicationModules.of(...).verify()`. |
+| REST API tests | `src/test/java/checkmo/*/*ApiTest.java` | Extend `ApiTestSupport` unless a narrower test surface is justified. |
+| Test harness | `src/test/java/checkmo/support` | `@ApiTest`, `@SpringTest`, fixtures, cleanup, external mocks. |
+| DB migrations | `src/main/resources/db/migration` | Flyway MySQL migration history. |
+| Environment rules | `docs/environment_setup.md` | `.env` exists locally; do not read or expose its contents. |
+| Architecture docs | `docs/02_spring_modulith.md`, `docs/module_graph.md` | Explain boundary intent and module graph vocabulary. |
+
+## CODE MAP
+
+| Symbol | Type | Location | Role |
+| --- | --- | --- | --- |
+| `CheckmoApplication` | Spring Boot app | `src/main/java/checkmo/CheckmoApplication.java` | Main entry point; enables async, retry, scheduling, JPA auditing. |
+| `HealthCheckController` | Controller | `src/main/java/checkmo/HealthCheckController.java` | `GET /health`, used by compose/deployment health checks. |
+| `ApplicationModules.of(...).verify()` | Test assertion | `src/test/java/checkmo/CheckmoApplicationTests.java` | Enforces Modulith package boundaries. |
+| `ApiTest` | Test meta-annotation | `src/test/java/checkmo/support/ApiTest.java` | Random-port Spring Boot + RestAssured API tests. |
+| `SpringTest` | Test meta-annotation | `src/test/java/checkmo/support/SpringTest.java` | Non-web Spring context tests. |
+| `ApiTestSupport` | Abstract test support | `src/test/java/checkmo/support/ApiTestSupport.java` | JWT fixtures, H2 cleanup, Redis/S3/mail/scheduler mocks. |
+
+## CONVENTIONS
+
+- Read `.omo/rules/*.md` before code work; they are the LazyCodex project rule surface.
+- Keep module changes inside the owning top-level module unless the public API/event contract must change.
+- If cross-module data is needed, add or use a top-level `*API`, `*ExternalDTO`, or `*Event`; do not inject another module's service, repository, facade, entity, or web DTO.
+- Store relationships to another module by ID, not by JPA entity reference.
+- Services are concrete classes, not interfaces. Use `QueryService`/`CommandService` naming already present in the module.
+- Query methods in `QueryService`/facade start with `retrieve`; public API fetch methods start with `fetch`.
+- New Spring config belongs in `application-<profile>.yml` and must be included deliberately from `application.yml`.
+- QueryDSL generated-source wiring is non-standard in `build.gradle`; inspect before changing generated source paths.
+
+## ANTI-PATTERNS
+
+- Do not read, print, commit, or summarize `.env` or secret-bearing files. Existence checks are enough.
+- Do not import `checkmo.<otherModule>.internal.*` or `checkmo.<otherModule>.web.*` from production code.
+- Do not bypass `ApplicationModules.verify()` failures by widening dependencies without checking the domain boundary.
+- Do not add cross-domain JPA object references for convenience.
+- Do not add new dependencies for cleanup or rule work unless the user explicitly asks.
+- Do not revert existing user changes; inspect `git status` first and work around unrelated changes.
+
+## COMMANDS
+
+```bash
+./gradlew test --tests checkmo.CheckmoApplicationTests
+./gradlew test --tests checkmo.support.ApiTestInfrastructureTest
+./gradlew test --tests '*Api*'
+./gradlew test
+```
+
+## NOTES
+
+- Current local branch for this setup work is `chore/220/lazycodex`.
+- `.env` exists at the repository root and is ignored by git.
+- `.github/workflows/release.yml` deploys on push to `develop` through ECR + SCP/SSH, despite the workflow name mentioning CodeDeploy.
+- CodeDeploy files also exist (`appspec.yml`, `scripts/codedeploy/*`) and use a different deployment directory than the GitHub Actions SSH path.
+- `.claude/settings.local.json` only allows `./gradlew:*` for Claude-local Bash permissions.

--- a/src/main/java/checkmo/AGENTS.md
+++ b/src/main/java/checkmo/AGENTS.md
@@ -1,0 +1,71 @@
+# CHECKMO APPLICATION MODULES
+
+## OVERVIEW
+
+This tree is the Spring Modulith application surface. Top-level packages under `checkmo` are application modules; each module's `package-info.java` declares its allowed dependencies.
+
+## STRUCTURE
+
+```text
+checkmo/
+├── authentication/     # auth, OAuth2/JWT, current member resolution
+├── book/               # book lookup, Aladin integration, book social actions
+├── bookStory/          # book story domain
+├── clubManagement/     # clubs and membership
+├── clubMeeting/        # meetings, bookshelf, topics, reviews
+├── clubNotice/         # notices, comments, votes
+├── common/             # open shared base/config/payload/template code
+├── infra/              # email, S3, scheduling infrastructure
+├── member/             # member profile, follow/block lifecycle
+├── news/               # news and carousel domain
+├── notification/       # notification settings and event listeners
+├── realtime/           # websocket/realtime chat and presentation flows
+└── report/             # reporting flows
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Module dependency contract | `<module>/package-info.java` | Update only with a clear boundary reason. |
+| Public synchronous API | `<module>/*API.java` | Methods generally use `fetch...` naming. |
+| Public shared DTO | `<module>/*ExternalDTO.java` | Expose only data needed by other modules. |
+| Public events | `<module>/*Event.java` | Prefer event publication for async cross-module side effects. |
+| Internal API implementation | `<module>/internal/*APIImpl.java` | Implementation stays inside `internal`. |
+| HTTP controllers | `<module>/web/controller` | Adapter layer; may call own module internals. |
+| Request/response DTOs | `<module>/web/dto` | Do not use these as cross-module contracts. |
+
+## MODULE DEPENDENCIES
+
+| Module | Declared dependencies |
+| --- | --- |
+| `authentication` | `common` |
+| `book` | `common`, `authentication`, `member` |
+| `bookStory` | `authentication`, `book`, `clubManagement`, `common`, `member` |
+| `clubManagement` | `authentication`, `book`, `common`, `member` |
+| `clubMeeting` | `authentication`, `book`, `clubManagement`, `common`, `member` |
+| `clubNotice` | `authentication`, `clubManagement`, `clubMeeting`, `common`, `member` |
+| `common` | open module |
+| `infra` | `authentication`, `member`, `clubManagement`, `clubNotice`, `common` |
+| `member` | `authentication`, `common` |
+| `news` | `authentication`, `common`, `member` |
+| `notification` | `authentication`, `bookStory`, `clubManagement`, `clubMeeting`, `clubNotice`, `common`, `member` |
+| `realtime` | `authentication`, `clubManagement`, `clubMeeting`, `common`, `member` |
+| `report` | `authentication`, `member`, `bookStory`, `clubManagement`, `clubNotice`, `clubMeeting`, `realtime`, `common` |
+
+## CONVENTIONS
+
+- Top-level module package contains only public contracts: `*API`, `*ExternalDTO`, `*Event`, annotations, and `package-info.java`.
+- `internal` contains entities, repositories, services, converters, listeners, exceptions, schedulers, validators, and API implementations.
+- `web` contains controllers and web DTOs.
+- Same-module code can use its own `internal`; cross-module production code must use public contracts only.
+- Cross-module persistence references store IDs, not foreign module entity objects.
+- Event listeners use Spring Modulith listener patterns and must be idempotent when events can be retried.
+
+## ANTI-PATTERNS
+
+- Importing another module's `internal` or `web` package from production code.
+- Returning internal entities or web DTOs from public APIs.
+- Adding `allowedDependencies` entries as a shortcut before checking whether an event or existing API fits.
+- Creating JPA `@ManyToOne` or object references to another module's entity.
+- Moving generated QueryDSL classes by hand; generated output is managed by Gradle configuration.

--- a/src/test/java/checkmo/AGENTS.md
+++ b/src/test/java/checkmo/AGENTS.md
@@ -1,0 +1,44 @@
+# CHECKMO TESTS
+
+## OVERVIEW
+
+Tests are integration-heavy and run under the `test` profile. API tests use a real random-port Spring Boot server with RestAssured and H2; Modulith boundaries are verified separately.
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+| --- | --- | --- |
+| Modulith boundary test | `CheckmoApplicationTests.java` | Runs `ApplicationModules.of(CheckmoApplication.class).verify()`. |
+| HTTP API test meta-annotation | `support/ApiTest.java` | `RANDOM_PORT`, `@ActiveProfiles("test")`, `@Tag("integration")`. |
+| Non-web Spring test meta-annotation | `support/SpringTest.java` | `webEnvironment = NONE`, same test profile/tag. |
+| Shared API fixtures | `support/ApiTestSupport.java` | Test users, JWT cookies, H2 cleanup, mocked Redis/S3/mail/schedulers. |
+| API test rationale | `docs/api-test/README.md` | Explains H2, RestAssured, fixture, external boundary strategy. |
+| API coverage plan | `docs/api-test/coverage-matrix.md` | Use when expanding endpoint coverage. |
+
+## CONVENTIONS
+
+- Use `ApiTestSupport` for REST API tests that need the actual filter chain, JWT cookies, or HTTP status/body assertions.
+- Use `@SpringTest` for non-HTTP Spring integration tests.
+- Keep API test names with the `*ApiTest` suffix.
+- Prefer behavior-specific test method names over generic numbered names.
+- Mock external boundaries through the shared support layer when the boundary is common across API tests.
+- Tests run with `src/test/resources/application.yml` activating only the `test` profile.
+- Current API-test DB strategy is H2 with Hibernate schema creation; Flyway/MySQL migration compatibility is a separate future layer, not active Testcontainers coverage.
+
+## COMMANDS
+
+```bash
+./gradlew test --tests checkmo.CheckmoApplicationTests
+./gradlew test --tests checkmo.support.ApiTestInfrastructureTest
+./gradlew test --tests 'checkmo.<package>.<ClassName>'
+./gradlew test --tests '*Api*'
+./gradlew test
+```
+
+## ANTI-PATTERNS
+
+- Do not read `.env` to make tests pass.
+- Do not activate production profiles (`prod`, `redis`, `aladin`, `mail`, `jwt`, `oauth2`, `s3`) from tests.
+- Do not weaken or remove `ApplicationModules.verify()` when a module boundary fails.
+- Do not add network, Redis, S3, mail, or scheduler dependencies to API tests unless the test explicitly owns that boundary.
+- Do not leave persistent test data; rely on `ApiTestSupport` cleanup or add local cleanup for new tables.


### PR DESCRIPTION
## 작업 내용

- LazyCodex/OmO가 checkmo 프로젝트 구조를 빠르게 파악할 수 있도록 루트 `AGENTS.md`를 추가했습니다.
- Spring Modulith 애플리케이션 모듈 영역과 테스트 영역에 하위 `AGENTS.md`를 추가했습니다.
- `.omo/rules/`에 checkmo 전용 규칙 문서를 추가했습니다.
  - `spring-modulith.md`
  - `testing.md`
  - `security.md`
  - `domain-conventions.md`

## 적용 기준

- #220 기준으로 기능 구현 없이 프로젝트 지식 베이스와 에이전트 작업 규칙만 구성했습니다.
- 모듈별 `AGENTS.md`는 과도한 중복을 피하기 위해 생성하지 않았고, `src/main/java/checkmo/AGENTS.md`에서 각 모듈의 `package-info.java`와 `allowedDependencies`를 기준으로 보도록 정리했습니다.
- `.env`는 존재 여부만 확인했고 내용을 읽거나 문서화하지 않았습니다.

## 검증

- `git diff --check`
- `./gradlew test --tests checkmo.CheckmoApplicationTests`
- `./gradlew test`
- 생성 문서 검토 에이전트: `UNCONDITIONAL APPROVAL`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive development guidelines covering domain conventions, security practices, Spring Modulith architecture, and testing standards.
  * Added project knowledge base documenting repository structure, module boundaries, coding conventions, and test execution guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->