### PR TITLE
fix: HTTP 5xx 도메인/백그라운드 예외 Sentry 캡처

### DIFF
--- a/src/main/java/checkmo/book/internal/scheduler/BookRecommendationScheduler.java
+++ b/src/main/java/checkmo/book/internal/scheduler/BookRecommendationScheduler.java
@@ -1,7 +1,9 @@
 package checkmo.book.internal.scheduler;
 
 import checkmo.book.internal.service.BookRecommendationService;
+import checkmo.book.web.dto.BookResponseDTO;
 import checkmo.common.monitoring.SentryCaptureClient;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -36,11 +38,25 @@ public class BookRecommendationScheduler {
 
     private void retrieveAndSaveRecommendedBooks() {
         try {
-            recommendationService.refreshDailyRecommendedBooks();
+            BookResponseDTO.BookList refreshedBooks = recommendationService.refreshDailyRecommendedBooks();
+            if (isEmpty(refreshedBooks)) {
+                log.warn("추천 책 갱신 결과가 비어있어 기존 캐시 상태를 유지합니다.");
+                return;
+            }
+
             log.info("추천 책 갱신 완료");
         } catch (Exception e) {
-            log.error("추천 책 갱신 중 오류 발생", e);
+            log.error("추천 책 갱신 중 예기치 못한 오류 발생", e);
             sentryCaptureClient.captureException(e);
         }
+    }
+
+    private boolean isEmpty(BookResponseDTO.BookList bookList) {
+        if (bookList == null) {
+            return true;
+        }
+
+        List<BookResponseDTO.DetailInfo> books = bookList.getDetailInfoList();
+        return books == null || books.isEmpty();
     }
 }

--- a/src/main/java/checkmo/book/internal/scheduler/BookRecommendationScheduler.java
+++ b/src/main/java/checkmo/book/internal/scheduler/BookRecommendationScheduler.java
@@ -1,6 +1,7 @@
 package checkmo.book.internal.scheduler;
 
 import checkmo.book.internal.service.BookRecommendationService;
+import checkmo.common.monitoring.SentryCaptureClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Component;
 public class BookRecommendationScheduler {
 
     private final BookRecommendationService recommendationService;
+    private final SentryCaptureClient sentryCaptureClient;
 
     @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
     public void updateDailyRecommendedBooks() {
@@ -38,6 +40,7 @@ public class BookRecommendationScheduler {
             log.info("추천 책 갱신 완료");
         } catch (Exception e) {
             log.error("추천 책 갱신 중 오류 발생", e);
+            sentryCaptureClient.captureException(e);
         }
     }
 }

--- a/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
+++ b/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
@@ -4,6 +4,7 @@ import checkmo.book.internal.service.query.AladinApiService;
 import checkmo.book.internal.util.DayOfWeekUtils;
 import checkmo.book.web.dto.BookResponseDTO;
 import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import checkmo.common.monitoring.SentryCaptureClient;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -22,6 +23,7 @@ public class BookRecommendationService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final AladinApiService aladinApiService;
+    private final SentryCaptureClient sentryCaptureClient;
 
     public BookResponseDTO.BookList retrieveRecommendedBooks(String memberId) {
         try {
@@ -69,6 +71,7 @@ public class BookRecommendationService {
 
         } catch (Exception e) {
             log.error("API에서 추천 책 가져오기 중 오류", e);
+            sentryCaptureClient.captureException(e);
             return createEmptyBookList();
         }
     }
@@ -90,6 +93,7 @@ public class BookRecommendationService {
             redisTemplate.opsForValue().set(REDIS_UPDATED_AT_KEY, LocalDate.now().toString());
         } catch (Exception e) {
             log.error("Redis에 추천 책 저장 중 오류 발생", e);
+            sentryCaptureClient.captureException(e);
         }
     }
 

--- a/src/main/java/checkmo/common/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/checkmo/common/apiPayload/exception/ExceptionAdvice.java
@@ -105,6 +105,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(value = GeneralException.class)
     public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
         ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        captureIfServerError(generalException, errorReasonHttpStatus);
         return handleExceptionInternal(generalException, errorReasonHttpStatus, null, request);
     }
 
@@ -171,6 +172,12 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                 errorCommonStatus.getHttpStatus(),
                 request
         );
+    }
+
+    private void captureIfServerError(GeneralException exception, ErrorReasonDTO reason) {
+        if (reason != null && reason.getHttpStatus() != null && reason.getHttpStatus().is5xxServerError()) {
+            sentryCaptureClient.captureException(exception);
+        }
     }
 
     private ResponseEntity<Object> handleExceptionInternalConstraint(

--- a/src/main/java/checkmo/infra/s3/internal/listener/S3EventListener.java
+++ b/src/main/java/checkmo/infra/s3/internal/listener/S3EventListener.java
@@ -2,6 +2,7 @@ package checkmo.infra.s3.internal.listener;
 
 import checkmo.clubManagement.ClubManagementEvent.DeleteClubImageEvent;
 import checkmo.clubNotice.ClubNoticeEvent;
+import checkmo.common.monitoring.SentryCaptureClient;
 import checkmo.infra.s3.internal.service.S3Service;
 import checkmo.member.MemberEvent;
 import java.util.List;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Component;
 public class S3EventListener {
 
     private final S3Service s3Service;
+    private final SentryCaptureClient sentryCaptureClient;
 
     @ApplicationModuleListener
     public void handleDeleteProfileImageEvent(MemberEvent.DeleteProfileImage event) {
@@ -50,6 +52,7 @@ public class S3EventListener {
             s3Service.deleteImage(imageKey);
         } catch (Exception e) {
             log.error("{} 삭제 실패, url={}, event={}", label, imageUrl, event, e);
+            sentryCaptureClient.captureException(e);
         }
     }
 }

--- a/src/main/java/checkmo/member/internal/scheduler/MemberCleanupScheduler.java
+++ b/src/main/java/checkmo/member/internal/scheduler/MemberCleanupScheduler.java
@@ -1,6 +1,7 @@
 package checkmo.member.internal.scheduler;
 
 import checkmo.authentication.AuthenticationAPI;
+import checkmo.common.monitoring.SentryCaptureClient;
 import checkmo.member.internal.entity.Member;
 import checkmo.member.internal.repository.MemberRepository;
 import checkmo.member.internal.service.command.MemberCommandService;
@@ -20,6 +21,7 @@ public class MemberCleanupScheduler {
     private final MemberRepository memberRepository;
     private final AuthenticationAPI authenticationAPI;
     private final MemberCommandService memberCommandService;
+    private final SentryCaptureClient sentryCaptureClient;
 
     /**
      * 프로필 미완료(유령) 회원 삭제 스케줄러
@@ -75,6 +77,7 @@ public class MemberCleanupScheduler {
                 memberCommandService.deleteMember(memberId);
             } catch (Exception e) {
                 log.error("탈퇴 1년 경과 회원 삭제 실패. memberId={}", memberId, e);
+                sentryCaptureClient.captureException(e);
             }
         }
 

--- a/src/main/java/checkmo/member/internal/scheduler/MemberCleanupScheduler.java
+++ b/src/main/java/checkmo/member/internal/scheduler/MemberCleanupScheduler.java
@@ -72,15 +72,29 @@ public class MemberCleanupScheduler {
                 .map(Member::getId)
                 .toList();
 
+        Exception firstFailure = null;
         for (String memberId : expiredMemberIds) {
             try {
                 memberCommandService.deleteMember(memberId);
             } catch (Exception e) {
                 log.error("탈퇴 1년 경과 회원 삭제 실패. memberId={}", memberId, e);
-                sentryCaptureClient.captureException(e);
+                firstFailure = collectFailure(firstFailure, e);
             }
         }
 
+        if (firstFailure != null) {
+            sentryCaptureClient.captureException(firstFailure);
+        }
+
         log.info("탈퇴 1년 경과 회원 삭제 완료");
+    }
+
+    private Exception collectFailure(Exception firstFailure, Exception failure) {
+        if (firstFailure == null) {
+            return failure;
+        }
+
+        firstFailure.addSuppressed(failure);
+        return firstFailure;
     }
 }

--- a/src/test/java/checkmo/common/apiPayload/exception/SentryExceptionAdviceApiTest.java
+++ b/src/test/java/checkmo/common/apiPayload/exception/SentryExceptionAdviceApiTest.java
@@ -54,4 +54,37 @@ class SentryExceptionAdviceApiTest extends ApiTestSupport {
                 .statusCode(200);
     }
 
+    @Test
+    void captures5xxDomainExceptionWithoutChangingResponseShape() {
+        String before = given()
+                .when()
+                .get("/api/test/sentry/captures/count")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        String body = given()
+                .when()
+                .get("/api/test/sentry/domain-server-error")
+                .then()
+                .statusCode(500)
+                .extract()
+                .asString();
+
+        String after = given()
+                .when()
+                .get("/api/test/sentry/captures/count")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        assertThat(body)
+                .contains("\"isSuccess\":false")
+                .contains("\"code\":\"COMMON_500\"")
+                .contains("\"message\":\"서버 에러, 관리자에게 문의 바랍니다.\"");
+        assertThat(Integer.parseInt(after)).isEqualTo(Integer.parseInt(before) + 1);
+    }
+
 }

--- a/src/test/java/checkmo/common/apiPayload/exception/SentryExpectedErrorExclusionTest.java
+++ b/src/test/java/checkmo/common/apiPayload/exception/SentryExpectedErrorExclusionTest.java
@@ -4,8 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import checkmo.authentication.internal.exception.AuthErrorStatus;
+import checkmo.authentication.internal.exception.AuthException;
+import checkmo.book.internal.exception.BookErrorStatus;
+import checkmo.book.internal.exception.BookException;
 import checkmo.common.apiPayload.code.status.ErrorStatus;
 import checkmo.common.monitoring.RecordingSentryCaptureClient;
+import checkmo.infra.s3.internal.exception.S3ErrorStatus;
+import checkmo.infra.s3.internal.exception.S3InfraException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import java.lang.reflect.Method;
@@ -23,13 +29,42 @@ import org.springframework.web.context.request.ServletWebRequest;
 class SentryExpectedErrorExclusionTest {
 
     @Test
-    void doesNotCaptureGeneralException() {
+    void doesNotCaptureExpected4xxGeneralException() {
         RecordingSentryCaptureClient captureClient = new RecordingSentryCaptureClient();
         ExceptionAdvice advice = new ExceptionAdvice(captureClient);
 
         advice.onThrowException(new GeneralException(ErrorStatus._BAD_REQUEST), new MockHttpServletRequest());
 
         assertThat(captureClient.count()).isZero();
+    }
+
+    @Test
+    void capturesCommon5xxGeneralException() {
+        RecordingSentryCaptureClient captureClient = new RecordingSentryCaptureClient();
+        ExceptionAdvice advice = new ExceptionAdvice(captureClient);
+        GeneralException exception = new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+
+        advice.onThrowException(exception, new MockHttpServletRequest());
+
+        assertThat(captureClient.captured()).containsExactly(exception);
+    }
+
+    @Test
+    void capturesRepresentativeModule5xxGeneralExceptions() {
+        RecordingSentryCaptureClient captureClient = new RecordingSentryCaptureClient();
+        ExceptionAdvice advice = new ExceptionAdvice(captureClient);
+        AuthException authException = new AuthException(AuthErrorStatus.INTERNAL_SERVER_ERROR);
+        BookException bookException = new BookException(BookErrorStatus.ALADIN_API_ERROR);
+        S3InfraException s3DeleteException = new S3InfraException(S3ErrorStatus.S3_FILE_DELETE_FAILED);
+        S3InfraException s3PresignedUrlException = new S3InfraException(S3ErrorStatus.S3_PRESIGNED_URL_GENERATION_FAILED);
+
+        advice.onThrowException(authException, new MockHttpServletRequest());
+        advice.onThrowException(bookException, new MockHttpServletRequest());
+        advice.onThrowException(s3DeleteException, new MockHttpServletRequest());
+        advice.onThrowException(s3PresignedUrlException, new MockHttpServletRequest());
+
+        assertThat(captureClient.captured())
+                .containsExactly(authException, bookException, s3DeleteException, s3PresignedUrlException);
     }
 
     @Test

--- a/src/test/java/checkmo/common/apiPayload/exception/SentryQaFaultController.java
+++ b/src/test/java/checkmo/common/apiPayload/exception/SentryQaFaultController.java
@@ -33,6 +33,11 @@ public class SentryQaFaultController {
         throw new GeneralException(ErrorStatus._BAD_REQUEST);
     }
 
+    @GetMapping("/domain-server-error")
+    public void domainServerError() {
+        throw new GeneralException(ErrorStatus._INTERNAL_SERVER_ERROR);
+    }
+
     @GetMapping("/captures/count")
     public String captureCount() {
         return String.valueOf(captureState.count());

--- a/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
+++ b/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
@@ -1,0 +1,105 @@
+package checkmo.common.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import checkmo.authentication.AuthenticationAPI;
+import checkmo.book.internal.service.BookRecommendationService;
+import checkmo.book.internal.service.query.AladinApiService;
+import checkmo.book.internal.scheduler.BookRecommendationScheduler;
+import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.infra.s3.internal.listener.S3EventListener;
+import checkmo.infra.s3.internal.service.S3Service;
+import checkmo.member.MemberEvent;
+import checkmo.member.internal.entity.Member;
+import checkmo.member.internal.repository.MemberRepository;
+import checkmo.member.internal.scheduler.MemberCleanupScheduler;
+import checkmo.member.internal.service.command.MemberCommandService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.RedisTemplate;
+
+class SentryBackgroundCaptureTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void capturesRecommendationRefreshFailureWhileReturningFallbackEmptyList() {
+        RedisTemplate<String, Object> redisTemplate = mock(RedisTemplate.class);
+        AladinApiService aladinApiService = mock(AladinApiService.class);
+        RecordingSentryCaptureClient captureClient = new RecordingSentryCaptureClient();
+        RuntimeException failure = new RuntimeException("aladin unavailable");
+        BookRecommendationService service = new BookRecommendationService(
+                redisTemplate,
+                aladinApiService,
+                captureClient
+        );
+        when(aladinApiService.retrieveRecommendedBooks()).thenThrow(failure);
+
+        BookResponseDTO.BookList response = service.refreshDailyRecommendedBooks();
+
+        assertThat(response.getDetailInfoList()).isEmpty();
+        assertThat(captureClient.captured()).containsExactly(failure);
+    }
+
+    @Test
+    void capturesRecommendationSchedulerFailureWithoutThrowing() {
+        BookRecommendationService recommendationService = mock(BookRecommendationService.class);
+        RecordingSentryCaptureClient captureClient = new RecordingSentryCaptureClient();
+        BookRecommendationScheduler scheduler = new BookRecommendationScheduler(recommendationService, captureClient);
+        RuntimeException failure = new RuntimeException("scheduler refresh failed");
+        doThrow(failure).when(recommendationService).refreshDailyRecommendedBooks();
+
+        assertDoesNotThrow(scheduler::updateDailyRecommendedBooks);
+
+        assertThat(captureClient.captured()).containsExactly(failure);
+    }
+
+    @Test
+    void capturesExpiredMemberCleanupFailureAndContinuesWithRemainingMembers() {
+        MemberRepository memberRepository = mock(MemberRepository.class);
+        AuthenticationAPI authenticationAPI = mock(AuthenticationAPI.class);
+        MemberCommandService memberCommandService = mock(MemberCommandService.class);
+        RecordingSentryCaptureClient captureClient = new RecordingSentryCaptureClient();
+        MemberCleanupScheduler scheduler = new MemberCleanupScheduler(
+                memberRepository,
+                authenticationAPI,
+                memberCommandService,
+                captureClient
+        );
+        RuntimeException failure = new RuntimeException("delete failed");
+        Member first = Member.builder().id("member-1").build();
+        Member second = Member.builder().id("member-2").build();
+        when(memberRepository.findAllByDeactivatedAtBefore(any(LocalDateTime.class)))
+                .thenReturn(List.of(first, second));
+        doThrow(failure).when(memberCommandService).deleteMember("member-1");
+
+        assertDoesNotThrow(scheduler::cleanupExpiredDeactivatedMembers);
+
+        verify(memberCommandService).deleteMember("member-1");
+        verify(memberCommandService).deleteMember("member-2");
+        assertThat(captureClient.captured()).containsExactly(failure);
+    }
+
+    @Test
+    void capturesS3DeleteFailureAndKeepsListenerFallbackBehavior() {
+        S3Service s3Service = mock(S3Service.class);
+        RecordingSentryCaptureClient captureClient = new RecordingSentryCaptureClient();
+        S3EventListener listener = new S3EventListener(s3Service, captureClient);
+        RuntimeException failure = new RuntimeException("s3 delete failed");
+        when(s3Service.extractKeyFromUrl("https://bucket.s3.ap-northeast-2.amazonaws.com/images/a.png"))
+                .thenReturn("images/a.png");
+        doThrow(failure).when(s3Service).deleteImage("images/a.png");
+
+        assertDoesNotThrow(() -> listener.handleDeleteProfileImageEvent(
+                new MemberEvent.DeleteProfileImage("https://bucket.s3.ap-northeast-2.amazonaws.com/images/a.png")
+        ));
+
+        assertThat(captureClient.captured()).containsExactly(failure);
+    }
+}

--- a/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
+++ b/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
@@ -48,7 +48,24 @@ class SentryBackgroundCaptureTest {
     }
 
     @Test
-    void capturesRecommendationSchedulerFailureWithoutThrowing() {
+    void doesNotCaptureRecommendationSchedulerFallbackEmptyList() {
+        BookRecommendationService recommendationService = mock(BookRecommendationService.class);
+        RecordingSentryCaptureClient captureClient = new RecordingSentryCaptureClient();
+        BookRecommendationScheduler scheduler = new BookRecommendationScheduler(recommendationService, captureClient);
+        BookResponseDTO.BookList emptyFallback = BookResponseDTO.BookList.builder()
+                .detailInfoList(List.of())
+                .hasNext(false)
+                .currentPage(null)
+                .build();
+        when(recommendationService.refreshDailyRecommendedBooks()).thenReturn(emptyFallback);
+
+        assertDoesNotThrow(scheduler::updateDailyRecommendedBooks);
+
+        assertThat(captureClient.captured()).isEmpty();
+    }
+
+    @Test
+    void capturesUnexpectedRecommendationSchedulerFailureWithoutThrowing() {
         BookRecommendationService recommendationService = mock(BookRecommendationService.class);
         RecordingSentryCaptureClient captureClient = new RecordingSentryCaptureClient();
         BookRecommendationScheduler scheduler = new BookRecommendationScheduler(recommendationService, captureClient);
@@ -61,7 +78,7 @@ class SentryBackgroundCaptureTest {
     }
 
     @Test
-    void capturesExpiredMemberCleanupFailureAndContinuesWithRemainingMembers() {
+    void capturesExpiredMemberCleanupFailuresOnceAndContinuesWithRemainingMembers() {
         MemberRepository memberRepository = mock(MemberRepository.class);
         AuthenticationAPI authenticationAPI = mock(AuthenticationAPI.class);
         MemberCommandService memberCommandService = mock(MemberCommandService.class);
@@ -72,18 +89,21 @@ class SentryBackgroundCaptureTest {
                 memberCommandService,
                 captureClient
         );
-        RuntimeException failure = new RuntimeException("delete failed");
+        RuntimeException firstFailure = new RuntimeException("delete failed first");
+        RuntimeException secondFailure = new RuntimeException("delete failed second");
         Member first = Member.builder().id("member-1").build();
         Member second = Member.builder().id("member-2").build();
         when(memberRepository.findAllByDeactivatedAtBefore(any(LocalDateTime.class)))
                 .thenReturn(List.of(first, second));
-        doThrow(failure).when(memberCommandService).deleteMember("member-1");
+        doThrow(firstFailure).when(memberCommandService).deleteMember("member-1");
+        doThrow(secondFailure).when(memberCommandService).deleteMember("member-2");
 
         assertDoesNotThrow(scheduler::cleanupExpiredDeactivatedMembers);
 
         verify(memberCommandService).deleteMember("member-1");
         verify(memberCommandService).deleteMember("member-2");
-        assertThat(captureClient.captured()).containsExactly(failure);
+        assertThat(captureClient.captured()).containsExactly(firstFailure);
+        assertThat(firstFailure.getSuppressed()).containsExactly(secondFailure);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- HTTP `GeneralException`은 5xx 상태일 때만 `SentryCaptureClient`로 capture합니다.
- 400/401/403/404, validation, authentication, authorization, illegal argument 경로는 계속 capture하지 않습니다.
- T2 inventory에서 `capture-now`로 분류한 swallowed background 경계만 capture합니다.
  - 추천 책 refresh/save fallback
  - 추천 책 scheduler fallback
  - 탈퇴 1년 경과 회원 삭제 per-member fallback
  - S3 이미지 삭제 listener fallback

## Scope Guard
- Sentry SDK 직접 호출 없음
- PII/Auth/Cookie/JWT/refresh token/password/verification-code/request body/query string 정책 변경 없음
- `SENTRY_ENABLED=false` no-op 롤백 유지
- Cron Monitor, tracing/Apdex, profiling, logback logging, Aladin API 리팩터링 제외

## Tests
- RED:
  - `./gradlew test --tests checkmo.common.apiPayload.exception.SentryExpectedErrorExclusionTest`
  - `./gradlew test --tests checkmo.common.apiPayload.exception.SentryExceptionAdviceApiTest`
  - `./gradlew test --tests checkmo.common.monitoring.SentryBackgroundCaptureTest`
- GREEN / regression:
  - `./gradlew test --tests checkmo.common.apiPayload.exception.SentryExpectedErrorExclusionTest --tests checkmo.common.apiPayload.exception.SentryExceptionAdviceApiTest --tests checkmo.common.monitoring.SentryBackgroundCaptureTest`
  - `./gradlew test --tests checkmo.common.config.SentryConfigurationTest --tests checkmo.common.config.SentryPrivacyConfigurationTest --tests checkmo.common.apiPayload.exception.ExceptionAdvicePrivacyTest --tests checkmo.common.monitoring.SentrySdkCaptureClientTest`
  - `./gradlew test --tests checkmo.CheckmoApplicationTests --tests checkmo.common.apiPayload.exception.SentryExpectedErrorExclusionTest --tests checkmo.common.apiPayload.exception.SentryExceptionAdviceApiTest --tests checkmo.common.monitoring.SentryBackgroundCaptureTest`
  - `./gradlew test --rerun-tasks --no-daemon --no-parallel --max-workers=1`

## Manual QA
- Non-prod/local Sentry UI verification is not executed in this branch because it requires a real non-prod DSN and controlled failure trigger.
- Manual procedure is documented in `.omo/evidence/sentry-236/task-10-manual-qa.md`.

Closes #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Monitoring & Infrastructure**
  * Integrated centralized error reporting into several background schedulers, services, and event listeners.
  * Changed behavior to only send monitoring captures for server-side (5xx) errors while preserving existing logs and API responses.
  * Aggregated and reported first failure when multiple deletions fail, attaching subsequent failures as suppressed.

* **Tests**
  * Added tests and a QA endpoint validating monitoring capture behavior across background flows and API error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->