### PR TITLE
feat: 백엔드 Sentry tracing 최소 도입

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,14 @@ jobs:
       - name: Create .env file
         run: |
           printf '%s\n' "${{ secrets.ENV_FILE }}" > .env
-          awk '!/^(SENTRY_ENABLED|SENTRY_DSN|SENTRY_ENVIRONMENT|SENTRY_RELEASE|SENTRY_AUTH_TOKEN)=/' .env > .env.tmp
+          awk '!/^(SENTRY_ENABLED|SENTRY_DSN|SENTRY_ENVIRONMENT|SENTRY_RELEASE|SENTRY_AUTH_TOKEN|SENTRY_TRACES_SAMPLE_RATE)=/' .env > .env.tmp
           mv .env.tmp .env
           printf 'SENTRY_ENABLED=%s\n' "${{ secrets.SENTRY_ENABLED }}" >> .env
           printf 'SENTRY_DSN=%s\n' "${{ secrets.SENTRY_DSN }}" >> .env
           printf 'SENTRY_ENVIRONMENT=%s\n' "${{ secrets.SENTRY_ENVIRONMENT }}" >> .env
           printf 'SENTRY_RELEASE=checkmo-backend@%s\n' "${GITHUB_SHA}" >> .env
+          SENTRY_TRACES_SAMPLE_RATE="${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}"
+          printf 'SENTRY_TRACES_SAMPLE_RATE=%s\n' "${SENTRY_TRACES_SAMPLE_RATE:-0.0}" >> .env
 
       # 5. 설정 파일 전송 (SCP)
       - name: Copy files to EC2

--- a/docs/sentry_backend_monitoring.md
+++ b/docs/sentry_backend_monitoring.md
@@ -8,7 +8,6 @@ Branch: `feat/222/sentry-monitoring`
 This rollout enables first-phase Sentry monitoring for the Spring Boot backend only. It is limited to unexpected 500-class exceptions handled by `ExceptionAdvice`.
 
 Not included in this issue:
-- tracing or performance monitoring
 - Logback/Sentry log shipping
 - async profiler
 - realtime/websocket capture
@@ -24,6 +23,7 @@ SENTRY_ENABLED=true|false
 SENTRY_DSN=<non-prod or prod DSN>
 SENTRY_ENVIRONMENT=staging|prod
 SENTRY_RELEASE=checkmo-backend@<deployed git sha>
+SENTRY_TRACES_SAMPLE_RATE=0.0|0.1
 ```
 
 Default behavior is safe for local and test runs:
@@ -31,18 +31,18 @@ Default behavior is safe for local and test runs:
 - blank `SENTRY_DSN`
 - no request body capture
 - no default PII
-- no tracing sample rate configured
+- tracing sample rate `0.0`
 - Sentry logs disabled
 
-The application binds these values through `checkmo.sentry.*` properties and initializes the Sentry SDK only when `SENTRY_ENABLED=true` and `SENTRY_DSN` is not blank. The committed config intentionally does not set `sentry.dsn` and excludes every Sentry 8.43.1 Spring Boot auto-configuration import, so the starter cannot initialize independently of the kill switch.
+The application binds these values through `checkmo.sentry.*` properties. Runtime event capture is enabled only when `SENTRY_ENABLED=true` and `SENTRY_DSN` is not blank. Sentry Spring Boot auto-configuration is allowed for core Spring Web tracing, while profiler, Logback appender, and WebFlux auto-configurations stay excluded.
 
-In the current deployment flow, `.github/workflows/release.yml` creates `.env` from `secrets.ENV_FILE`, removes any stale `SENTRY_RELEASE`, appends `SENTRY_RELEASE=checkmo-backend@${GITHUB_SHA}`, and copies it to EC2 with `compose.yml`. Operators must update the GitHub `ENV_FILE` secret with `SENTRY_ENABLED`, `SENTRY_DSN`, and `SENTRY_ENVIRONMENT`; `SENTRY_RELEASE` is deployment-generated and should not be maintained manually in the secret. Do not edit, print, or commit the local `.env` file.
+In the current deployment flow, `.github/workflows/release.yml` creates `.env` from `secrets.ENV_FILE`, removes stale Sentry runtime values, appends the current GitHub Secrets plus `SENTRY_RELEASE=checkmo-backend@${GITHUB_SHA}`, and copies it to EC2 with `compose.yml`. Operators must maintain GitHub repository secrets for `SENTRY_ENABLED`, `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, and `SENTRY_TRACES_SAMPLE_RATE`; `SENTRY_RELEASE` is deployment-generated and should not be maintained manually in the secret. Do not edit, print, or commit the local `.env` file.
 
 ## Release and Deploy Tracking
 
 Issue #232 adds CI-side Sentry release/deploy automation for the backend project. The GitHub Actions workflow creates a Sentry release named `checkmo-backend@<github sha>` after the EC2 deployment succeeds, then records a `prod` deploy for that release.
 
-This automation uses `getsentry/action-release@v3` and requires this GitHub Actions secret:
+This automation uses `getsentry/action-release` pinned to a full commit SHA and requires this GitHub Actions secret:
 
 ```text
 SENTRY_AUTH_TOKEN=<Sentry Internal Integration token>
@@ -69,6 +69,38 @@ checkmo-backend@<github sha>
 ```
 
 The deployment workflow pins every third-party GitHub Action to a full commit SHA. When updating an action version, first resolve the intended upstream tag or branch to its current commit SHA, update the `uses:` line to that SHA, then rerun `SentryReleaseWorkflowTest`. Do not switch new or existing workflow actions back to mutable tags such as `@v3` or branches such as `@master`.
+
+## Backend Tracing
+
+Issue #234 enables minimal Spring Web tracing for backend endpoint timing.
+
+Tracing is different from error monitoring:
+- Error monitoring records unexpected failures.
+- Tracing records a sampled subset of normal requests so Sentry can show endpoint transaction names and durations.
+
+The production default should be:
+
+```text
+SENTRY_TRACES_SAMPLE_RATE=0.1
+```
+
+`0.1` means Sentry samples about 10% of eligible backend request transactions. Set it to `0.0` and redeploy to disable tracing without reverting code.
+
+Noise endpoints are sampled at `0.0` by the backend sampler:
+- `/health`
+- `/swagger-ui`
+- `/v3/api-docs`
+
+After deployment, check Sentry:
+1. Open project `checkmo-spring-boot`.
+2. Open Performance, Traces, or Transactions.
+3. Filter by `environment:prod`.
+4. Confirm backend transactions appear with endpoint names and durations.
+5. If a release filter is available, use `checkmo-backend@<github sha>`.
+
+The first success criterion is endpoint transaction timing. DB spans may appear depending on Sentry/Spring instrumentation, but DB query ranking is not guaranteed by this rollout.
+
+Do not enable profiling, Logback log shipping, or Apdex alerts as part of this rollout.
 
 ## Privacy Rules
 
@@ -105,6 +137,7 @@ Only the generic unexpected exception path is captured in this issue.
    SENTRY_ENABLED=true
    SENTRY_DSN=<non-prod DSN>
    SENTRY_ENVIRONMENT=staging
+   SENTRY_TRACES_SAMPLE_RATE=0.1
    ```
 
 3. Deploy from `develop` after the pull request is merged. The workflow appends `SENTRY_RELEASE=checkmo-backend@<github sha>` automatically.
@@ -112,7 +145,8 @@ Only the generic unexpected exception path is captured in this issue.
 5. Confirm exactly one Sentry issue/event is created.
 6. Inspect the event and confirm it does not contain authorization headers, cookies, JWTs, refresh tokens, passwords, verification codes, request bodies, or user context.
 7. Trigger expected 400/401/403 cases and confirm no new Sentry issue is created.
-8. Save dashboard evidence under `.omo/evidence/sentry-222/nonprod-sentry-event.*` with sensitive values redacted.
+8. Trigger several safe non-sensitive API requests and confirm transaction timing appears under Performance, Traces, or Transactions.
+9. Save dashboard evidence under `.omo/evidence/sentry-234/nonprod-sentry-tracing.*` with sensitive values redacted.
 
 ## Prod Rollout
 
@@ -124,6 +158,7 @@ Proceed only after non-prod verification passes.
    SENTRY_ENABLED=true
    SENTRY_DSN=<prod DSN>
    SENTRY_ENVIRONMENT=prod
+   SENTRY_TRACES_SAMPLE_RATE=0.1
    ```
 
 2. Deploy during a low-risk window. The workflow appends `SENTRY_RELEASE=checkmo-backend@<github sha>` automatically.
@@ -132,6 +167,7 @@ Proceed only after non-prod verification passes.
 5. In Sentry, open the `checkmo-spring-boot` project and confirm release `checkmo-backend@<github sha>` appears with a `prod` deploy.
 6. Confirm expected 400/401/403 traffic does not create issue noise.
 7. Confirm unexpected 500 events are grouped and actionable.
+8. Confirm backend endpoint transactions appear with durations in Performance, Traces, or Transactions.
 
 ## Rollback
 
@@ -153,7 +189,18 @@ Sentry can be disabled without code changes.
 3. Confirm `/health` is still healthy.
 4. If the code itself must be reverted, revert the commits for issue #222 and redeploy.
 
+Tracing can be disabled without disabling error monitoring:
+
+1. Set this GitHub repository secret:
+
+   ```text
+   SENTRY_TRACES_SAMPLE_RATE=0.0
+   ```
+
+2. Redeploy through the existing GitHub Actions workflow.
+3. Confirm error monitoring still works and new backend transactions stop appearing.
+
 Release/deploy automation can be rolled back independently of runtime event sending:
-- Revert the workflow change that adds `getsentry/action-release@v3`.
+- Revert the workflow change that adds `getsentry/action-release`.
 - Remove or rotate GitHub `SENTRY_AUTH_TOKEN`.
 - Revoke the Sentry Internal Integration token if it is no longer needed.

--- a/src/main/java/checkmo/common/config/SentryMonitoringConfiguration.java
+++ b/src/main/java/checkmo/common/config/SentryMonitoringConfiguration.java
@@ -41,8 +41,13 @@ public class SentryMonitoringConfiguration {
         if (transactionName == null) {
             return false;
         }
-        return transactionName.contains("/health")
+        return isHealthCheckTransaction(transactionName)
                 || transactionName.contains("/swagger-ui")
                 || transactionName.contains("/v3/api-docs");
+    }
+
+    private boolean isHealthCheckTransaction(String transactionName) {
+        return transactionName.equals("/health")
+                || transactionName.endsWith(" /health");
     }
 }

--- a/src/main/java/checkmo/common/config/SentryMonitoringConfiguration.java
+++ b/src/main/java/checkmo/common/config/SentryMonitoringConfiguration.java
@@ -2,6 +2,7 @@ package checkmo.common.config;
 
 import checkmo.common.monitoring.SentryCaptureClient;
 import checkmo.common.monitoring.SentrySdkCaptureClient;
+import io.sentry.SentryOptions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -13,14 +14,35 @@ public class SentryMonitoringConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public SentryCaptureClient sentryCaptureClient(
-            SentryMonitoringProperties properties,
-            SentrySanitizingBeforeSendCallback beforeSendCallback
-    ) {
+    public SentryCaptureClient sentryCaptureClient(SentryMonitoringProperties properties) {
         if (!properties.enabled() || properties.dsn().isBlank()) {
             return exception -> {
             };
         }
-        return new SentrySdkCaptureClient(properties, beforeSendCallback);
+        return new SentrySdkCaptureClient();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SentryOptions.TracesSamplerCallback sentryTracesSamplerCallback(SentryMonitoringProperties properties) {
+        return samplingContext -> {
+            if (!properties.enabled() || properties.tracesSampleRate() <= 0.0) {
+                return 0.0;
+            }
+            String transactionName = samplingContext.getTransactionContext().getName();
+            if (isNoisyTransaction(transactionName)) {
+                return 0.0;
+            }
+            return properties.tracesSampleRate();
+        };
+    }
+
+    private boolean isNoisyTransaction(String transactionName) {
+        if (transactionName == null) {
+            return false;
+        }
+        return transactionName.contains("/health")
+                || transactionName.contains("/swagger-ui")
+                || transactionName.contains("/v3/api-docs");
     }
 }

--- a/src/main/java/checkmo/common/config/SentryMonitoringProperties.java
+++ b/src/main/java/checkmo/common/config/SentryMonitoringProperties.java
@@ -7,12 +7,24 @@ public record SentryMonitoringProperties(
         boolean enabled,
         String dsn,
         String environment,
-        String release
+        String release,
+        double tracesSampleRate
 ) {
 
     public SentryMonitoringProperties {
         dsn = dsn == null ? "" : dsn;
         environment = environment == null || environment.isBlank() ? "local" : environment;
         release = release == null || release.isBlank() ? "local" : release;
+        tracesSampleRate = normalizeSampleRate(tracesSampleRate);
+    }
+
+    private static double normalizeSampleRate(double sampleRate) {
+        if (Double.isNaN(sampleRate) || sampleRate < 0.0) {
+            return 0.0;
+        }
+        if (sampleRate > 1.0) {
+            return 1.0;
+        }
+        return sampleRate;
     }
 }

--- a/src/main/java/checkmo/common/config/SentryPrivacyPolicy.java
+++ b/src/main/java/checkmo/common/config/SentryPrivacyPolicy.java
@@ -21,8 +21,7 @@ public class SentryPrivacyPolicy {
             "token",
             "refresh",
             "password",
-            "verification",
-            "code"
+            "verification"
     );
     private static final Set<String> BLOCKED_QUERY_KEYWORDS = Set.of(
             "authorization",
@@ -31,8 +30,7 @@ public class SentryPrivacyPolicy {
             "token",
             "refresh",
             "password",
-            "verification",
-            "code"
+            "verification"
     );
 
     public boolean sendDefaultPii() {

--- a/src/main/java/checkmo/common/config/SentryPrivacyPolicy.java
+++ b/src/main/java/checkmo/common/config/SentryPrivacyPolicy.java
@@ -14,6 +14,16 @@ public class SentryPrivacyPolicy {
             "x-access-token",
             "x-refresh-token"
     );
+    private static final Set<String> BLOCKED_HEADER_KEYWORDS = Set.of(
+            "authorization",
+            "cookie",
+            "jwt",
+            "token",
+            "refresh",
+            "password",
+            "verification",
+            "code"
+    );
     private static final Set<String> BLOCKED_QUERY_KEYWORDS = Set.of(
             "authorization",
             "cookie",
@@ -41,7 +51,9 @@ public class SentryPrivacyPolicy {
         if (headerName == null || headerName.isBlank()) {
             return false;
         }
-        return !BLOCKED_HEADERS.contains(headerName.toLowerCase(Locale.ROOT));
+        String normalized = headerName.toLowerCase(Locale.ROOT);
+        return !BLOCKED_HEADERS.contains(normalized)
+                && BLOCKED_HEADER_KEYWORDS.stream().noneMatch(normalized::contains);
     }
 
     public boolean shouldSendQueryParameter(String parameterName) {

--- a/src/main/java/checkmo/common/monitoring/SentrySdkCaptureClient.java
+++ b/src/main/java/checkmo/common/monitoring/SentrySdkCaptureClient.java
@@ -1,23 +1,10 @@
 package checkmo.common.monitoring;
 
-import checkmo.common.config.SentryMonitoringProperties;
-import checkmo.common.config.SentrySanitizingBeforeSendCallback;
 import io.sentry.Sentry;
 
 public class SentrySdkCaptureClient implements SentryCaptureClient {
 
-    public SentrySdkCaptureClient(
-            SentryMonitoringProperties properties,
-            SentrySanitizingBeforeSendCallback beforeSendCallback
-    ) {
-        Sentry.init(options -> {
-            options.setDsn(properties.dsn());
-            options.setEnvironment(properties.environment());
-            options.setRelease(properties.release());
-            options.setSendDefaultPii(false);
-            options.setMaxRequestBodySize(io.sentry.SentryOptions.RequestSize.NONE);
-            options.setBeforeSend(beforeSendCallback);
-        });
+    public SentrySdkCaptureClient() {
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,6 @@
 spring:
   autoconfigure:
     exclude:
-      - io.sentry.spring.boot.jakarta.SentryAutoConfiguration
       - io.sentry.spring.boot.jakarta.SentryProfilerAutoConfiguration
       - io.sentry.spring.boot.jakarta.SentryLogbackAppenderAutoConfiguration
       - io.sentry.spring.boot.jakarta.SentryWebfluxAutoConfiguration
@@ -30,11 +29,13 @@ checkmo:
     dsn: ${SENTRY_DSN:}
     environment: ${SENTRY_ENVIRONMENT:local}
     release: ${SENTRY_RELEASE:local}
+    traces-sample-rate: ${SENTRY_TRACES_SAMPLE_RATE:0.0}
 
 sentry:
   enabled: ${SENTRY_ENABLED:false}
   environment: ${SENTRY_ENVIRONMENT:local}
   release: ${SENTRY_RELEASE:local}
+  traces-sample-rate: ${SENTRY_TRACES_SAMPLE_RATE:0.0}
   send-default-pii: false
   max-request-body-size: none
   logging:

--- a/src/test/java/checkmo/common/config/SentryConfigurationTest.java
+++ b/src/test/java/checkmo/common/config/SentryConfigurationTest.java
@@ -105,6 +105,7 @@ class SentryConfigurationTest {
         assertThat(enabledSampler.sample(samplingContext("GET /health"))).isZero();
         assertThat(enabledSampler.sample(samplingContext("GET /swagger-ui/index.html"))).isZero();
         assertThat(enabledSampler.sample(samplingContext("GET /v3/api-docs"))).isZero();
+        assertThat(enabledSampler.sample(samplingContext("GET /api/v1/user/health"))).isEqualTo(0.1);
         assertThat(enabledSampler.sample(samplingContext("GET /api/books"))).isEqualTo(0.1);
     }
 

--- a/src/test/java/checkmo/common/config/SentryConfigurationTest.java
+++ b/src/test/java/checkmo/common/config/SentryConfigurationTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import checkmo.common.monitoring.SentryCaptureClient;
 import checkmo.common.monitoring.SentrySdkCaptureClient;
 import checkmo.support.SpringTest;
+import io.sentry.SamplingContext;
+import io.sentry.SentryOptions;
+import io.sentry.TransactionContext;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ListableBeanFactory;
@@ -12,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
 
 @SpringTest
 class SentryConfigurationTest {
@@ -50,6 +54,19 @@ class SentryConfigurationTest {
         assertThat(properties.dsn()).isBlank();
         assertThat(properties.environment()).isEqualTo("test");
         assertThat(properties.release()).isEqualTo("local-test");
+        assertThat(properties.tracesSampleRate()).isZero();
+    }
+
+    @Test
+    void sentryRuntimePropertiesBindTracingSampleRateFromEnvironmentNames() {
+        MockEnvironment mockEnvironment = new MockEnvironment()
+                .withProperty("checkmo.sentry.traces-sample-rate", "0.1");
+
+        SentryMonitoringProperties bound = Binder.get(mockEnvironment)
+                .bind("checkmo.sentry", SentryMonitoringProperties.class)
+                .orElseThrow(() -> new AssertionError("checkmo.sentry properties should bind"));
+
+        assertThat(bound.tracesSampleRate()).isEqualTo(0.1);
     }
 
     @Test
@@ -58,14 +75,14 @@ class SentryConfigurationTest {
     }
 
     @Test
-    void sentryStarterAutoConfigurationIsExcluded() {
+    void sentryStarterAutoConfigurationKeepsWebTracingAvailableWithoutProfilerLogbackOrWebflux() {
         List<String> excludes = Binder.get(environment)
                 .bind("spring.autoconfigure.exclude", Bindable.listOf(String.class))
                 .orElse(List.of());
 
         assertThat(excludes)
+                .doesNotContain("io.sentry.spring.boot.jakarta.SentryAutoConfiguration")
                 .contains(
-                        "io.sentry.spring.boot.jakarta.SentryAutoConfiguration",
                         "io.sentry.spring.boot.jakarta.SentryProfilerAutoConfiguration",
                         "io.sentry.spring.boot.jakarta.SentryLogbackAppenderAutoConfiguration",
                         "io.sentry.spring.boot.jakarta.SentryWebfluxAutoConfiguration"
@@ -74,15 +91,32 @@ class SentryConfigurationTest {
     }
 
     @Test
-    void tracingIsNotEnabledByCommittedProperties() {
-        assertThat(environment.getProperty("sentry.traces-sample-rate")).isNull();
+    void tracingSamplerDropsDisabledAndNoiseTransactions() {
+        SentryMonitoringConfiguration configuration = new SentryMonitoringConfiguration();
+
+        SentryOptions.TracesSamplerCallback disabledSampler = configuration.sentryTracesSamplerCallback(
+                new SentryMonitoringProperties(false, "https://public@example.com/1", "prod", "release", 0.1)
+        );
+        SentryOptions.TracesSamplerCallback enabledSampler = configuration.sentryTracesSamplerCallback(
+                new SentryMonitoringProperties(true, "https://public@example.com/1", "prod", "release", 0.1)
+        );
+
+        assertThat(disabledSampler.sample(samplingContext("GET /api/books"))).isZero();
+        assertThat(enabledSampler.sample(samplingContext("GET /health"))).isZero();
+        assertThat(enabledSampler.sample(samplingContext("GET /swagger-ui/index.html"))).isZero();
+        assertThat(enabledSampler.sample(samplingContext("GET /v3/api-docs"))).isZero();
+        assertThat(enabledSampler.sample(samplingContext("GET /api/books"))).isEqualTo(0.1);
+    }
+
+    @Test
+    void tracingDefaultsToZeroByCommittedProperties() {
+        assertThat(environment.getProperty("sentry.traces-sample-rate")).isEqualTo("0.0");
     }
 
     @Test
     void sentryDisabledWithDsnStillUsesNoOpCaptureClient() {
         SentryCaptureClient client = new SentryMonitoringConfiguration().sentryCaptureClient(
-                new SentryMonitoringProperties(false, "https://public@example.com/1", "prod", "release"),
-                new SentrySanitizingBeforeSendCallback(new SentryPrivacyPolicy())
+                new SentryMonitoringProperties(false, "https://public@example.com/1", "prod", "release", 0.1)
         );
 
         assertThat(client).isNotInstanceOf(SentrySdkCaptureClient.class);
@@ -91,10 +125,13 @@ class SentryConfigurationTest {
     @Test
     void sentryEnabledWithBlankDsnUsesNoOpCaptureClient() {
         SentryCaptureClient client = new SentryMonitoringConfiguration().sentryCaptureClient(
-                new SentryMonitoringProperties(true, "", "prod", "release"),
-                new SentrySanitizingBeforeSendCallback(new SentryPrivacyPolicy())
+                new SentryMonitoringProperties(true, "", "prod", "release", 0.1)
         );
 
         assertThat(client).isNotInstanceOf(SentrySdkCaptureClient.class);
+    }
+
+    private SamplingContext samplingContext(String transactionName) {
+        return new SamplingContext(new TransactionContext(transactionName, "http.server"), null);
     }
 }

--- a/src/test/java/checkmo/common/config/SentryPrivacyConfigurationTest.java
+++ b/src/test/java/checkmo/common/config/SentryPrivacyConfigurationTest.java
@@ -43,6 +43,8 @@ class SentryPrivacyConfigurationTest {
         assertThat(privacyPolicy.shouldSendHeader("X-JWT")).isFalse();
         assertThat(privacyPolicy.shouldSendHeader("Verification-Code")).isFalse();
         assertThat(privacyPolicy.shouldSendHeader("X-Request-Id")).isTrue();
+        assertThat(privacyPolicy.shouldSendHeader("X-Status-Code")).isTrue();
+        assertThat(privacyPolicy.shouldSendHeader("X-Error-Code")).isTrue();
     }
 
     @Test
@@ -55,6 +57,8 @@ class SentryPrivacyConfigurationTest {
         assertThat(privacyPolicy.shouldSendQueryParameter("verification-code")).isFalse();
         assertThat(privacyPolicy.shouldSendQueryParameter("jwt")).isFalse();
         assertThat(privacyPolicy.shouldSendQueryParameter("page")).isTrue();
+        assertThat(privacyPolicy.shouldSendQueryParameter("categoryCode")).isTrue();
+        assertThat(privacyPolicy.shouldSendQueryParameter("productCode")).isTrue();
     }
 
     @Test
@@ -76,7 +80,8 @@ class SentryPrivacyConfigurationTest {
                 "X-JWT", "secret",
                 "Verification-Code", "123456",
                 "Cookie", "SESSION=secret",
-                "X-Request-Id", "request-id"
+                "X-Request-Id", "request-id",
+                "X-Status-Code", "500"
         ));
         event.setRequest(request);
 
@@ -93,6 +98,7 @@ class SentryPrivacyConfigurationTest {
         assertThat(sanitized.getRequest().getUrl()).isEqualTo("https://api.checkmo.kr/books");
         assertThat(sanitized.getRequest().getHeaders())
                 .containsEntry("X-Request-Id", "request-id")
+                .containsEntry("X-Status-Code", "500")
                 .doesNotContainKeys("Authorization", "RefreshToken", "X-JWT", "Verification-Code", "Cookie");
     }
 

--- a/src/test/java/checkmo/common/config/SentryPrivacyConfigurationTest.java
+++ b/src/test/java/checkmo/common/config/SentryPrivacyConfigurationTest.java
@@ -38,6 +38,10 @@ class SentryPrivacyConfigurationTest {
         assertThat(privacyPolicy.shouldSendHeader("Authorization")).isFalse();
         assertThat(privacyPolicy.shouldSendHeader("AUTHORIZATION")).isFalse();
         assertThat(privacyPolicy.shouldSendHeader("Cookie")).isFalse();
+        assertThat(privacyPolicy.shouldSendHeader("RefreshToken")).isFalse();
+        assertThat(privacyPolicy.shouldSendHeader("X-Refresh-Token")).isFalse();
+        assertThat(privacyPolicy.shouldSendHeader("X-JWT")).isFalse();
+        assertThat(privacyPolicy.shouldSendHeader("Verification-Code")).isFalse();
         assertThat(privacyPolicy.shouldSendHeader("X-Request-Id")).isTrue();
     }
 
@@ -49,6 +53,7 @@ class SentryPrivacyConfigurationTest {
         assertThat(privacyPolicy.shouldSendQueryParameter("password")).isFalse();
         assertThat(privacyPolicy.shouldSendQueryParameter("verificationCode")).isFalse();
         assertThat(privacyPolicy.shouldSendQueryParameter("verification-code")).isFalse();
+        assertThat(privacyPolicy.shouldSendQueryParameter("jwt")).isFalse();
         assertThat(privacyPolicy.shouldSendQueryParameter("page")).isTrue();
     }
 
@@ -61,12 +66,15 @@ class SentryPrivacyConfigurationTest {
     void beforeSendRemovesSensitiveRequestDataAndUserContext() {
         SentryEvent event = new SentryEvent(new RuntimeException("unexpected"));
         Request request = new Request();
-        request.setData("raw-body");
+        request.setData("password=secret&verification-code=123456");
         request.setCookies("SESSION=secret");
-        request.setQueryString("page=1&refreshToken=secret");
-        request.setUrl("https://api.checkmo.kr/books?refreshToken=secret&page=1");
+        request.setQueryString("page=1&refreshToken=secret&jwt=secret");
+        request.setUrl("https://api.checkmo.kr/books?refreshToken=secret&page=1&jwt=secret");
         request.setHeaders(Map.of(
                 "Authorization", "Bearer secret",
+                "RefreshToken", "secret",
+                "X-JWT", "secret",
+                "Verification-Code", "123456",
                 "Cookie", "SESSION=secret",
                 "X-Request-Id", "request-id"
         ));
@@ -85,7 +93,7 @@ class SentryPrivacyConfigurationTest {
         assertThat(sanitized.getRequest().getUrl()).isEqualTo("https://api.checkmo.kr/books");
         assertThat(sanitized.getRequest().getHeaders())
                 .containsEntry("X-Request-Id", "request-id")
-                .doesNotContainKeys("Authorization", "Cookie");
+                .doesNotContainKeys("Authorization", "RefreshToken", "X-JWT", "Verification-Code", "Cookie");
     }
 
     @Test

--- a/src/test/java/checkmo/common/config/SentryReleaseWorkflowTest.java
+++ b/src/test/java/checkmo/common/config/SentryReleaseWorkflowTest.java
@@ -65,4 +65,15 @@ class SentryReleaseWorkflowTest {
                 .contains("SENTRY_ENABLED|SENTRY_DSN|SENTRY_ENVIRONMENT|SENTRY_RELEASE|SENTRY_AUTH_TOKEN");
         assertThat(workflow).doesNotContain("printf 'SENTRY_AUTH_TOKEN=");
     }
+
+    @Test
+    void releaseWorkflowPropagatesTracingSampleRateFromGithubSecret() throws IOException {
+        String workflow = Files.readString(RELEASE_WORKFLOW);
+
+        assertThat(workflow)
+                .contains("SENTRY_ENABLED|SENTRY_DSN|SENTRY_ENVIRONMENT|SENTRY_RELEASE|SENTRY_AUTH_TOKEN|SENTRY_TRACES_SAMPLE_RATE");
+        assertThat(workflow).contains("SENTRY_TRACES_SAMPLE_RATE=\"${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}\"");
+        assertThat(workflow).contains("printf 'SENTRY_TRACES_SAMPLE_RATE=%s\\n' \"${SENTRY_TRACES_SAMPLE_RATE:-0.0}\"");
+        assertThat(workflow).doesNotContain("printf 'SENTRY_TRACES_SAMPLE_RATE=0.1");
+    }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,6 @@
 spring:
   autoconfigure:
     exclude:
-      - io.sentry.spring.boot.jakarta.SentryAutoConfiguration
       - io.sentry.spring.boot.jakarta.SentryProfilerAutoConfiguration
       - io.sentry.spring.boot.jakarta.SentryLogbackAppenderAutoConfiguration
       - io.sentry.spring.boot.jakarta.SentryWebfluxAutoConfiguration
@@ -120,11 +119,13 @@ checkmo:
     dsn:
     environment: test
     release: local-test
+    traces-sample-rate: 0.0
 
 sentry:
   enabled: false
   environment: test
   release: local-test
+  traces-sample-rate: 0.0
   send-default-pii: false
   max-request-body-size: none
   logging:


### PR DESCRIPTION
## 요약
- Sentry Spring Web auto-configuration을 열어 endpoint transaction tracing을 사용할 수 있게 했습니다.
- SENTRY_TRACES_SAMPLE_RATE로 sampling rate를 제어하고, 미설정/빈 값이면 0.0으로 배포되게 했습니다.
- 기존 PII/Auth/Cookie/JWT/refresh token/password/verification-code/request body 차단 정책을 테스트로 보강했습니다.

## 제외 범위
- Cron Monitor
- profiling
- Logback logging
- Apdex/alert 설정
- expected 400/401/403 error capture 정책 변경

## 검증
- ./gradlew test --tests checkmo.common.config.SentryReleaseWorkflowTest --tests checkmo.common.config.SentryConfigurationTest --tests checkmo.common.config.SentryPrivacyConfigurationTest --tests checkmo.CheckmoApplicationTests --rerun-tasks --no-daemon --no-parallel --max-workers=1
- git diff --check
- Sentry 8.43.1 local source jar로 BeforeSendCallback/TracesSamplerCallback bean 연결 확인

## 배포 후 확인 필요
- GitHub Secret SENTRY_TRACES_SAMPLE_RATE=0.1 설정 후 배포
- Sentry checkmo-spring-boot 프로젝트의 Performance/Traces/Transactions에서 environment:prod, release:checkmo-backend@<sha> 필터로 endpoint transaction 수신 확인
- request body/Auth/Cookie/JWT/refresh/password/verification-code가 보이지 않는지 확인

Closes #234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backend request tracing and transaction monitoring enabled with configurable sample rates.
  * Automatic filtering of noisy health-check and documentation endpoints from traces.

* **Documentation**
  * Comprehensive backend tracing setup, verification, and deployment rollout guide added.

* **Improvements**
  * Enhanced privacy filtering for sensitive request headers and query parameters.
  * Refined Sentry release automation and configuration propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->