### PR TITLE
feat: 운영 Sentry smoke endpoint 임시 추가

### DIFF
--- a/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
+++ b/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**", "/api/members/check-nickname").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/clubs", "/api/clubs/*/home", "/api/clubs/search").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/clubs/*/notices/latest").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/internal/monitoring/sentry-smoke/9f3c2b8e7a6d4c11").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(exception -> exception

--- a/src/main/java/checkmo/common/monitoring/SentrySmokeController.java
+++ b/src/main/java/checkmo/common/monitoring/SentrySmokeController.java
@@ -1,0 +1,13 @@
+package checkmo.common.monitoring;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SentrySmokeController {
+
+    @PostMapping("/internal/monitoring/sentry-smoke/9f3c2b8e7a6d4c11")
+    public void smoke() {
+        throw new IllegalStateException("Sentry smoke test");
+    }
+}

--- a/src/test/java/checkmo/common/apiPayload/exception/SentryExceptionAdviceApiTest.java
+++ b/src/test/java/checkmo/common/apiPayload/exception/SentryExceptionAdviceApiTest.java
@@ -53,4 +53,65 @@ class SentryExceptionAdviceApiTest extends ApiTestSupport {
                 .then()
                 .statusCode(200);
     }
+
+    @Test
+    void temporarySmokeEndpointCapturesControlledServerError() {
+        String before = given()
+                .when()
+                .get("/api/test/sentry/captures/count")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        String body = given()
+                .when()
+                .post("/internal/monitoring/sentry-smoke/9f3c2b8e7a6d4c11")
+                .then()
+                .statusCode(500)
+                .extract()
+                .asString();
+
+        String after = given()
+                .when()
+                .get("/api/test/sentry/captures/count")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        assertThat(body)
+                .contains("\"isSuccess\":false")
+                .contains("\"code\":\"COMMON_500\"")
+                .contains("\"message\":\"서버 에러, 관리자에게 문의 바랍니다.\"")
+                .doesNotContain("Sentry smoke test");
+        assertThat(Integer.parseInt(after)).isEqualTo(Integer.parseInt(before) + 1);
+    }
+
+    @Test
+    void nonMatchingSmokeEndpointPathDoesNotCaptureServerError() {
+        String before = given()
+                .when()
+                .get("/api/test/sentry/captures/count")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        given()
+                .when()
+                .post("/internal/monitoring/sentry-smoke/wrong")
+                .then()
+                .statusCode(401);
+
+        String after = given()
+                .when()
+                .get("/api/test/sentry/captures/count")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        assertThat(Integer.parseInt(after)).isEqualTo(Integer.parseInt(before));
+    }
 }


### PR DESCRIPTION
## 요약

- 운영 Sentry ingestion 확인용 임시 POST endpoint 추가
- exact random path만 Spring Security에서 permit 처리
- 호출 시 `IllegalStateException("Sentry smoke test")`를 발생시켜 기존 500/Sentry capture 경로를 검증

Closes #224

## 임시 endpoint

```bash
curl -i -X POST "https://<PROD_BASE_URL>/internal/monitoring/sentry-smoke/9f3c2b8e7a6d4c11"
```

검증 후 즉시 제거 PR을 올려야 합니다.

## 검증

- RED: `./gradlew test --tests checkmo.common.apiPayload.exception.SentryExceptionAdviceApiTest` 실패 확인
- GREEN: `./gradlew test --tests checkmo.common.apiPayload.exception.SentryExceptionAdviceApiTest`
- Modulith: `./gradlew test --tests checkmo.CheckmoApplicationTests`
- 전체: `./gradlew test`
- Manual HTTP QA:
  - `curl -i -X POST http://localhost:18080/internal/monitoring/sentry-smoke/9f3c2b8e7a6d4c11` → `500 COMMON_500`
  - `curl -i -X POST http://localhost:18080/internal/monitoring/sentry-smoke/wrong` → `401 UNAUTHORIZED`

## 운영 확인 필터

Sentry Issues에서 아래로 확인합니다.

- environment: `prod`
- exception type: `IllegalStateException`
- message: `Sentry smoke test`
- release: 배포 커밋 기반 `checkmo-backend@<sha>`

## 주의

이 PR은 임시 검증용입니다. 운영 Sentry 수신 확인 직후 `SentrySmokeController`와 `SecurityConfig`의 exact permit matcher를 제거해야 합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal monitoring endpoint for error tracking verification.

* **Tests**
  * Added test coverage for monitoring endpoint authentication and error response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->