### PR TITLE
fix(auth): 미완성 프로필 이미지 업로드 허용

### DIFF
--- a/src/main/java/checkmo/authentication/internal/security/auth/ProfileCompletionAuthorizationFilter.java
+++ b/src/main/java/checkmo/authentication/internal/security/auth/ProfileCompletionAuthorizationFilter.java
@@ -28,7 +28,7 @@ public class ProfileCompletionAuthorizationFilter extends OncePerRequestFilter {
             "/api/v1/members/additional-info",
             "/api/v1/auth/redirect/oauth2",
             "/api/v1/members/check-nickname",
-            "/api/v1/s3/image/upload-url",
+            "/api/v1/image/PROFILE/upload-url",
             "/swagger-ui/**",
             "/v3/api-docs/**"
     );

--- a/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
+++ b/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
@@ -423,6 +423,16 @@ class BookStoryNewsReportNotificationImageApiTest extends ApiTestSupport {
                 .when()
                 .post("/api/v1/image/{type}/upload-url", "PROFILE")
                 .then()
+                .statusCode(200)
+                .body("result.imageUrl", equalTo("https://cdn.example.com/profile.png"));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .cookie(accessTokenCookie(incomplete))
+                .body(Map.of("originalFileName", "club.png", "contentType", "image/png"))
+                .when()
+                .post("/api/v1/image/{type}/upload-url", "CLUB")
+                .then()
                 .statusCode(403);
     }
 


### PR DESCRIPTION
## Summary
- ProfileCompletionAuthorizationFilter의 이미지 업로드 예외 경로를 실제 PROFILE 업로드 URL 경로로 수정했습니다.
- profileCompleted=false 회원은 PROFILE upload-url만 발급받고, CLUB upload-url은 계속 403으로 막히도록 회귀 테스트를 보강했습니다.

## Tests
- ./gradlew test --tests checkmo.book.BookStoryNewsReportNotificationImageApiTest.imageUploadUrlValidatesAuthenticationProfileAndFileType
- ./gradlew test --tests checkmo.book.BookStoryNewsReportNotificationImageApiTest
- git diff --check

Closes #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected profile image upload endpoint path with proper authentication validation enforcement for incomplete user profiles.

* **Tests**
  * Added test coverage verifying authentication and file type validation for profile image upload operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->