### PR TITLE
ci: 백엔드 Sentry release deploy 자동화

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Create .env file
         run: |
           printf '%s\n' "${{ secrets.ENV_FILE }}" > .env
-          awk '!/^(SENTRY_ENABLED|SENTRY_DSN|SENTRY_ENVIRONMENT|SENTRY_RELEASE)=/' .env > .env.tmp
+          awk '!/^(SENTRY_ENABLED|SENTRY_DSN|SENTRY_ENVIRONMENT|SENTRY_RELEASE|SENTRY_AUTH_TOKEN)=/' .env > .env.tmp
           mv .env.tmp .env
           printf 'SENTRY_ENABLED=%s\n' "${{ secrets.SENTRY_ENABLED }}" >> .env
           printf 'SENTRY_DSN=%s\n' "${{ secrets.SENTRY_DSN }}" >> .env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,13 @@ jobs:
     steps:
       # 1. 코드 체크아웃
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       # 2. AWS 자격 증명 설정
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -26,7 +26,7 @@ jobs:
       # 3. ECR 로그인
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419
 
       # 4. Docker 이미지 빌드 및 ECR 푸시 (여기서 빌드가 일어납니다)
       - name: Build and push Docker image
@@ -50,7 +50,7 @@ jobs:
 
       # 5. 설정 파일 전송 (SCP)
       - name: Copy files to EC2
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@a6e43c3aaf4e8e6b0b15bf34e19d71118f6b1ca7
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
@@ -60,7 +60,7 @@ jobs:
 
       # 6. EC2 접속 및 배포 실행 (SSH)
       - name: Deploy to EC2
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@1530429296e979861824d74fb800013190b5dee0
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
@@ -84,7 +84,7 @@ jobs:
             docker image prune -f
 
       - name: Create Sentry release
-        uses: getsentry/action-release@v3
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: checkmo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
       # 1. 코드 체크아웃
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # 2. AWS 자격 증명 설정
       - name: Configure AWS credentials
@@ -80,3 +82,13 @@ jobs:
 
             # 미사용 이미지 정리
             docker image prune -f
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@v3
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: checkmo
+          SENTRY_PROJECT: checkmo-spring-boot
+        with:
+          environment: prod
+          release: checkmo-backend@${{ github.sha }}

--- a/docs/sentry_backend_monitoring.md
+++ b/docs/sentry_backend_monitoring.md
@@ -68,6 +68,8 @@ The release name in Sentry must match the runtime SDK release value:
 checkmo-backend@<github sha>
 ```
 
+The deployment workflow pins every third-party GitHub Action to a full commit SHA. When updating an action version, first resolve the intended upstream tag or branch to its current commit SHA, update the `uses:` line to that SHA, then rerun `SentryReleaseWorkflowTest`. Do not switch new or existing workflow actions back to mutable tags such as `@v3` or branches such as `@master`.
+
 ## Privacy Rules
 
 The backend must not send these values to Sentry:

--- a/docs/sentry_backend_monitoring.md
+++ b/docs/sentry_backend_monitoring.md
@@ -38,6 +38,36 @@ The application binds these values through `checkmo.sentry.*` properties and ini
 
 In the current deployment flow, `.github/workflows/release.yml` creates `.env` from `secrets.ENV_FILE`, removes any stale `SENTRY_RELEASE`, appends `SENTRY_RELEASE=checkmo-backend@${GITHUB_SHA}`, and copies it to EC2 with `compose.yml`. Operators must update the GitHub `ENV_FILE` secret with `SENTRY_ENABLED`, `SENTRY_DSN`, and `SENTRY_ENVIRONMENT`; `SENTRY_RELEASE` is deployment-generated and should not be maintained manually in the secret. Do not edit, print, or commit the local `.env` file.
 
+## Release and Deploy Tracking
+
+Issue #232 adds CI-side Sentry release/deploy automation for the backend project. The GitHub Actions workflow creates a Sentry release named `checkmo-backend@<github sha>` after the EC2 deployment succeeds, then records a `prod` deploy for that release.
+
+This automation uses `getsentry/action-release@v3` and requires this GitHub Actions secret:
+
+```text
+SENTRY_AUTH_TOKEN=<Sentry Internal Integration token>
+```
+
+`SENTRY_AUTH_TOKEN` is different from `SENTRY_DSN`:
+- `SENTRY_DSN` is used by the running Spring Boot app to send events.
+- `SENTRY_AUTH_TOKEN` is used only by GitHub Actions to create releases and deploy records through the Sentry API.
+- Sentry `Client Secret` is not the CI auth token.
+
+Do not add `SENTRY_AUTH_TOKEN` to `.env`, `ENV_FILE`, `compose.yml`, Spring configuration, or application runtime environment. Store it only as a GitHub Actions repository secret. The current token was created from a Sentry Internal Integration with release/CI-oriented scopes (`org:ci`, `org:read`, `project:read`, `project:releases`).
+
+The Sentry organization and project slugs are non-secret workflow constants:
+
+```text
+SENTRY_ORG=checkmo
+SENTRY_PROJECT=checkmo-spring-boot
+```
+
+The release name in Sentry must match the runtime SDK release value:
+
+```text
+checkmo-backend@<github sha>
+```
+
 ## Privacy Rules
 
 The backend must not send these values to Sentry:
@@ -96,8 +126,10 @@ Proceed only after non-prod verification passes.
 
 2. Deploy during a low-risk window. The workflow appends `SENTRY_RELEASE=checkmo-backend@<github sha>` automatically.
 3. Watch `/health`, application logs, and Sentry issue volume.
-4. Confirm expected 400/401/403 traffic does not create issue noise.
-5. Confirm unexpected 500 events are grouped and actionable.
+4. Confirm the GitHub Actions Sentry release step succeeds after the EC2 deploy step.
+5. In Sentry, open the `checkmo-spring-boot` project and confirm release `checkmo-backend@<github sha>` appears with a `prod` deploy.
+6. Confirm expected 400/401/403 traffic does not create issue noise.
+7. Confirm unexpected 500 events are grouped and actionable.
 
 ## Rollback
 
@@ -118,3 +150,8 @@ Sentry can be disabled without code changes.
 
 3. Confirm `/health` is still healthy.
 4. If the code itself must be reverted, revert the commits for issue #222 and redeploy.
+
+Release/deploy automation can be rolled back independently of runtime event sending:
+- Revert the workflow change that adds `getsentry/action-release@v3`.
+- Remove or rotate GitHub `SENTRY_AUTH_TOKEN`.
+- Revoke the Sentry Internal Integration token if it is no longer needed.

--- a/src/test/java/checkmo/common/config/SentryReleaseWorkflowTest.java
+++ b/src/test/java/checkmo/common/config/SentryReleaseWorkflowTest.java
@@ -56,4 +56,13 @@ class SentryReleaseWorkflowTest {
         assertThat(workflow).doesNotContain("Client Secret");
         assertThat(workflow).doesNotContain("SENTRY_AUTH_TOKEN=");
     }
+
+    @Test
+    void releaseWorkflowStripsCiOnlySentryAuthTokenFromRuntimeEnvFile() throws IOException {
+        String workflow = Files.readString(RELEASE_WORKFLOW);
+
+        assertThat(workflow)
+                .contains("SENTRY_ENABLED|SENTRY_DSN|SENTRY_ENVIRONMENT|SENTRY_RELEASE|SENTRY_AUTH_TOKEN");
+        assertThat(workflow).doesNotContain("printf 'SENTRY_AUTH_TOKEN=");
+    }
 }

--- a/src/test/java/checkmo/common/config/SentryReleaseWorkflowTest.java
+++ b/src/test/java/checkmo/common/config/SentryReleaseWorkflowTest.java
@@ -5,27 +5,47 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 class SentryReleaseWorkflowTest {
 
     private static final Path RELEASE_WORKFLOW = Path.of(".github/workflows/release.yml");
+    private static final Pattern PINNED_GITHUB_ACTION = Pattern.compile(
+            "^\\s*uses: [\\w.-]+/[\\w.-]+@[0-9a-f]{40}(?:\\s+# .*)?$",
+            Pattern.MULTILINE
+    );
 
     @Test
     void releaseWorkflowPublishesBackendReleaseAfterSuccessfulEc2Deploy() throws IOException {
         String workflow = Files.readString(RELEASE_WORKFLOW);
 
-        assertThat(workflow).contains("uses: actions/checkout@v4");
+        assertThat(workflow).contains("uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5");
         assertThat(workflow).contains("fetch-depth: 0");
         assertThat(workflow).contains("SENTRY_RELEASE=checkmo-backend@%s");
-        assertThat(workflow).contains("uses: getsentry/action-release@v3");
+        assertThat(workflow).contains("uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528");
         assertThat(workflow).contains("SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}");
         assertThat(workflow).contains("SENTRY_ORG: checkmo");
         assertThat(workflow).contains("SENTRY_PROJECT: checkmo-spring-boot");
         assertThat(workflow).contains("environment: prod");
         assertThat(workflow).contains("release: checkmo-backend@${{ github.sha }}");
-        assertThat(workflow.indexOf("name: Deploy to EC2"))
-                .isLessThan(workflow.indexOf("uses: getsentry/action-release@v3"));
+
+        int deployIndex = workflow.indexOf("- name: Deploy to EC2");
+        int sentryIndex = workflow.indexOf("uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528");
+
+        assertThat(deployIndex).isGreaterThanOrEqualTo(0);
+        assertThat(sentryIndex).isGreaterThanOrEqualTo(0);
+        assertThat(deployIndex).isLessThan(sentryIndex);
+    }
+
+    @Test
+    void releaseWorkflowPinsAllGithubActionsToFullCommitSha() throws IOException {
+        String workflow = Files.readString(RELEASE_WORKFLOW);
+
+        assertThat(workflow.lines()
+                .filter(line -> line.trim().startsWith("uses: "))
+                .toList())
+                .allSatisfy(line -> assertThat(line).matches(PINNED_GITHUB_ACTION));
     }
 
     @Test

--- a/src/test/java/checkmo/common/config/SentryReleaseWorkflowTest.java
+++ b/src/test/java/checkmo/common/config/SentryReleaseWorkflowTest.java
@@ -1,0 +1,39 @@
+package checkmo.common.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class SentryReleaseWorkflowTest {
+
+    private static final Path RELEASE_WORKFLOW = Path.of(".github/workflows/release.yml");
+
+    @Test
+    void releaseWorkflowPublishesBackendReleaseAfterSuccessfulEc2Deploy() throws IOException {
+        String workflow = Files.readString(RELEASE_WORKFLOW);
+
+        assertThat(workflow).contains("uses: actions/checkout@v4");
+        assertThat(workflow).contains("fetch-depth: 0");
+        assertThat(workflow).contains("SENTRY_RELEASE=checkmo-backend@%s");
+        assertThat(workflow).contains("uses: getsentry/action-release@v3");
+        assertThat(workflow).contains("SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}");
+        assertThat(workflow).contains("SENTRY_ORG: checkmo");
+        assertThat(workflow).contains("SENTRY_PROJECT: checkmo-spring-boot");
+        assertThat(workflow).contains("environment: prod");
+        assertThat(workflow).contains("release: checkmo-backend@${{ github.sha }}");
+        assertThat(workflow.indexOf("name: Deploy to EC2"))
+                .isLessThan(workflow.indexOf("uses: getsentry/action-release@v3"));
+    }
+
+    @Test
+    void releaseWorkflowDoesNotContainRawSentryCredentials() throws IOException {
+        String workflow = Files.readString(RELEASE_WORKFLOW);
+
+        assertThat(workflow).doesNotContain("sntrys_");
+        assertThat(workflow).doesNotContain("Client Secret");
+        assertThat(workflow).doesNotContain("SENTRY_AUTH_TOKEN=");
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #232
- Adds backend Sentry release/deploy automation to the `develop` deployment workflow.
- Keeps the app runtime release name aligned with Sentry release name: `checkmo-backend@<github sha>`.
- Documents `SENTRY_AUTH_TOKEN` usage and rollback boundaries.

## Scope
- `getsentry/action-release@v3` runs after the EC2 deploy step succeeds.
- `actions/checkout@v4` now uses `fetch-depth: 0`.
- `SENTRY_AUTH_TOKEN` is referenced only as a GitHub Actions secret.
- Cron Monitor, tracing/Apdex, source context upload, and error capture policy changes are intentionally excluded.

## Verification
- `./gradlew test --tests checkmo.common.config.SentryReleaseWorkflowTest --rerun-tasks`
- `./gradlew test --tests checkmo.common.config.SentryConfigurationTest`
- `git diff --check`
- Secret scan over workflow/docs/test files found no raw Sentry token or DSN values.

## Post-merge verification
- Confirm the `Create Sentry release` step succeeds in GitHub Actions.
- Confirm Sentry project `checkmo-spring-boot` shows release `checkmo-backend@<deployed sha>`.
- Confirm the release has a `prod` deploy.
- Confirm CI logs do not expose DSN, auth token, or `.env` contents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now creates Sentry releases and records prod deploys for backend deployments.

* **Documentation**
  * Added guidance for CI-side Sentry release/deploy tracking, rollout/rollback checks, token usage, and verification steps to reduce noisy/error-prone deployments.

* **Tests**
  * Added workflow validation tests to ensure release steps, secure token usage, action pinning, and full repo fetch settings remain correctly configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->