### PR TITLE
fix: Sentry smoke nginx route 임시 허용

### DIFF
--- a/nginx/conf.d/websites/api.checkmo.co.kr.conf
+++ b/nginx/conf.d/websites/api.checkmo.co.kr.conf
@@ -97,6 +97,12 @@ server {
         include /etc/nginx/conf.d/snippets/proxy-settings.conf;
     }
 
+    # Sentry 운영 수신 확인용 임시 경로
+    location = /internal/monitoring/sentry-smoke/9f3c2b8e7a6d4c11 {
+        proxy_pass http://backend;
+        include /etc/nginx/conf.d/snippets/proxy-settings.conf;
+    }
+
     # 특정 파일 확장자 직접 차단
     location ~* \.(php|asp|aspx|jsp)$ {
         return 444;


### PR DESCRIPTION
## 요약

- 운영 nginx가 `/internal/**`를 catch-all `444`로 닫고 있어 #225 smoke endpoint에 외부 요청이 도달하지 못함
- exact path `/internal/monitoring/sentry-smoke/9f3c2b8e7a6d4c11` 하나만 backend로 proxy
- 검증 완료 후 endpoint 제거 PR에서 이 location도 함께 제거 예정

Closes #226

## 확인

- #225 배포 후 `/health`는 200, smoke path는 `curl: (52) Empty reply from server`
- nginx 설정상 `/internal/**`는 별도 location이 없어 catch-all `location / { return 444; }`로 처리됨
- exact location을 catch-all보다 앞에 배치

## 검증

- `git diff --check`
- diff에서 exact location이 catch-all보다 앞에 있는 것 확인

## 미검증

- 로컬에 `nginx` binary가 없어 `nginx -t`는 실행하지 못함
