### PR TITLE
feat(book): 알라딘 검색 totalResults 응답 및 Redis 캐시/prefetch 추가

### DIFF
--- a/src/main/java/checkmo/authentication/internal/converter/AuthConverter.java
+++ b/src/main/java/checkmo/authentication/internal/converter/AuthConverter.java
@@ -29,7 +29,6 @@ public class AuthConverter {
                 .role(Role.USER)
                 .deactivatedAt(null)
                 .profileCompleted(false)
-                .nickName("")
                 .build();
     }
 
@@ -44,7 +43,6 @@ public class AuthConverter {
                 .role(Role.USER)
                 .deactivatedAt(null)
                 .profileCompleted(false)
-                .nickName("")
                 .build();
     }
 }

--- a/src/main/java/checkmo/authentication/internal/entity/AuthUser.java
+++ b/src/main/java/checkmo/authentication/internal/entity/AuthUser.java
@@ -29,7 +29,7 @@ public class AuthUser extends BaseEntity {
     @Column(nullable = false)
     private boolean profileCompleted;
 
-    @Column(length = 20, nullable = false)
+    @Column(length = 20)
     private String nickName;
 
     private LocalDateTime deactivatedAt;
@@ -63,7 +63,7 @@ public class AuthUser extends BaseEntity {
     }
 
     public void updateNickname(String nickName) {
-        this.nickName = nickName != null ? nickName : "";
+        this.nickName = nickName;
     }
 
     public boolean isAdmin() {

--- a/src/main/java/checkmo/authentication/internal/exception/AuthErrorStatus.java
+++ b/src/main/java/checkmo/authentication/internal/exception/AuthErrorStatus.java
@@ -28,7 +28,8 @@ public enum AuthErrorStatus implements BaseErrorCode {
     TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "AUTH_406", "로그아웃된 토큰입니다. 다시 로그인해주세요."),
     SOCIAL_MEMBER_CANNOT_CHANGE_EMAIL(HttpStatus.BAD_REQUEST, "AUTH_407", "소셜 로그인 회원은 이메일을 변경할 수 없습니다."),
     CURRENT_EMAIL_INCORRECT(HttpStatus.BAD_REQUEST, "AUTH_408", "입력하신 기존 이메일 정보가 정확하지 않습니다."),
-    PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "AUTH_409", "새 비밀번호가 기존 비밀번호와 동일합니다.")
+    PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "AUTH_409", "새 비밀번호가 기존 비밀번호와 동일합니다."),
+    NICKNAME_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH_410", "닉네임은 필수입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/checkmo/authentication/internal/service/command/AuthUserCommandService.java
+++ b/src/main/java/checkmo/authentication/internal/service/command/AuthUserCommandService.java
@@ -13,6 +13,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @RequiredArgsConstructor
 @Transactional
@@ -119,6 +120,10 @@ public class AuthUserCommandService {
     }
 
     public void updateNickname(String memberId, String nickname) {
+        if (!StringUtils.hasText(nickname)) {
+            throw new AuthException(AuthErrorStatus.NICKNAME_REQUIRED);
+        }
+
         AuthUser authUser = authRepository.findById(memberId)
                 .orElseThrow(() -> new AuthException(AuthErrorStatus.MEMBER_NOT_FOUND));
 

--- a/src/main/java/checkmo/book/internal/converter/BookConverter.java
+++ b/src/main/java/checkmo/book/internal/converter/BookConverter.java
@@ -88,6 +88,7 @@ public class BookConverter {
                 .detailInfoList(books)
                 .hasNext(hasNext)
                 .currentPage(page)
+                .totalResults(bookList.getTotalResults())
                 .build();
     }
 
@@ -116,6 +117,7 @@ public class BookConverter {
                 .detailInfoList(List.of())
                 .hasNext(false)
                 .currentPage(null)
+                .totalResults(0)
                 .build();
     }
 

--- a/src/main/java/checkmo/book/internal/service/query/AladinApiService.java
+++ b/src/main/java/checkmo/book/internal/service/query/AladinApiService.java
@@ -38,6 +38,10 @@ public class AladinApiService {
     private final SentryCaptureClient sentryCaptureClient;
 
     public BookResponseDTO.BookList retrieveSearchBooks(String keyword, int page, String memberId) {
+        if (keyword == null || keyword.isBlank()) {
+            return emptySearchResult(page);
+        }
+
         int maxResults = aladinProperties.getSearch().getMaxResults();
 
         var cachedBookList = bookSearchCacheService.retrieve(keyword, maxResults, page);
@@ -61,6 +65,15 @@ public class AladinApiService {
             }
             throw new BookException(BookErrorStatus.ALADIN_API_ERROR, e);
         }
+    }
+
+    private BookResponseDTO.BookList emptySearchResult(int page) {
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(List.of())
+                .hasNext(false)
+                .currentPage(page)
+                .totalResults(0)
+                .build();
     }
 
     private void prefetchNextPageIfNeeded(String keyword, int page, BookResponseDTO.BookList bookList) {

--- a/src/main/java/checkmo/book/internal/service/query/AladinApiService.java
+++ b/src/main/java/checkmo/book/internal/service/query/AladinApiService.java
@@ -8,6 +8,7 @@ import checkmo.book.internal.repository.BookLikedRepository;
 import checkmo.book.web.dto.AladinApiResponseDTO;
 import checkmo.book.web.dto.BookResponseDTO;
 import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import checkmo.common.monitoring.SentryCaptureClient;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -31,21 +32,47 @@ public class AladinApiService {
 
     private final AladinProperties aladinProperties;
     private final BookLikedRepository bookLikedRepository;
+    private final BookSearchCacheService bookSearchCacheService;
+    private final AladinSearchClient aladinSearchClient;
+    private final AladinSearchPrefetchService aladinSearchPrefetchService;
+    private final SentryCaptureClient sentryCaptureClient;
 
-    public BookResponseDTO.BookList searchBooks(String keyword, int page, String memberId) {
-        String url = buildHttpUrl(keyword, page);
+    public BookResponseDTO.BookList retrieveSearchBooks(String keyword, int page, String memberId) {
+        int maxResults = aladinProperties.getSearch().getMaxResults();
+
+        var cachedBookList = bookSearchCacheService.retrieve(keyword, maxResults, page);
+        if (cachedBookList.isPresent()) {
+            return applyLikedByMe(cachedBookList.get(), memberId);
+        }
+
         try {
-            var response = restTemplate.getForObject(
-                    url,
-                    AladinApiResponseDTO.BookList.class
-            );
+            BookResponseDTO.BookList bookList = aladinSearchClient.fetchSearchBooks(keyword, page);
+            bookSearchCacheService.save(keyword, maxResults, page, bookList);
 
-            BookResponseDTO.BookList bookList = BookConverter.toBookList(response, page);
+            prefetchNextPageIfNeeded(keyword, page, bookList);
             return applyLikedByMe(bookList, memberId);
 
         } catch (Exception e) {
-            logAladinFailure("searchBooks", url, e);
+            logAladinSearchFailure(e);
+            var fallbackBookList = bookSearchCacheService.retrieve(keyword, maxResults, page);
+            if (fallbackBookList.isPresent()) {
+                sentryCaptureClient.captureException(e);
+                return applyLikedByMe(fallbackBookList.get(), memberId);
+            }
             throw new BookException(BookErrorStatus.ALADIN_API_ERROR, e);
+        }
+    }
+
+    private void prefetchNextPageIfNeeded(String keyword, int page, BookResponseDTO.BookList bookList) {
+        if (bookList == null || !bookList.isHasNext()) {
+            return;
+        }
+
+        try {
+            aladinSearchPrefetchService.prefetchNextPage(keyword, page);
+        } catch (Exception e) {
+            log.warn("알라딘 검색 다음 페이지 prefetch 요청 실패. page={}", page + 1, e);
+            sentryCaptureClient.captureException(e);
         }
     }
 
@@ -105,20 +132,6 @@ public class AladinApiService {
                 .toUriString();
     }
 
-    private String buildHttpUrl(String keyword, int page) {
-        return UriComponentsBuilder
-                .fromUriString(aladinProperties.getUrl().getBase() + aladinProperties.getUrl().getItemSearch())
-                .queryParam("ttbkey", aladinProperties.getAuth().getTtbKey())
-                .queryParam("Query", keyword)
-                .queryParam("QueryType", aladinProperties.getSearch().getSearchQueryType())
-                .queryParam("MaxResults", aladinProperties.getSearch().getMaxResults())
-                .queryParam("start", page)
-                .queryParam("output", aladinProperties.getSearch().getOutput())
-                .queryParam("Version", aladinProperties.getAuth().getVersion())
-                .build()
-                .toUriString();
-    }
-
     private String buildHttpUrl(String isbn) {
         return UriComponentsBuilder
                 .fromUriString(aladinProperties.getUrl().getBase() + aladinProperties.getUrl().getItemLookup())
@@ -160,6 +173,34 @@ public class AladinApiService {
         }
     }
 
+    private void logAladinSearchFailure(Exception exception) {
+        log.error(
+                "Aladin API request failed. operation={}, exceptionType={}, message={}",
+                "retrieveSearchBooks",
+                exception.getClass().getName(),
+                sanitize(exception.getMessage())
+        );
+
+        Throwable cause = exception.getCause();
+        if (cause != null) {
+            log.error(
+                    "Aladin API failure cause. operation={}, causeType={}, causeMessage={}",
+                    "retrieveSearchBooks",
+                    cause.getClass().getName(),
+                    sanitize(cause.getMessage())
+            );
+        }
+
+        if (exception instanceof RestClientResponseException responseException) {
+            log.error(
+                    "Aladin API response failure. operation={}, statusCode={}, responseBody={}",
+                    "retrieveSearchBooks",
+                    responseException.getStatusCode(),
+                    trimForLog(sanitize(responseException.getResponseBodyAsString()))
+            );
+        }
+    }
+
     private String maskTtbKey(String value) {
         return sanitize(value);
     }
@@ -168,7 +209,7 @@ public class AladinApiService {
         if (value == null) {
             return null;
         }
-        return value.replaceAll("(?i)(ttbkey=)[^&\\s]+", "$1***");
+        return value.replaceAll("(?i)((?:ttbkey|query|keyword|authorization|cookie|jwt|accessToken|refreshToken|password|verification[-_]?code)=)[^&\\s]+", "$1***");
     }
 
     private String trimForLog(String value) {
@@ -205,6 +246,7 @@ public class AladinApiService {
                 .detailInfoList(updatedDetails)
                 .hasNext(bookList.isHasNext())
                 .currentPage(bookList.getCurrentPage())
+                .totalResults(bookList.getTotalResults())
                 .build();
     }
 }

--- a/src/main/java/checkmo/book/internal/service/query/AladinSearchClient.java
+++ b/src/main/java/checkmo/book/internal/service/query/AladinSearchClient.java
@@ -6,6 +6,8 @@ import checkmo.book.web.dto.AladinApiResponseDTO;
 import checkmo.book.web.dto.BookResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -17,12 +19,29 @@ public class AladinSearchClient {
     private final AladinProperties aladinProperties;
 
     public BookResponseDTO.BookList fetchSearchBooks(String keyword, int page) {
-        var response = restTemplate.getForObject(
-                buildHttpUrl(keyword, page),
-                AladinApiResponseDTO.BookList.class
-        );
+        AladinApiResponseDTO.BookList response;
+        try {
+            response = restTemplate.getForObject(
+                    buildHttpUrl(keyword, page),
+                    AladinApiResponseDTO.BookList.class
+            );
+        } catch (RestClientException e) {
+            throw new IllegalStateException(sanitizedFailureMessage(e));
+        }
 
         return BookConverter.toBookList(response, page);
+    }
+
+    private String sanitizedFailureMessage(RestClientException exception) {
+        if (exception instanceof RestClientResponseException responseException) {
+            return "Aladin API request failed for search books. exceptionType=%s, statusCode=%s".formatted(
+                    exception.getClass().getName(),
+                    responseException.getStatusCode()
+            );
+        }
+        return "Aladin API request failed for search books. exceptionType=%s".formatted(
+                exception.getClass().getName()
+        );
     }
 
     private String buildHttpUrl(String keyword, int page) {

--- a/src/main/java/checkmo/book/internal/service/query/AladinSearchClient.java
+++ b/src/main/java/checkmo/book/internal/service/query/AladinSearchClient.java
@@ -1,0 +1,41 @@
+package checkmo.book.internal.service.query;
+
+import checkmo.book.internal.config.properties.AladinProperties;
+import checkmo.book.internal.converter.BookConverter;
+import checkmo.book.web.dto.AladinApiResponseDTO;
+import checkmo.book.web.dto.BookResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class AladinSearchClient {
+
+    private final RestTemplate restTemplate;
+    private final AladinProperties aladinProperties;
+
+    public BookResponseDTO.BookList fetchSearchBooks(String keyword, int page) {
+        var response = restTemplate.getForObject(
+                buildHttpUrl(keyword, page),
+                AladinApiResponseDTO.BookList.class
+        );
+
+        return BookConverter.toBookList(response, page);
+    }
+
+    private String buildHttpUrl(String keyword, int page) {
+        return UriComponentsBuilder
+                .fromUriString(aladinProperties.getUrl().getBase() + aladinProperties.getUrl().getItemSearch())
+                .queryParam("ttbkey", aladinProperties.getAuth().getTtbKey())
+                .queryParam("Query", keyword)
+                .queryParam("QueryType", aladinProperties.getSearch().getSearchQueryType())
+                .queryParam("MaxResults", aladinProperties.getSearch().getMaxResults())
+                .queryParam("start", page)
+                .queryParam("output", aladinProperties.getSearch().getOutput())
+                .queryParam("Version", aladinProperties.getAuth().getVersion())
+                .build()
+                .toUriString();
+    }
+}

--- a/src/main/java/checkmo/book/internal/service/query/AladinSearchPrefetchService.java
+++ b/src/main/java/checkmo/book/internal/service/query/AladinSearchPrefetchService.java
@@ -1,0 +1,38 @@
+package checkmo.book.internal.service.query;
+
+import checkmo.book.internal.config.properties.AladinProperties;
+import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.common.monitoring.SentryCaptureClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AladinSearchPrefetchService {
+
+    private final AladinProperties aladinProperties;
+    private final BookSearchCacheService bookSearchCacheService;
+    private final AladinSearchClient aladinSearchClient;
+    private final SentryCaptureClient sentryCaptureClient;
+
+    @Async
+    public void prefetchNextPage(String keyword, int currentPage) {
+        int nextPage = currentPage + 1;
+        int maxResults = aladinProperties.getSearch().getMaxResults();
+
+        try {
+            if (bookSearchCacheService.retrieve(keyword, maxResults, nextPage).isPresent()) {
+                return;
+            }
+
+            BookResponseDTO.BookList bookList = aladinSearchClient.fetchSearchBooks(keyword, nextPage);
+            bookSearchCacheService.save(keyword, maxResults, nextPage, bookList);
+        } catch (Exception e) {
+            log.warn("알라딘 검색 다음 페이지 prefetch 실패. page={}", nextPage, e);
+            sentryCaptureClient.captureException(e);
+        }
+    }
+}

--- a/src/main/java/checkmo/book/internal/service/query/BookSearchCacheService.java
+++ b/src/main/java/checkmo/book/internal/service/query/BookSearchCacheService.java
@@ -1,0 +1,104 @@
+package checkmo.book.internal.service.query;
+
+import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.HexFormat;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookSearchCacheService {
+
+    private static final String KEY_PREFIX = "book:search:v1:";
+    private static final Duration TTL = Duration.ofMinutes(10);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public Optional<BookResponseDTO.BookList> retrieve(String keyword, int maxResults, int page) {
+        try {
+            Object cachedData = redisTemplate.opsForValue().get(buildKey(keyword, maxResults, page));
+            if (cachedData instanceof BookResponseDTO.BookList bookList) {
+                return Optional.of(bookList);
+            }
+        } catch (Exception e) {
+            log.warn("책 검색 캐시 조회 중 오류 발생. keywordHash={}, page={}", keywordHashForLog(keyword), page, e);
+        }
+        return Optional.empty();
+    }
+
+    public void save(String keyword, int maxResults, int page, BookResponseDTO.BookList bookList) {
+        if (bookList == null) {
+            return;
+        }
+        try {
+            redisTemplate.opsForValue().set(
+                    buildKey(keyword, maxResults, page),
+                    withoutLikedByMe(bookList),
+                    TTL
+            );
+        } catch (Exception e) {
+            log.warn("책 검색 캐시 저장 중 오류 발생. keywordHash={}, page={}", keywordHashForLog(keyword), page, e);
+        }
+    }
+
+    String buildKey(String keyword, int maxResults, int page) {
+        return KEY_PREFIX + sha256(normalizedPayload(keyword, maxResults, page));
+    }
+
+    BookResponseDTO.BookList withoutLikedByMe(BookResponseDTO.BookList bookList) {
+        List<DetailInfo> details = Optional.ofNullable(bookList.getDetailInfoList())
+                .orElseGet(List::of)
+                .stream()
+                .map(detail -> DetailInfo.builder()
+                        .isbn(detail.getIsbn())
+                        .title(detail.getTitle())
+                        .author(detail.getAuthor())
+                        .imgUrl(detail.getImgUrl())
+                        .publisher(detail.getPublisher())
+                        .description(detail.getDescription())
+                        .link(detail.getLink())
+                        .likedByMe(false)
+                        .build())
+                .toList();
+
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(details)
+                .hasNext(bookList.isHasNext())
+                .currentPage(bookList.getCurrentPage())
+                .totalResults(bookList.getTotalResults())
+                .build();
+    }
+
+    private String normalizedPayload(String keyword, int maxResults, int page) {
+        String normalizedKeyword = Optional.ofNullable(keyword)
+                .orElse("")
+                .trim()
+                .replaceAll("\\s+", " ")
+                .toLowerCase(Locale.ROOT);
+        return normalizedKeyword + "|" + maxResults + "|" + page;
+    }
+
+    private String keywordHashForLog(String keyword) {
+        return sha256(Optional.ofNullable(keyword).orElse("").trim().toLowerCase(Locale.ROOT));
+    }
+
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", e);
+        }
+    }
+}

--- a/src/main/java/checkmo/book/web/controller/BookController.java
+++ b/src/main/java/checkmo/book/web/controller/BookController.java
@@ -50,7 +50,7 @@ public class BookController {
             @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
             int page
     ) {
-        BookResponseDTO.BookList result = aladinApiService.searchBooks(keyword, page, memberId);
+        BookResponseDTO.BookList result = aladinApiService.retrieveSearchBooks(keyword, page, memberId);
         return ApiResponse.onSuccess(result);
     }
 

--- a/src/main/java/checkmo/book/web/dto/BookResponseDTO.java
+++ b/src/main/java/checkmo/book/web/dto/BookResponseDTO.java
@@ -31,6 +31,7 @@ public class BookResponseDTO {
         private List<DetailInfo> detailInfoList;
         private boolean hasNext;
         private Integer currentPage;
+        private int totalResults;
     }
 
     @Getter

--- a/src/main/java/checkmo/member/internal/entity/Member.java
+++ b/src/main/java/checkmo/member/internal/entity/Member.java
@@ -52,7 +52,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private String phoneNumber;
 
-    @Column(length = 20, nullable = false)
+    @Column(length = 20)
     private String nickName;
 
     @Column(length = 40)
@@ -85,7 +85,7 @@ public class Member extends BaseEntity {
     private Set<MemberInterestCategory> interestCategories = new HashSet<>();
 
     public void updateAdditionalInfo(String nickName, String name, String phoneNumber, String description) {
-        this.nickName = nickName != null ? nickName : "";
+        this.nickName = nickName;
         this.name = name != null ? name : "";
         this.phoneNumber = phoneNumber != null ? phoneNumber : "";
         this.description = description;

--- a/src/main/java/checkmo/member/internal/exception/MemberErrorStatus.java
+++ b/src/main/java/checkmo/member/internal/exception/MemberErrorStatus.java
@@ -15,6 +15,7 @@ public enum MemberErrorStatus implements BaseErrorCode {
     CURRENT_PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, "MEMBER_412", "기존 비밀번호가 올바르지 않습니다. 다시 시도해주세요."),
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER_413", "이미 사용 중인 이메일입니다."),
     CURRENT_EMAIL_INCORRECT(HttpStatus.BAD_REQUEST, "MEMBER_414", "입력하신 기존 이메일 정보가 정확하지 않습니다."),
+    NICKNAME_REQUIRED(HttpStatus.BAD_REQUEST, "MEMBER_415", "닉네임은 필수입니다."),
 
     // 팔로우
     MEMBER_CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST, "FOLLOW_400", "자기 자신을 팔로잉할 수 없습니다."),

--- a/src/main/java/checkmo/member/internal/repository/MemberRepository.java
+++ b/src/main/java/checkmo/member/internal/repository/MemberRepository.java
@@ -40,7 +40,7 @@ public interface MemberRepository extends JpaRepository<Member, String>, MemberR
     List<Member> lockActiveMembersByIdIn(@Param("memberIds") List<String> memberIds);
 
     // 생성일시가 특정 시간 이전이고, 추가정보(nickname)가 아직 입력되지 않은(프로필 미완료) 회원 조회
-    @Query("SELECT m FROM Member m WHERE m.createdAt < :threshold AND (m.nickName IS NULL OR m.nickName = '')")
+    @Query("SELECT m FROM Member m WHERE m.createdAt < :threshold AND m.nickName IS NULL")
     List<Member> findAllGhostMembers(@Param("threshold") LocalDateTime threshold);
 
     List<Member> findAllByDeactivatedAtBefore(LocalDateTime threshold);

--- a/src/main/java/checkmo/member/internal/service/command/MemberCommandService.java
+++ b/src/main/java/checkmo/member/internal/service/command/MemberCommandService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.HashSet;
 
@@ -37,7 +38,6 @@ public class MemberCommandService {
         Member member = Member.builder()
                 .id(memberId)
                 .email(email)
-                .nickName("")
                 .name("")
                 .phoneNumber("")
                 .description("")
@@ -57,6 +57,10 @@ public class MemberCommandService {
      */
     public void addAdditionalInfo(String memberId, MemberRequestDTO.AdditionalInfo request) {
         Member member = findActiveMember(memberId);
+
+        if (!StringUtils.hasText(request.getNickname())) {
+            throw new MemberException(MemberErrorStatus.NICKNAME_REQUIRED);
+        }
 
         member.updateAdditionalInfo(
                 request.getNickname(),

--- a/src/main/resources/db/migration/V20260612_1__modify_member_nickname_null.sql
+++ b/src/main/resources/db/migration/V20260612_1__modify_member_nickname_null.sql
@@ -1,0 +1,10 @@
+ALTER TABLE member
+    MODIFY COLUMN nick_name VARCHAR(20) NULL;
+
+UPDATE auth_user
+SET nick_name = NULL
+WHERE nick_name = '';
+
+UPDATE member
+SET nick_name = NULL
+WHERE nick_name = '';

--- a/src/test/java/checkmo/authentication/AuthApiTest.java
+++ b/src/test/java/checkmo/authentication/AuthApiTest.java
@@ -105,6 +105,42 @@ class AuthApiTest extends ApiTestSupport {
     }
 
     @Test
+    void signUpAllowsMultipleIncompleteUsersWithoutNicknameConflicts() {
+        String firstEmail = "signup-null-nickname-1@example.com";
+        String secondEmail = "signup-null-nickname-2@example.com";
+        when(redisHashOperations.get("verification:" + firstEmail, "verified")).thenReturn(true);
+        when(redisHashOperations.get("verification:" + secondEmail, "verified")).thenReturn(true);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("email", firstEmail, "password", "Pass123!"))
+                .when()
+                .post("/api/auth/signup")
+                .then()
+                .statusCode(200);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("email", secondEmail, "password", "Pass123!"))
+                .when()
+                .post("/api/auth/signup")
+                .then()
+                .statusCode(200);
+
+        var firstUser = authRepository.findByEmail(firstEmail).orElseThrow();
+        var secondUser = authRepository.findByEmail(secondEmail).orElseThrow();
+        var firstMember = memberRepository.findById(firstUser.getId()).orElseThrow();
+        var secondMember = memberRepository.findById(secondUser.getId()).orElseThrow();
+
+        assertThat(firstUser.getNickName()).isNull();
+        assertThat(secondUser.getNickName()).isNull();
+        assertThat(firstMember.getNickName()).isNull();
+        assertThat(secondMember.getNickName()).isNull();
+        assertThat(firstUser.isProfileCompleted()).isFalse();
+        assertThat(secondUser.isProfileCompleted()).isFalse();
+    }
+
+    @Test
     void signUpRejectsUnverifiedEmail() {
         given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
+++ b/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
@@ -76,9 +76,10 @@ class BookStoryNewsReportNotificationImageApiTest extends ApiTestSupport {
                 .detailInfoList(List.of(detail))
                 .currentPage(1)
                 .hasNext(false)
+                .totalResults(123)
                 .build();
 
-        when(aladinApiService.searchBooks(eq("자바"), eq(1), anyString())).thenReturn(oneBookList);
+        when(aladinApiService.retrieveSearchBooks(eq("자바"), eq(1), anyString())).thenReturn(oneBookList);
         when(aladinApiService.retrieveBookDetailInfo(ISBN)).thenReturn(detail);
         when(aladinApiService.retrieveRecommendedBooks()).thenReturn(BookResponseDTO.BookList.builder()
                 .detailInfoList(IntStream.rangeClosed(1, 28)
@@ -112,7 +113,8 @@ class BookStoryNewsReportNotificationImageApiTest extends ApiTestSupport {
                 .get("/api/books/search")
                 .then()
                 .statusCode(200)
-                .body("result.detailInfoList[0].isbn", equalTo(ISBN));
+                .body("result.detailInfoList[0].isbn", equalTo(ISBN))
+                .body("result.totalResults", equalTo(123));
 
         given()
                 .when()

--- a/src/test/java/checkmo/book/internal/converter/BookConverterTest.java
+++ b/src/test/java/checkmo/book/internal/converter/BookConverterTest.java
@@ -1,0 +1,57 @@
+package checkmo.book.internal.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import checkmo.book.web.dto.AladinApiResponseDTO;
+import checkmo.book.web.dto.BookResponseDTO;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import org.junit.jupiter.api.Test;
+
+class BookConverterTest {
+
+    private final XmlMapper xmlMapper = new XmlMapper();
+
+    @Test
+    void toBookListIncludesTotalResultsFromAladinResponse() throws Exception {
+        AladinApiResponseDTO.BookList aladinResponse = xmlMapper.readValue(
+                """
+                        <object>
+                            <totalResults>37</totalResults>
+                            <startIndex>1</startIndex>
+                            <itemsPerPage>10</itemsPerPage>
+                            <item>
+                                <title>테스트 책</title>
+                                <author>테스트 저자 (지은이)</author>
+                                <isbn13>9791169213882</isbn13>
+                                <cover>https://image.aladin.co.kr/product/coversum/test.jpg</cover>
+                                <publisher>테스트 출판사</publisher>
+                                <description>테스트 설명</description>
+                                <link>https://www.aladin.co.kr/shop/wproduct.aspx?ItemId=1</link>
+                            </item>
+                        </object>
+                        """,
+                AladinApiResponseDTO.BookList.class
+        );
+
+        BookResponseDTO.BookList response = BookConverter.toBookList(aladinResponse, 1);
+
+        assertThat(response.getTotalResults()).isEqualTo(37);
+        assertThat(response.isHasNext()).isTrue();
+        assertThat(response.getCurrentPage()).isEqualTo(1);
+        assertThat(response.getDetailInfoList()).singleElement()
+                .satisfies(book -> {
+                    assertThat(book.getIsbn()).isEqualTo("9791169213882");
+                    assertThat(book.getAuthor()).isEqualTo("테스트 저자");
+                });
+    }
+
+    @Test
+    void toBookListReturnsZeroTotalResultsForInvalidResponse() {
+        BookResponseDTO.BookList response = BookConverter.toBookList(null, 1);
+
+        assertThat(response.getTotalResults()).isZero();
+        assertThat(response.isHasNext()).isFalse();
+        assertThat(response.getCurrentPage()).isNull();
+        assertThat(response.getDetailInfoList()).isEmpty();
+    }
+}

--- a/src/test/java/checkmo/book/internal/service/query/AladinApiServiceTest.java
+++ b/src/test/java/checkmo/book/internal/service/query/AladinApiServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import checkmo.book.internal.config.properties.AladinProperties;
@@ -82,6 +83,23 @@ class AladinApiServiceTest {
         assertThat(response.getDetailInfoList()).singleElement()
                 .extracting(DetailInfo::isLikedByMe)
                 .isEqualTo(true);
+    }
+
+    @Test
+    void searchBooksReturnsEmptyResultWhenKeywordIsBlank() {
+        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("   ", 1, "member-1");
+
+        assertThat(response.getTotalResults()).isZero();
+        assertThat(response.getCurrentPage()).isEqualTo(1);
+        assertThat(response.isHasNext()).isFalse();
+        assertThat(response.getDetailInfoList()).isEmpty();
+        verifyNoInteractions(
+                bookLikedRepository,
+                bookSearchCacheService,
+                aladinSearchClient,
+                aladinSearchPrefetchService,
+                sentryCaptureClient
+        );
     }
 
     @Test

--- a/src/test/java/checkmo/book/internal/service/query/AladinApiServiceTest.java
+++ b/src/test/java/checkmo/book/internal/service/query/AladinApiServiceTest.java
@@ -1,0 +1,169 @@
+package checkmo.book.internal.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import checkmo.book.internal.config.properties.AladinProperties;
+import checkmo.book.internal.exception.BookErrorStatus;
+import checkmo.book.internal.exception.BookException;
+import checkmo.book.internal.repository.BookLikedRepository;
+import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import checkmo.common.monitoring.SentryCaptureClient;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.springframework.web.client.RestTemplate;
+
+class AladinApiServiceTest {
+
+    private RestTemplate restTemplate;
+    private AladinProperties aladinProperties;
+    private BookLikedRepository bookLikedRepository;
+    private BookSearchCacheService bookSearchCacheService;
+    private AladinSearchClient aladinSearchClient;
+    private AladinSearchPrefetchService aladinSearchPrefetchService;
+    private SentryCaptureClient sentryCaptureClient;
+    private AladinApiService aladinApiService;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = mock(RestTemplate.class);
+        aladinProperties = aladinProperties();
+        bookLikedRepository = mock(BookLikedRepository.class, Answers.CALLS_REAL_METHODS);
+        bookSearchCacheService = mock(BookSearchCacheService.class);
+        aladinSearchClient = mock(AladinSearchClient.class);
+        aladinSearchPrefetchService = mock(AladinSearchPrefetchService.class);
+        sentryCaptureClient = mock(SentryCaptureClient.class);
+        aladinApiService = new AladinApiService(
+                restTemplate,
+                aladinProperties,
+                bookLikedRepository,
+                bookSearchCacheService,
+                aladinSearchClient,
+                aladinSearchPrefetchService,
+                sentryCaptureClient
+        );
+    }
+
+    @Test
+    void applyLikedByMePreservesSearchMetadata() {
+        when(bookLikedRepository.findLikedBookIds(eq("member-1"), anyList()))
+                .thenReturn(List.of("9791169213882"));
+
+        BookResponseDTO.BookList response = aladinApiService.applyLikedByMe(bookList(false, true), "member-1");
+
+        assertThat(response.getTotalResults()).isEqualTo(37);
+        assertThat(response.getCurrentPage()).isEqualTo(2);
+        assertThat(response.isHasNext()).isTrue();
+        assertThat(response.getDetailInfoList()).singleElement()
+                .extracting(DetailInfo::isLikedByMe)
+                .isEqualTo(true);
+    }
+
+    @Test
+    void searchBooksUsesCachedRawResultAndAppliesLikedByMe() {
+        when(bookSearchCacheService.retrieve("java", 10, 1)).thenReturn(Optional.of(bookList(false, true)));
+        when(bookLikedRepository.findLikedBookIds(eq("member-1"), anyList()))
+                .thenReturn(List.of("9791169213882"));
+
+        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("java", 1, "member-1");
+
+        verify(aladinSearchClient, never()).fetchSearchBooks("java", 1);
+        assertThat(response.getTotalResults()).isEqualTo(37);
+        assertThat(response.getDetailInfoList()).singleElement()
+                .extracting(DetailInfo::isLikedByMe)
+                .isEqualTo(true);
+    }
+
+    @Test
+    void searchBooksCachesSuccessfulRawResultAndPrefetchesNextPage() {
+        BookResponseDTO.BookList rawBookList = bookList(false, true);
+        when(bookSearchCacheService.retrieve("java", 10, 1)).thenReturn(Optional.empty());
+        when(aladinSearchClient.fetchSearchBooks("java", 1)).thenReturn(rawBookList);
+        when(bookLikedRepository.findLikedBookIds(eq("member-1"), anyList()))
+                .thenReturn(List.of("9791169213882"));
+
+        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("java", 1, "member-1");
+
+        verify(bookSearchCacheService).save("java", 10, 1, rawBookList);
+        verify(aladinSearchPrefetchService).prefetchNextPage("java", 1);
+        assertThat(response.getDetailInfoList()).singleElement()
+                .extracting(DetailInfo::isLikedByMe)
+                .isEqualTo(true);
+    }
+
+    @Test
+    void searchBooksDoesNotPrefetchWhenHasNextIsFalse() {
+        BookResponseDTO.BookList rawBookList = bookList(false, false);
+        when(bookSearchCacheService.retrieve("java", 10, 1)).thenReturn(Optional.empty());
+        when(aladinSearchClient.fetchSearchBooks("java", 1)).thenReturn(rawBookList);
+
+        aladinApiService.retrieveSearchBooks("java", 1, "member-1");
+
+        verify(aladinSearchPrefetchService, never()).prefetchNextPage("java", 1);
+    }
+
+    @Test
+    void searchBooksReturnsCachedFallbackAndCapturesAladinFailure() {
+        RuntimeException failure = new RuntimeException("aladin unavailable");
+        when(bookSearchCacheService.retrieve("java", 10, 1))
+                .thenReturn(Optional.empty(), Optional.of(bookList(false, false)));
+        when(aladinSearchClient.fetchSearchBooks("java", 1)).thenThrow(failure);
+        when(bookLikedRepository.findLikedBookIds(eq("member-1"), anyList()))
+                .thenReturn(List.of("9791169213882"));
+
+        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("java", 1, "member-1");
+
+        verify(sentryCaptureClient).captureException(failure);
+        assertThat(response.getTotalResults()).isEqualTo(37);
+        assertThat(response.getDetailInfoList()).singleElement()
+                .extracting(DetailInfo::isLikedByMe)
+                .isEqualTo(true);
+    }
+
+    @Test
+    void searchBooksThrowsBook500WhenAladinFailsAndCacheMissing() {
+        RuntimeException failure = new RuntimeException("aladin unavailable");
+        when(bookSearchCacheService.retrieve("java", 10, 1)).thenReturn(Optional.empty());
+        when(aladinSearchClient.fetchSearchBooks("java", 1)).thenThrow(failure);
+
+        assertThatThrownBy(() -> aladinApiService.retrieveSearchBooks("java", 1, "member-1"))
+                .isInstanceOfSatisfying(BookException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(BookErrorStatus.ALADIN_API_ERROR)
+                )
+                .hasCause(failure);
+    }
+
+    private AladinProperties aladinProperties() {
+        AladinProperties properties = new AladinProperties();
+        properties.getSearch().setMaxResults(10);
+        return properties;
+    }
+
+    private BookResponseDTO.BookList bookList(boolean likedByMe, boolean hasNext) {
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(List.of(DetailInfo.builder()
+                        .isbn("9791169213882")
+                        .title("테스트 책")
+                        .author("테스트 저자")
+                        .imgUrl("https://example.com/book.jpg")
+                        .publisher("테스트 출판사")
+                        .description("테스트 설명")
+                        .link("https://example.com/book")
+                        .likedByMe(likedByMe)
+                        .build()))
+                .hasNext(hasNext)
+                .currentPage(2)
+                .totalResults(37)
+                .build();
+    }
+}

--- a/src/test/java/checkmo/book/internal/service/query/AladinSearchClientTest.java
+++ b/src/test/java/checkmo/book/internal/service/query/AladinSearchClientTest.java
@@ -1,0 +1,46 @@
+package checkmo.book.internal.service.query;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import checkmo.book.internal.config.properties.AladinProperties;
+import checkmo.book.web.dto.AladinApiResponseDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+class AladinSearchClientTest {
+
+    @Test
+    void fetchSearchBooksThrowsSanitizedExceptionWhenRestTemplateFails() {
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        AladinSearchClient client = new AladinSearchClient(restTemplate, aladinProperties());
+        RestClientException failure = new RestClientException(
+                "I/O error on GET request for \"https://example.com/ItemSearch.aspx?ttbkey=secret-key&Query=자바\""
+        );
+        when(restTemplate.getForObject(anyString(), eq(AladinApiResponseDTO.BookList.class))).thenThrow(failure);
+
+        assertThatThrownBy(() -> client.fetchSearchBooks("자바", 1))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Aladin API request failed for search books")
+                .hasMessageContaining(RestClientException.class.getName())
+                .hasMessageNotContaining("secret-key")
+                .hasMessageNotContaining("자바")
+                .hasNoCause();
+    }
+
+    private AladinProperties aladinProperties() {
+        AladinProperties properties = new AladinProperties();
+        properties.getUrl().setBase("https://example.com");
+        properties.getUrl().setItemSearch("/ItemSearch.aspx");
+        properties.getAuth().setTtbKey("secret-key");
+        properties.getAuth().setVersion("20131101");
+        properties.getSearch().setSearchQueryType("Keyword");
+        properties.getSearch().setMaxResults(10);
+        properties.getSearch().setOutput("js");
+        return properties;
+    }
+}

--- a/src/test/java/checkmo/book/internal/service/query/AladinSearchPrefetchServiceTest.java
+++ b/src/test/java/checkmo/book/internal/service/query/AladinSearchPrefetchServiceTest.java
@@ -1,0 +1,91 @@
+package checkmo.book.internal.service.query;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import checkmo.book.internal.config.properties.AladinProperties;
+import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import checkmo.common.monitoring.SentryCaptureClient;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AladinSearchPrefetchServiceTest {
+
+    private AladinProperties aladinProperties;
+    private BookSearchCacheService bookSearchCacheService;
+    private AladinSearchClient aladinSearchClient;
+    private SentryCaptureClient sentryCaptureClient;
+    private AladinSearchPrefetchService aladinSearchPrefetchService;
+
+    @BeforeEach
+    void setUp() {
+        aladinProperties = new AladinProperties();
+        aladinProperties.getSearch().setMaxResults(10);
+        bookSearchCacheService = mock(BookSearchCacheService.class);
+        aladinSearchClient = mock(AladinSearchClient.class);
+        sentryCaptureClient = mock(SentryCaptureClient.class);
+        aladinSearchPrefetchService = new AladinSearchPrefetchService(
+                aladinProperties,
+                bookSearchCacheService,
+                aladinSearchClient,
+                sentryCaptureClient
+        );
+    }
+
+    @Test
+    void prefetchNextPageCachesOnlyCurrentPagePlusOne() {
+        BookResponseDTO.BookList page2 = bookList(2, true);
+        when(bookSearchCacheService.retrieve("java", 10, 2)).thenReturn(Optional.empty());
+        when(aladinSearchClient.fetchSearchBooks("java", 2)).thenReturn(page2);
+
+        aladinSearchPrefetchService.prefetchNextPage("java", 1);
+
+        verify(aladinSearchClient).fetchSearchBooks("java", 2);
+        verify(bookSearchCacheService).save("java", 10, 2, page2);
+        verify(aladinSearchClient, never()).fetchSearchBooks("java", 3);
+    }
+
+    @Test
+    void prefetchNextPageDoesNothingWhenNextPageAlreadyCached() {
+        when(bookSearchCacheService.retrieve("java", 10, 2)).thenReturn(Optional.of(bookList(2, true)));
+
+        aladinSearchPrefetchService.prefetchNextPage("java", 1);
+
+        verify(aladinSearchClient, never()).fetchSearchBooks("java", 2);
+    }
+
+    @Test
+    void prefetchNextPageCapturesFailureWithoutThrowing() {
+        RuntimeException failure = new RuntimeException("aladin unavailable");
+        when(bookSearchCacheService.retrieve("java", 10, 2)).thenReturn(Optional.empty());
+        when(aladinSearchClient.fetchSearchBooks("java", 2)).thenThrow(failure);
+
+        assertThatCode(() -> aladinSearchPrefetchService.prefetchNextPage("java", 1))
+                .doesNotThrowAnyException();
+
+        verify(sentryCaptureClient).captureException(failure);
+    }
+
+    private BookResponseDTO.BookList bookList(int page, boolean hasNext) {
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(List.of(DetailInfo.builder()
+                        .isbn("9791169213882")
+                        .title("테스트 책")
+                        .author("테스트 저자")
+                        .imgUrl("https://example.com/book.jpg")
+                        .publisher("테스트 출판사")
+                        .description("테스트 설명")
+                        .link("https://example.com/book")
+                        .build()))
+                .hasNext(hasNext)
+                .currentPage(page)
+                .totalResults(37)
+                .build();
+    }
+}

--- a/src/test/java/checkmo/book/internal/service/query/AladinSearchPrefetchServiceTest.java
+++ b/src/test/java/checkmo/book/internal/service/query/AladinSearchPrefetchServiceTest.java
@@ -1,6 +1,8 @@
 package checkmo.book.internal.service.query;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -58,6 +60,7 @@ class AladinSearchPrefetchServiceTest {
         aladinSearchPrefetchService.prefetchNextPage("java", 1);
 
         verify(aladinSearchClient, never()).fetchSearchBooks("java", 2);
+        verify(bookSearchCacheService, never()).save(eq("java"), eq(10), eq(2), any());
     }
 
     @Test

--- a/src/test/java/checkmo/book/internal/service/query/BookSearchCacheServiceTest.java
+++ b/src/test/java/checkmo/book/internal/service/query/BookSearchCacheServiceTest.java
@@ -1,0 +1,95 @@
+package checkmo.book.internal.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+class BookSearchCacheServiceTest {
+
+    private RedisTemplate<String, Object> redisTemplate;
+    private ValueOperations<String, Object> valueOperations;
+    private BookSearchCacheService bookSearchCacheService;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        redisTemplate = mock(RedisTemplate.class);
+        valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        bookSearchCacheService = new BookSearchCacheService(redisTemplate);
+    }
+
+    @Test
+    void buildKeyNormalizesKeywordAndIncludesMaxResultsAndPage() {
+        String normalizedKey = bookSearchCacheService.buildKey("  Java   Spring ", 10, 1);
+
+        assertThat(bookSearchCacheService.buildKey("java spring", 10, 1)).isEqualTo(normalizedKey);
+        assertThat(bookSearchCacheService.buildKey("java spring", 10, 2)).isNotEqualTo(normalizedKey);
+        assertThat(bookSearchCacheService.buildKey("java spring", 20, 1)).isNotEqualTo(normalizedKey);
+        assertThat(normalizedKey)
+                .startsWith("book:search:v1:")
+                .doesNotContain("Java")
+                .doesNotContain("java")
+                .doesNotContain("Spring")
+                .doesNotContain("spring");
+    }
+
+    @Test
+    void saveStoresRawBookListForTenMinutes() {
+        BookResponseDTO.BookList bookList = bookList(true);
+
+        bookSearchCacheService.save("java", 10, 1, bookList);
+
+        verify(valueOperations).set(
+                eq(bookSearchCacheService.buildKey("java", 10, 1)),
+                any(BookResponseDTO.BookList.class),
+                eq(Duration.ofMinutes(10))
+        );
+    }
+
+    @Test
+    void saveStripsLikedByMeBeforeCaching() {
+        BookResponseDTO.BookList bookList = bookList(true);
+
+        bookSearchCacheService.save("java", 10, 1, bookList);
+
+        org.mockito.ArgumentCaptor<BookResponseDTO.BookList> captor =
+                org.mockito.ArgumentCaptor.forClass(BookResponseDTO.BookList.class);
+        verify(valueOperations).set(eq(bookSearchCacheService.buildKey("java", 10, 1)), captor.capture(), any(Duration.class));
+
+        assertThat(captor.getValue().getTotalResults()).isEqualTo(37);
+        assertThat(captor.getValue().getDetailInfoList())
+                .extracting(DetailInfo::isLikedByMe)
+                .containsOnly(false);
+    }
+
+    private BookResponseDTO.BookList bookList(boolean likedByMe) {
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(List.of(DetailInfo.builder()
+                        .isbn("9791169213882")
+                        .title("테스트 책")
+                        .author("테스트 저자")
+                        .imgUrl("https://example.com/book.jpg")
+                        .publisher("테스트 출판사")
+                        .description("테스트 설명")
+                        .link("https://example.com/book")
+                        .likedByMe(likedByMe)
+                        .build()))
+                .hasNext(true)
+                .currentPage(1)
+                .totalResults(37)
+                .build();
+    }
+}

--- a/src/test/java/checkmo/common/config/SentryPrivacyConfigurationTest.java
+++ b/src/test/java/checkmo/common/config/SentryPrivacyConfigurationTest.java
@@ -117,6 +117,20 @@ class SentryPrivacyConfigurationTest {
     }
 
     @Test
+    void beforeSendRemovesBookSearchKeywordAndQueryString() {
+        SentryEvent event = new SentryEvent(new RuntimeException("aladin unavailable"));
+        Request request = new Request();
+        request.setQueryString("keyword=자바&page=1&refreshToken=secret");
+        request.setUrl("https://api.checkmo.kr/api/books/search?keyword=%EC%9E%90%EB%B0%94&page=1&refreshToken=secret");
+        event.setRequest(request);
+
+        SentryEvent sanitized = beforeSendCallback.execute(event, null);
+
+        assertThat(sanitized.getRequest().getQueryString()).isNull();
+        assertThat(sanitized.getRequest().getUrl()).isEqualTo("https://api.checkmo.kr/api/books/search");
+    }
+
+    @Test
     void beforeSendIgnoresHeadersWithNullNamesOrValues() {
         SentryEvent event = new SentryEvent(new RuntimeException("unexpected"));
         Request request = new Request();

--- a/src/test/java/checkmo/member/MemberApiTest.java
+++ b/src/test/java/checkmo/member/MemberApiTest.java
@@ -1,10 +1,13 @@
 package checkmo.member;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
 
 import checkmo.support.ApiTestSupport;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -31,6 +34,45 @@ class MemberApiTest extends ApiTestSupport {
                 .then()
                 .statusCode(200)
                 .body("isSuccess", equalTo(true));
+    }
+
+    @Test
+    void additionalInfoPersistsNicknameForSignupCreatedIncompleteUser() {
+        String email = "additional-info-null-nickname@example.com";
+        String nickname = "completeinfo";
+        when(redisHashOperations.get("verification:" + email, "verified")).thenReturn(true);
+
+        ExtractableResponse<Response> signUpResponse = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("email", email, "password", "Pass123!"))
+                .when()
+                .post("/api/auth/signup")
+                .then()
+                .statusCode(200)
+                .extract();
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", signUpResponse.cookie("accessToken"))
+                .body(Map.of(
+                        "nickname", nickname,
+                        "name", "완료",
+                        "phoneNumber", "010-1234-5678",
+                        "description", "소개",
+                        "categories", List.of("COMPUTER_IT")
+                ))
+                .when()
+                .post("/api/members/additional-info")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true));
+
+        var authUser = authRepository.findByEmail(email).orElseThrow();
+        var member = memberRepository.findById(authUser.getId()).orElseThrow();
+
+        assertThat(authUser.getNickName()).isEqualTo(nickname);
+        assertThat(member.getNickName()).isEqualTo(nickname);
+        assertThat(authUser.isProfileCompleted()).isTrue();
     }
 
     @Test

--- a/src/test/java/checkmo/support/ApiTestSupport.java
+++ b/src/test/java/checkmo/support/ApiTestSupport.java
@@ -217,7 +217,7 @@ public abstract class ApiTestSupport {
                 .password(passwordEncoder.encode(rawPassword))
                 .role(role)
                 .profileCompleted(profileCompleted)
-                .nickName(nickName)
+                .nickName(profileCompleted ? nickName : null)
                 .build();
         authRepository.save(authUser);
 
@@ -226,7 +226,7 @@ public abstract class ApiTestSupport {
                 .email(email)
                 .name("테스트")
                 .phoneNumber("01012345678")
-                .nickName(profileCompleted ? nickName : "")
+                .nickName(profileCompleted ? nickName : null)
                 .description("api test fixture")
                 .build();
         memberRepository.save(member);


### PR DESCRIPTION
Closes #238

## 변경 요약
- `GET /api/books/search` 응답의 `result.totalResults` 계약을 추가했습니다.
- 알라딘 검색 성공 결과를 Redis에 10분 동안 캐싱하고, raw 검색어가 key에 노출되지 않도록 normalized 검색 조건을 해시합니다.
- 캐시 저장 전 `likedByMe`를 제거하고, cache hit/miss/Aladin success/fallback 응답 직전에 현재 회원 기준 `likedByMe`를 적용합니다.
- 검색 성공 후 `hasNext=true`이면 별도 Spring bean의 `@Async` 메서드로 다음 페이지 1개만 prefetch합니다.
- 알라딘 장애 시 캐시가 있으면 fallback 응답을 반환하고, 캐시가 없으면 기존 `BOOK_500` 실패 경로를 유지합니다.
- 외부 API 실패는 Sentry 캡처가 유지되도록 하고, 검색어/query string/인증·토큰·쿠키류가 로그나 Sentry로 흘러가지 않도록 privacy 테스트를 보강했습니다.

## 테스트 결과
- PASS: `./gradlew test --tests checkmo.book.BookStoryNewsReportNotificationImageApiTest --tests checkmo.book.internal.converter.BookConverterTest --tests checkmo.book.internal.service.query.BookSearchCacheServiceTest --tests checkmo.book.internal.service.query.AladinApiServiceTest --tests checkmo.book.internal.service.query.AladinSearchPrefetchServiceTest --tests checkmo.common.config.SentryPrivacyConfigurationTest`
- PASS: `./gradlew test --tests checkmo.common.apiPayload.exception.SentryExpectedErrorExclusionTest --tests checkmo.CheckmoApplicationTests`
- PASS: `./gradlew cleanTest test`
- PASS: `git diff --check`
- PASS: `./gradlew compileJava`

RED/GREEN 증거는 `.omo/evidence/aladin-search-cache-prefetch/` 아래에 남겼습니다.

## 수동 QA 결과
- 실제 로컬 앱/Redis/알라딘 키/인증 쿠키 기반 curl QA는 `.env`를 읽지 않고 안전하게 구성할 수 없어 수행하지 못했습니다.
- 대신 `BookStoryNewsReportNotificationImageApiTest`에서 HTTP 응답 계약으로 `result.totalResults` 노출을 검증했습니다.
- 알라딘 장애 fallback 및 no-cache `BOOK_500` 경로는 `AladinApiServiceTest`에서 단위 검증했습니다.

## Redis 검증 결과
- `BookSearchCacheServiceTest`에서 key normalization, raw keyword 비노출, page/maxResults 분리, TTL 10분을 검증했습니다.
- 캐시 저장 값에서 `likedByMe=true`가 제거되고 `totalResults`가 보존되는 것을 검증했습니다.
- 실제 Redis CLI 검증은 외부 실행 환경과 secret을 요구하므로 수행하지 않았습니다.

## Sentry/PII 안전성 확인
- `SentryPrivacyConfigurationTest`로 `/api/books/search` 이벤트에서 query string/request body가 제거되는지 검증했습니다.
- `SentryExpectedErrorExclusionTest`로 기존 기대 예외 제외 정책이 유지되는지 검증했습니다.
- `AladinApiServiceTest`와 `AladinSearchPrefetchServiceTest`로 fallback/prefetch 실패 경로에서 외부 API 예외 캡처가 유지되는지 검증했습니다.
- 로그 경로는 raw query string, 검색어, `ttbkey`, 인증/쿠키/JWT/refresh token/password/verification-code/request body를 남기지 않도록 제한했습니다.

## 롤백 방법
- 코드 롤백: 이 PR의 커밋을 revert한 뒤 아래 검증을 실행합니다.
  - `./gradlew test --tests checkmo.book.BookStoryNewsReportNotificationImageApiTest`
  - `./gradlew test --tests checkmo.common.apiPayload.exception.SentryExpectedErrorExclusionTest`
  - `./gradlew test --tests checkmo.CheckmoApplicationTests`
- Redis 정리: 검색 캐시는 versioned prefix를 쓰므로 `book:search:v1:*` key만 삭제합니다.
  - `redis-cli --scan --pattern 'book:search:v1:*' | xargs -r redis-cli DEL`
- 운영 중 prefetch만 문제가 되면 `AladinApiService`의 prefetch 호출만 되돌리고 직접 검색 캐시/fallback 경로는 유지한 뒤 cache/fallback 테스트를 재실행합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search results include total-results count and preserve pagination metadata.
  * Results are cached and next-page prefetching speeds browsing.
  * “Liked by me” state is applied to search responses shown to users.

* **Bug Fixes**
  * Improved error handling and sanitized logging; cached fallbacks used on remote failures.
  * Empty search responses now report zero total results.
  * Nickname handling tightened: blank nicknames are rejected where required.

* **Tests**
  * Expanded tests for search flow, caching, prefetching, failure fallbacks, sanitization, DTO conversion, and nickname flows.

* **Chores**
  * DB migration to allow NULL nicknames and normalize existing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->