### PR TITLE
fix: 배포 env에 Sentry secrets 반영

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,11 @@ jobs:
       - name: Create .env file
         run: |
           printf '%s\n' "${{ secrets.ENV_FILE }}" > .env
-          awk '!/^SENTRY_RELEASE=/' .env > .env.tmp
+          awk '!/^(SENTRY_ENABLED|SENTRY_DSN|SENTRY_ENVIRONMENT|SENTRY_RELEASE)=/' .env > .env.tmp
           mv .env.tmp .env
+          printf 'SENTRY_ENABLED=%s\n' "${{ secrets.SENTRY_ENABLED }}" >> .env
+          printf 'SENTRY_DSN=%s\n' "${{ secrets.SENTRY_DSN }}" >> .env
+          printf 'SENTRY_ENVIRONMENT=%s\n' "${{ secrets.SENTRY_ENVIRONMENT }}" >> .env
           printf 'SENTRY_RELEASE=checkmo-backend@%s\n' "${GITHUB_SHA}" >> .env
 
       # 5. 설정 파일 전송 (SCP)


### PR DESCRIPTION
## 요약

- `release.yml`의 `.env` 생성 단계에서 개별 Sentry GitHub Secrets를 append하도록 수정
- 기존 `ENV_FILE`에 같은 키가 있어도 중복되지 않도록 `SENTRY_ENABLED`, `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_RELEASE` 라인을 제거한 뒤 다시 기록
- secret 값은 로그/본문에 노출하지 않음

Closes #229

## 배경

운영 smoke endpoint는 `500 COMMON_500`을 반환했지만 Sentry 이슈가 생성되지 않았다.
운영 서버 `/home/ubuntu/app/.env`에서 `SENTRY_*` key가 확인되지 않았고, 기존 workflow는 `secrets.ENV_FILE`과 `SENTRY_RELEASE`만 `.env`에 기록하고 있었다.

## 검증

- `git diff --check`
- workflow text check: `SENTRY_ENABLED`, `SENTRY_DSN`, `SENTRY_ENVIRONMENT` secret references present

## 배포 후 확인

운영 서버에서 값 노출 없이 key 존재 여부만 확인한다.

```bash
grep -E '^SENTRY_ENABLED=|^SENTRY_DSN=|^SENTRY_ENVIRONMENT=' /home/ubuntu/app/.env | sed 's/=.*/=<set>/'
```

그 다음 smoke endpoint를 1회 재호출해서 Sentry 수신을 확인한다.
