### PR TITLE
fix(book): 추천책 갱신 실패 복구 흐름 강화

### DIFF
--- a/src/main/java/checkmo/book/internal/RecommendationLogSanitizer.java
+++ b/src/main/java/checkmo/book/internal/RecommendationLogSanitizer.java
@@ -6,8 +6,17 @@ public final class RecommendationLogSanitizer {
 
     private static final int LOG_MESSAGE_MAX_LENGTH = 500;
     private static final Pattern URL_QUERY_PARAMETER_PATTERN = Pattern.compile("([?&][^=&#\\s]+)=([^&#\\s]*)");
+    private static final String SENSITIVE_FIELD_NAMES =
+            "ttbkey|query|keyword|auth|authorization|cookie|jwt|accessToken|access_token|refreshToken|"
+                    + "refresh_token|key|secret|password|verification(?:[-_]?|\\s+)code";
+    private static final Pattern QUOTED_SENSITIVE_LOG_FIELD_PATTERN = Pattern.compile(
+            "(?i)(\"?\\b(?:" + SENSITIVE_FIELD_NAMES + ")\\b\"?\\s*[:=]\\s*\")(?:Bearer\\s+)?[^\"]*(\")"
+    );
+    private static final Pattern UNTERMINATED_QUOTED_SENSITIVE_LOG_FIELD_PATTERN = Pattern.compile(
+            "(?i)(\"?\\b(?:" + SENSITIVE_FIELD_NAMES + ")\\b\"?\\s*[:=]\\s*\")(?:Bearer\\s+)?[^\"\\r\\n]*?(?=(?:[,;]\\s*[^=:\\s]+\\s*[=:])|$)"
+    );
     private static final Pattern SENSITIVE_LOG_FIELD_PATTERN = Pattern.compile(
-            "(?i)\\b(ttbkey|query|keyword|auth|authorization|cookie|jwt|accessToken|refreshToken|refresh_token|password|verification(?:[-_]?|\\s+)code)\\b(\\s*[:=]\\s*)(?:Bearer\\s+)?[^&;,\\s]+"
+            "(?i)(\"?\\b(?:" + SENSITIVE_FIELD_NAMES + ")\\b\"?\\s*[:=]\\s*)(?:Bearer\\s+)?[^\"&;,\\s]+"
     );
 
     private RecommendationLogSanitizer() {
@@ -19,7 +28,12 @@ public final class RecommendationLogSanitizer {
         }
 
         String sanitizedUrlParameters = URL_QUERY_PARAMETER_PATTERN.matcher(value).replaceAll("$1=***");
-        String sanitizedFields = SENSITIVE_LOG_FIELD_PATTERN.matcher(sanitizedUrlParameters).replaceAll("$1$2***");
+        String sanitizedQuotedFields = QUOTED_SENSITIVE_LOG_FIELD_PATTERN.matcher(sanitizedUrlParameters)
+                .replaceAll("$1***$2");
+        String sanitizedUnterminatedQuotedFields =
+                UNTERMINATED_QUOTED_SENSITIVE_LOG_FIELD_PATTERN.matcher(sanitizedQuotedFields).replaceAll("$1***");
+        String sanitizedFields = SENSITIVE_LOG_FIELD_PATTERN.matcher(sanitizedUnterminatedQuotedFields)
+                .replaceAll("$1***");
         if (sanitizedFields.length() <= LOG_MESSAGE_MAX_LENGTH) {
             return sanitizedFields;
         }

--- a/src/main/java/checkmo/book/internal/RecommendationLogSanitizer.java
+++ b/src/main/java/checkmo/book/internal/RecommendationLogSanitizer.java
@@ -1,0 +1,29 @@
+package checkmo.book.internal;
+
+import java.util.regex.Pattern;
+
+public final class RecommendationLogSanitizer {
+
+    private static final int LOG_MESSAGE_MAX_LENGTH = 500;
+    private static final Pattern URL_QUERY_PARAMETER_PATTERN = Pattern.compile("([?&][^=&#\\s]+)=([^&#\\s]*)");
+    private static final Pattern SENSITIVE_LOG_FIELD_PATTERN = Pattern.compile(
+            "(?i)\\b(ttbkey|query|keyword|auth|authorization|cookie|jwt|accessToken|refreshToken|refresh_token|password|verification(?:[-_]?|\\s+)code)\\b(\\s*[:=]\\s*)(?:Bearer\\s+)?[^&;,\\s]+"
+    );
+
+    private RecommendationLogSanitizer() {
+    }
+
+    public static String sanitize(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String sanitizedUrlParameters = URL_QUERY_PARAMETER_PATTERN.matcher(value).replaceAll("$1=***");
+        String sanitizedFields = SENSITIVE_LOG_FIELD_PATTERN.matcher(sanitizedUrlParameters).replaceAll("$1$2***");
+        if (sanitizedFields.length() <= LOG_MESSAGE_MAX_LENGTH) {
+            return sanitizedFields;
+        }
+
+        return sanitizedFields.substring(0, LOG_MESSAGE_MAX_LENGTH) + "...";
+    }
+}

--- a/src/main/java/checkmo/book/internal/config/properties/AladinProperties.java
+++ b/src/main/java/checkmo/book/internal/config/properties/AladinProperties.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import java.time.Duration;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +24,8 @@ public class AladinProperties {
     private Auth auth = new Auth();
     @Valid
     private Search search = new Search();
+    @Valid
+    private Recommendation recommendation = new Recommendation();
 
     @Getter
     @Setter
@@ -75,5 +79,44 @@ public class AladinProperties {
         @Positive(message = "타임아웃은 양수여야 합니다")
         @Min(value = 1000, message = "타임아웃은 1000ms 이상이어야 합니다")
         private int timeoutMs;
+    }
+
+    @Getter
+    @Setter
+    public static class Recommendation {
+        @Valid
+        private Refresh refresh = new Refresh();
+    }
+
+    @Getter
+    @Setter
+    public static class Refresh {
+        @Valid
+        private Retry retry = new Retry();
+        @Valid
+        private Background background = new Background();
+    }
+
+    @Getter
+    @Setter
+    public static class Retry {
+        @Min(value = 1, message = "추천 책 갱신 재시도 횟수는 1 이상이어야 합니다")
+        private int attempts = 3;
+
+        @DurationMin(millis = 1, message = "추천 책 갱신 초기 backoff는 양수여야 합니다")
+        private Duration initialBackoff = Duration.ofSeconds(1);
+
+        @Positive(message = "추천 책 갱신 backoff 배수는 양수여야 합니다")
+        private double multiplier = 2;
+
+        @DurationMin(millis = 1, message = "추천 책 갱신 최대 backoff는 양수여야 합니다")
+        private Duration maxBackoff = Duration.ofSeconds(5);
+    }
+
+    @Getter
+    @Setter
+    public static class Background {
+        @DurationMin(millis = 1, message = "추천 책 갱신 background fixed delay는 양수여야 합니다")
+        private Duration fixedDelay = Duration.ofMinutes(5);
     }
 }

--- a/src/main/java/checkmo/book/internal/config/properties/AladinProperties.java
+++ b/src/main/java/checkmo/book/internal/config/properties/AladinProperties.java
@@ -1,6 +1,7 @@
 package checkmo.book.internal.config.properties;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -101,12 +102,13 @@ public class AladinProperties {
     @Setter
     public static class Retry {
         @Min(value = 1, message = "추천 책 갱신 재시도 횟수는 1 이상이어야 합니다")
+        @Max(value = 10, message = "추천 책 갱신 재시도 횟수는 10 이하여야 합니다")
         private int attempts = 3;
 
         @DurationMin(millis = 1, message = "추천 책 갱신 초기 backoff는 양수여야 합니다")
         private Duration initialBackoff = Duration.ofSeconds(1);
 
-        @Positive(message = "추천 책 갱신 backoff 배수는 양수여야 합니다")
+        @DecimalMin(value = "1.0", inclusive = true, message = "추천 책 갱신 backoff 배수는 1 이상이어야 합니다")
         private double multiplier = 2;
 
         @DurationMin(millis = 1, message = "추천 책 갱신 최대 backoff는 양수여야 합니다")

--- a/src/main/java/checkmo/book/internal/scheduler/BookRecommendationScheduler.java
+++ b/src/main/java/checkmo/book/internal/scheduler/BookRecommendationScheduler.java
@@ -1,9 +1,11 @@
 package checkmo.book.internal.scheduler;
 
+import checkmo.book.internal.RecommendationLogSanitizer;
 import checkmo.book.internal.service.BookRecommendationService;
 import checkmo.book.web.dto.BookResponseDTO;
 import checkmo.common.monitoring.SentryCaptureClient;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -18,25 +20,42 @@ public class BookRecommendationScheduler {
 
     private final BookRecommendationService recommendationService;
     private final SentryCaptureClient sentryCaptureClient;
+    private final AtomicBoolean refreshInProgress = new AtomicBoolean(false);
 
     @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
     public void updateDailyRecommendedBooks() {
         log.info("일일 추천 책 갱신 시작");
-        retrieveAndSaveRecommendedBooks();
+        guardedRefreshRecommendedBooks();
+    }
+
+    @Scheduled(fixedDelayString = "${aladin.api.recommendation.refresh.background.fixed-delay}")
+    public void retryRecommendedBooksRefresh() {
+        if (recommendationService.hasRecommendedBooks() && !recommendationService.isRecommendedBooksStale()) {
+            log.debug("추천 책 캐시가 최신 상태라 background retry를 건너뜁니다.");
+            return;
+        }
+
+        log.info("추천 책 캐시가 없거나 오래되어 background retry 갱신 시작");
+        guardedRefreshRecommendedBooks();
     }
 
     @EventListener(ApplicationReadyEvent.class)
     public void initializeRecommendedBooks() {
         if (!recommendationService.hasRecommendedBooks() || recommendationService.isRecommendedBooksStale()) {
             log.info("서버 시작 시 Redis에 추천 책 데이터가 없거나 오래됨. 알라딘에 요청 시작");
-            retrieveAndSaveRecommendedBooks();
+            guardedRefreshRecommendedBooks();
             return;
         }
 
         log.info("서버 시작 시 Redis에 최신 추천 책 데이터가 존재");
     }
 
-    private void retrieveAndSaveRecommendedBooks() {
+    private void guardedRefreshRecommendedBooks() {
+        if (!refreshInProgress.compareAndSet(false, true)) {
+            log.info("추천 책 갱신이 이미 진행 중이라 이번 요청을 건너뜁니다.");
+            return;
+        }
+
         try {
             BookResponseDTO.BookList refreshedBooks = recommendationService.refreshDailyRecommendedBooks();
             if (isEmpty(refreshedBooks)) {
@@ -46,8 +65,16 @@ public class BookRecommendationScheduler {
 
             log.info("추천 책 갱신 완료");
         } catch (Exception e) {
-            log.error("추천 책 갱신 중 예기치 못한 오류 발생", e);
+            log.error(
+                    "추천 책 갱신 중 예기치 못한 오류 발생 exceptionType={} exceptionMessage={} causeType={} causeMessage={}",
+                    e.getClass().getName(),
+                    RecommendationLogSanitizer.sanitize(e.getMessage()),
+                    safeCauseType(e),
+                    safeCauseMessage(e)
+            );
             sentryCaptureClient.captureException(e);
+        } finally {
+            refreshInProgress.set(false);
         }
     }
 
@@ -58,5 +85,23 @@ public class BookRecommendationScheduler {
 
         List<BookResponseDTO.DetailInfo> books = bookList.getDetailInfoList();
         return books == null || books.isEmpty();
+    }
+
+    private String safeCauseType(Exception exception) {
+        Throwable cause = exception.getCause();
+        if (cause == null) {
+            return null;
+        }
+
+        return cause.getClass().getName();
+    }
+
+    private String safeCauseMessage(Exception exception) {
+        Throwable cause = exception.getCause();
+        if (cause == null) {
+            return null;
+        }
+
+        return RecommendationLogSanitizer.sanitize(cause.getMessage());
     }
 }

--- a/src/main/java/checkmo/book/internal/scheduler/BookRecommendationScheduler.java
+++ b/src/main/java/checkmo/book/internal/scheduler/BookRecommendationScheduler.java
@@ -22,7 +22,7 @@ public class BookRecommendationScheduler {
     private final SentryCaptureClient sentryCaptureClient;
     private final AtomicBoolean refreshInProgress = new AtomicBoolean(false);
 
-    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 6 * * ?", zone = "Asia/Seoul")
     public void updateDailyRecommendedBooks() {
         log.info("일일 추천 책 갱신 시작");
         guardedRefreshRecommendedBooks();

--- a/src/main/java/checkmo/book/internal/service/AladinRecommendationRefreshClient.java
+++ b/src/main/java/checkmo/book/internal/service/AladinRecommendationRefreshClient.java
@@ -1,0 +1,126 @@
+package checkmo.book.internal.service;
+
+import checkmo.book.internal.config.properties.AladinProperties;
+import checkmo.book.internal.config.properties.AladinProperties.Retry;
+import checkmo.book.internal.exception.BookErrorStatus;
+import checkmo.book.internal.exception.BookException;
+import checkmo.book.internal.service.query.AladinApiService;
+import checkmo.book.web.dto.BookResponseDTO;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.backoff.Sleeper;
+import org.springframework.retry.context.RetryContextSupport;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@Service
+public class AladinRecommendationRefreshClient {
+
+    private final AladinApiService aladinApiService;
+    private final RetryTemplate retryTemplate;
+
+    @Autowired
+    public AladinRecommendationRefreshClient(
+            AladinApiService aladinApiService,
+            AladinProperties aladinProperties
+    ) {
+        this(aladinApiService, aladinProperties, Thread::sleep);
+    }
+
+    AladinRecommendationRefreshClient(
+            AladinApiService aladinApiService,
+            AladinProperties aladinProperties,
+            Sleeper sleeper
+    ) {
+        this.aladinApiService = aladinApiService;
+        this.retryTemplate = buildRetryTemplate(aladinProperties.getRecommendation().getRefresh().getRetry(), sleeper);
+    }
+
+    public BookResponseDTO.BookList retrieveRecommendedBooks() {
+        return retryTemplate.execute(context -> {
+            if (context.getRetryCount() > 0) {
+                log.warn("알라딘 추천 책 갱신 재시도. attempt={}", context.getRetryCount() + 1);
+            }
+            return aladinApiService.retrieveRecommendedBooks();
+        });
+    }
+
+    private RetryTemplate buildRetryTemplate(Retry retry, Sleeper sleeper) {
+        RetryTemplate template = new RetryTemplate();
+        template.setRetryPolicy(new TransientAladinRetryPolicy(retry.getAttempts()));
+
+        ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+        backOffPolicy.setInitialInterval(retry.getInitialBackoff().toMillis());
+        backOffPolicy.setMultiplier(retry.getMultiplier());
+        backOffPolicy.setMaxInterval(retry.getMaxBackoff().toMillis());
+        backOffPolicy.setSleeper(sleeper);
+        template.setBackOffPolicy(backOffPolicy);
+
+        return template;
+    }
+
+    private static final class TransientAladinRetryPolicy implements RetryPolicy {
+
+        private final int maxAttempts;
+
+        private TransientAladinRetryPolicy(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+        }
+
+        @Override
+        public boolean canRetry(RetryContext context) {
+            Throwable lastThrowable = context.getLastThrowable();
+            return context.getRetryCount() < maxAttempts
+                    && (lastThrowable == null || isRetryableAladinAccessFailure(lastThrowable));
+        }
+
+        @Override
+        public RetryContext open(RetryContext parent) {
+            return new RetryContextSupport(parent);
+        }
+
+        @Override
+        public void close(RetryContext context) {
+        }
+
+        @Override
+        public void registerThrowable(RetryContext context, Throwable throwable) {
+            ((RetryContextSupport) context).registerThrowable(throwable);
+        }
+
+        private boolean isRetryableAladinAccessFailure(Throwable throwable) {
+            Throwable current = throwable;
+            boolean wrappedByAladinBookException = false;
+
+            while (current != null) {
+                if (current instanceof IllegalArgumentException) {
+                    return false;
+                }
+
+                if (current instanceof BookException bookException) {
+                    if (bookException.getErrorCode() != BookErrorStatus.ALADIN_API_ERROR) {
+                        return false;
+                    }
+                    wrappedByAladinBookException = true;
+                    if (current.getCause() == null) {
+                        return false;
+                    }
+                } else if (current instanceof RestClientException || current instanceof IOException) {
+                    return true;
+                } else if (!wrappedByAladinBookException) {
+                    return false;
+                }
+
+                current = current.getCause();
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
+++ b/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
@@ -104,7 +104,7 @@ public class BookRecommendationService {
             throw new BookException(BookErrorStatus.ALADIN_API_ERROR);
         }
 
-        var booksForToday = allBooks.subList(startIndex, startIndex + 4);
+        List<DetailInfo> booksForToday = List.copyOf(allBooks.subList(startIndex, startIndex + 4));
         saveRecommendedBooks(booksForToday);
 
         return BookResponseDTO.BookList.builder()

--- a/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
+++ b/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
@@ -1,5 +1,8 @@
 package checkmo.book.internal.service;
 
+import checkmo.book.internal.RecommendationLogSanitizer;
+import checkmo.book.internal.exception.BookErrorStatus;
+import checkmo.book.internal.exception.BookException;
 import checkmo.book.internal.service.query.AladinApiService;
 import checkmo.book.internal.util.DayOfWeekUtils;
 import checkmo.book.web.dto.BookResponseDTO;
@@ -23,57 +26,98 @@ public class BookRecommendationService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private final AladinApiService aladinApiService;
+    private final AladinRecommendationRefreshClient recommendationRefreshClient;
     private final SentryCaptureClient sentryCaptureClient;
 
     public BookResponseDTO.BookList retrieveRecommendedBooks(String memberId) {
-        try {
-            Object cachedData = redisTemplate.opsForValue().get(REDIS_KEY);
+        BookResponseDTO.BookList cachedBooks = retrieveUsableCachedBooks();
 
-            if (cachedData instanceof BookResponseDTO.BookList recommendedBooks && !isRecommendedBooksStale()) {
-                return aladinApiService.applyLikedByMe(recommendedBooks, memberId);
+        if (cachedBooks != null && !isRecommendedBooksStale()) {
+            return aladinApiService.applyLikedByMe(cachedBooks, memberId);
+        }
+
+        try {
+            BookResponseDTO.BookList refreshedBooks = retrieveAndSaveRecommendedBooksFromAladin();
+            return aladinApiService.applyLikedByMe(refreshedBooks, memberId);
+        } catch (Exception e) {
+            if (cachedBooks != null) {
+                log.warn(
+                        "추천 책 갱신 실패로 stale 캐시를 반환합니다. exceptionType={}, errorStatus={}, message={}, causeType={}, causeMessage={}",
+                        e.getClass().getName(),
+                        safeErrorStatus(e),
+                        RecommendationLogSanitizer.sanitize(e.getMessage()),
+                        safeCauseType(e),
+                        safeCauseMessage(e)
+                );
+                sentryCaptureClient.captureException(e);
+                return aladinApiService.applyLikedByMe(cachedBooks, memberId);
             }
 
-            return aladinApiService.applyLikedByMe(refreshDailyRecommendedBooks(), memberId);
-
-        } catch (Exception e) {
-            log.error("Redis에서 추천 책 조회 중 오류 발생. API에서 데이터를 가져오기.", e);
-            return aladinApiService.applyLikedByMe(refreshDailyRecommendedBooks(), memberId);
+            throw new BookException(BookErrorStatus.ALADIN_API_ERROR, e);
         }
     }
 
     public BookResponseDTO.BookList refreshDailyRecommendedBooks() {
         try {
-            BookResponseDTO.BookList bookList = aladinApiService.retrieveRecommendedBooks();
-
-            if (bookList == null || bookList.getDetailInfoList() == null || bookList.getDetailInfoList().isEmpty()) {
-                log.error("알라딘 API에서 추천 책을 가져오지 못했습니다.");
-                return createEmptyBookList();
-            }
-
-            // 요일에 따라 4권만 저장
-            int startIndex = DayOfWeekUtils.calculateStartIndexByDayOfWeek();
-            var allBooks = bookList.getDetailInfoList();
-
-            if (allBooks.size() < startIndex + 4) {
-                log.error("추천 책 목록 부족, 전체: {}개, 필요: {}개", allBooks.size(), startIndex + 4);
-                return createEmptyBookList();
-            }
-
-            var booksForToday = allBooks.subList(startIndex, startIndex + 4);
-            saveRecommendedBooks(booksForToday);
-
-            // 저장한 4권을 BookList로 감싸서 반환
-            return BookResponseDTO.BookList.builder()
-                    .detailInfoList(booksForToday)
-                    .hasNext(false)
-                    .currentPage(null)
-                    .build();
-
+            return retrieveAndSaveRecommendedBooksFromAladin();
         } catch (Exception e) {
-            log.error("API에서 추천 책 가져오기 중 오류", e);
+            log.error(
+                    "API에서 추천 책 가져오기 중 오류. exceptionType={}, errorStatus={}, message={}, causeType={}, causeMessage={}",
+                    e.getClass().getName(),
+                    safeErrorStatus(e),
+                    RecommendationLogSanitizer.sanitize(e.getMessage()),
+                    safeCauseType(e),
+                    safeCauseMessage(e)
+            );
             sentryCaptureClient.captureException(e);
             return createEmptyBookList();
         }
+    }
+
+    private BookResponseDTO.BookList retrieveUsableCachedBooks() {
+        try {
+            Object cachedData = redisTemplate.opsForValue().get(REDIS_KEY);
+
+            if (cachedData instanceof BookResponseDTO.BookList bookList && isUsableBookList(bookList)) {
+                return bookList;
+            }
+        } catch (Exception e) {
+            log.error("Redis에서 추천 책 조회 중 오류 발생. API에서 데이터를 가져오기.", e);
+        }
+
+        return null;
+    }
+
+    private BookResponseDTO.BookList retrieveAndSaveRecommendedBooksFromAladin() {
+        BookResponseDTO.BookList bookList = recommendationRefreshClient.retrieveRecommendedBooks();
+
+        if (!isUsableBookList(bookList)) {
+            log.error("알라딘 API에서 추천 책을 가져오지 못했습니다.");
+            throw new BookException(BookErrorStatus.ALADIN_API_ERROR);
+        }
+
+        int startIndex = DayOfWeekUtils.calculateStartIndexByDayOfWeek();
+        var allBooks = bookList.getDetailInfoList();
+
+        if (allBooks.size() < startIndex + 4) {
+            log.error("추천 책 목록 부족, 전체: {}개, 필요: {}개", allBooks.size(), startIndex + 4);
+            throw new BookException(BookErrorStatus.ALADIN_API_ERROR);
+        }
+
+        var booksForToday = allBooks.subList(startIndex, startIndex + 4);
+        saveRecommendedBooks(booksForToday);
+
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(booksForToday)
+                .hasNext(false)
+                .currentPage(null)
+                .build();
+    }
+
+    private boolean isUsableBookList(BookResponseDTO.BookList bookList) {
+        return bookList != null
+                && bookList.getDetailInfoList() != null
+                && !bookList.getDetailInfoList().isEmpty();
     }
 
     private void saveRecommendedBooks(List<DetailInfo> books) {
@@ -128,5 +172,31 @@ public class BookRecommendationService {
                 .hasNext(false)
                 .currentPage(null)
                 .build();
+    }
+
+    private String safeErrorStatus(Exception exception) {
+        if (exception instanceof BookException bookException) {
+            return bookException.getErrorReasonHttpStatus().getCode();
+        }
+
+        return null;
+    }
+
+    private String safeCauseType(Exception exception) {
+        Throwable cause = exception.getCause();
+        if (cause == null) {
+            return null;
+        }
+
+        return cause.getClass().getName();
+    }
+
+    private String safeCauseMessage(Exception exception) {
+        Throwable cause = exception.getCause();
+        if (cause == null) {
+            return null;
+        }
+
+        return RecommendationLogSanitizer.sanitize(cause.getMessage());
     }
 }

--- a/src/main/resources/application-aladin.yml
+++ b/src/main/resources/application-aladin.yml
@@ -16,3 +16,12 @@ aladin:
       max-results: 10
       item-id-type: ISBN13
       timeout-ms: 5000
+    recommendation:
+      refresh:
+        retry:
+          attempts: 3
+          initial-backoff: 1s
+          multiplier: 2
+          max-backoff: 5s
+        background:
+          fixed-delay: 5m

--- a/src/test/java/checkmo/book/AladinConfigurationTest.java
+++ b/src/test/java/checkmo/book/AladinConfigurationTest.java
@@ -17,4 +17,40 @@ class AladinConfigurationTest {
                 .contains("base: https://www.aladin.co.kr/ttb/api")
                 .doesNotContain("base: http://www.aladin.co.kr/ttb/api");
     }
+
+    @Test
+    void recommendationRefreshImmediateRetryDefaultsAreBoundedAndNonSecret() throws IOException {
+        String configuration = Files.readString(Path.of("src/main/resources/application-aladin.yml"));
+
+        assertThat(configuration)
+                .contains("recommendation:")
+                .contains("refresh:")
+                .contains("retry:")
+                .contains("attempts: 3")
+                .contains("initial-backoff: 1s")
+                .contains("multiplier: 2")
+                .contains("max-backoff: 5s");
+    }
+
+    @Test
+    void recommendationRefreshBackgroundRetryUsesFiveMinuteFixedDelay() throws IOException {
+        String configuration = Files.readString(Path.of("src/main/resources/application-aladin.yml"));
+
+        assertThat(configuration)
+                .contains("background:")
+                .contains("fixed-delay: 5m");
+    }
+
+    @Test
+    void recommendationCacheSaveDoesNotUseRedisTtl() throws IOException {
+        String service = Files.readString(
+                Path.of("src/main/java/checkmo/book/internal/service/BookRecommendationService.java"));
+
+        assertThat(service)
+                .contains("book:recommendations:daily")
+                .contains("redisTemplate.opsForValue().set(REDIS_KEY, bookList);")
+                .contains("redisTemplate.opsForValue().set(REDIS_UPDATED_AT_KEY, LocalDate.now().toString());")
+                .doesNotContain("redisTemplate.opsForValue().set(REDIS_KEY, bookList,")
+                .doesNotContain("Duration.of");
+    }
 }

--- a/src/test/java/checkmo/book/AladinConfigurationTest.java
+++ b/src/test/java/checkmo/book/AladinConfigurationTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import checkmo.book.internal.config.properties.AladinProperties;
 import jakarta.validation.Validation;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -83,7 +82,8 @@ class AladinConfigurationTest {
     }
 
     private Map<String, Object> aladinApiConfiguration() throws IOException {
-        try (var input = new FileInputStream("src/main/resources/application-aladin.yml")) {
+        try (var input = getClass().getClassLoader().getResourceAsStream("application-aladin.yml")) {
+            assertThat(input).isNotNull();
             Map<String, Object> configuration = new Yaml().load(input);
             Map<String, Object> aladin = nestedMap(configuration, "aladin");
             return nestedMap(aladin, "api");

--- a/src/test/java/checkmo/book/AladinConfigurationTest.java
+++ b/src/test/java/checkmo/book/AladinConfigurationTest.java
@@ -2,55 +2,96 @@ package checkmo.book;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import checkmo.book.internal.config.properties.AladinProperties;
+import jakarta.validation.Validation;
+import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
 
 class AladinConfigurationTest {
 
     @Test
     void aladinApiBaseUrlUsesHttps() throws IOException {
-        String configuration = Files.readString(Path.of("src/main/resources/application-aladin.yml"));
+        Map<String, Object> api = aladinApiConfiguration();
+        Map<String, Object> url = nestedMap(api, "url");
 
-        assertThat(configuration)
-                .contains("base: https://www.aladin.co.kr/ttb/api")
-                .doesNotContain("base: http://www.aladin.co.kr/ttb/api");
+        assertThat(url.get("base"))
+                .isEqualTo("https://www.aladin.co.kr/ttb/api");
     }
 
     @Test
     void recommendationRefreshImmediateRetryDefaultsAreBoundedAndNonSecret() throws IOException {
-        String configuration = Files.readString(Path.of("src/main/resources/application-aladin.yml"));
+        Map<String, Object> retry = recommendationRetryConfiguration();
 
-        assertThat(configuration)
-                .contains("recommendation:")
-                .contains("refresh:")
-                .contains("retry:")
-                .contains("attempts: 3")
-                .contains("initial-backoff: 1s")
-                .contains("multiplier: 2")
-                .contains("max-backoff: 5s");
+        assertThat(retry)
+                .containsEntry("attempts", 3)
+                .containsEntry("initial-backoff", "1s")
+                .containsEntry("multiplier", 2)
+                .containsEntry("max-backoff", "5s");
     }
 
     @Test
     void recommendationRefreshBackgroundRetryUsesFiveMinuteFixedDelay() throws IOException {
-        String configuration = Files.readString(Path.of("src/main/resources/application-aladin.yml"));
+        Map<String, Object> api = aladinApiConfiguration();
+        Map<String, Object> recommendation = nestedMap(api, "recommendation");
+        Map<String, Object> refresh = nestedMap(recommendation, "refresh");
+        Map<String, Object> background = nestedMap(refresh, "background");
 
-        assertThat(configuration)
-                .contains("background:")
-                .contains("fixed-delay: 5m");
+        assertThat(background)
+                .containsEntry("fixed-delay", "5m");
     }
 
     @Test
-    void recommendationCacheSaveDoesNotUseRedisTtl() throws IOException {
-        String service = Files.readString(
-                Path.of("src/main/java/checkmo/book/internal/service/BookRecommendationService.java"));
+    void recommendationRefreshRetryAttemptsRejectsValuesAboveTen() {
+        var retry = new AladinProperties.Retry();
+        retry.setAttempts(11);
 
-        assertThat(service)
-                .contains("book:recommendations:daily")
-                .contains("redisTemplate.opsForValue().set(REDIS_KEY, bookList);")
-                .contains("redisTemplate.opsForValue().set(REDIS_UPDATED_AT_KEY, LocalDate.now().toString());")
-                .doesNotContain("redisTemplate.opsForValue().set(REDIS_KEY, bookList,")
-                .doesNotContain("Duration.of");
+        var violations = Validation.buildDefaultValidatorFactory()
+                .getValidator()
+                .validate(retry);
+
+        assertThat(violations)
+                .anySatisfy(violation -> {
+                    assertThat(violation.getPropertyPath().toString()).isEqualTo("attempts");
+                    assertThat(violation.getMessage()).isEqualTo("추천 책 갱신 재시도 횟수는 10 이하여야 합니다");
+                });
+    }
+
+    @Test
+    void recommendationRefreshRetryMultiplierRejectsValuesBelowOne() {
+        var retry = new AladinProperties.Retry();
+        retry.setMultiplier(0.5);
+
+        var violations = Validation.buildDefaultValidatorFactory()
+                .getValidator()
+                .validate(retry);
+
+        assertThat(violations)
+                .anySatisfy(violation -> {
+                    assertThat(violation.getPropertyPath().toString()).isEqualTo("multiplier");
+                    assertThat(violation.getMessage()).isEqualTo("추천 책 갱신 backoff 배수는 1 이상이어야 합니다");
+                });
+    }
+
+    private Map<String, Object> recommendationRetryConfiguration() throws IOException {
+        Map<String, Object> api = aladinApiConfiguration();
+        Map<String, Object> recommendation = nestedMap(api, "recommendation");
+        Map<String, Object> refresh = nestedMap(recommendation, "refresh");
+        return nestedMap(refresh, "retry");
+    }
+
+    private Map<String, Object> aladinApiConfiguration() throws IOException {
+        try (var input = new FileInputStream("src/main/resources/application-aladin.yml")) {
+            Map<String, Object> configuration = new Yaml().load(input);
+            Map<String, Object> aladin = nestedMap(configuration, "aladin");
+            return nestedMap(aladin, "api");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> nestedMap(Map<String, Object> source, String key) {
+        return (Map<String, Object>) source.get(key);
     }
 }

--- a/src/test/java/checkmo/book/BookRecommendationApiTest.java
+++ b/src/test/java/checkmo/book/BookRecommendationApiTest.java
@@ -1,0 +1,115 @@
+package checkmo.book;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import checkmo.book.internal.service.AladinRecommendationRefreshClient;
+import checkmo.book.internal.service.query.AladinApiService;
+import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import checkmo.support.ApiTestSupport;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class BookRecommendationApiTest extends ApiTestSupport {
+
+    private static final String REDIS_KEY = "book:recommendations:daily";
+    private static final String REDIS_UPDATED_AT_KEY = "book:recommendations:daily:updated_at";
+
+    @MockitoBean
+    AladinRecommendationRefreshClient recommendationRefreshClient;
+
+    @MockitoBean
+    AladinApiService aladinApiService;
+
+    @Test
+    void recommendBooksReturnsStaleCacheWhenAladinRefreshFails() {
+        TestUser user = createUser();
+        BookResponseDTO.BookList staleCache = bookList("stale", 4);
+
+        when(redisValueOperations.get(REDIS_KEY)).thenReturn(staleCache);
+        when(redisValueOperations.get(REDIS_UPDATED_AT_KEY)).thenReturn(LocalDate.now().minusDays(1).toString());
+        when(recommendationRefreshClient.retrieveRecommendedBooks())
+                .thenThrow(new RuntimeException("aladin unavailable"));
+        when(aladinApiService.applyLikedByMe(staleCache, user.id())).thenReturn(staleCache);
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/v1/books/recommend")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true))
+                .body("code", equalTo("COMMON200"))
+                .body("result.detailInfoList.size()", equalTo(4));
+
+        verify(recommendationRefreshClient).retrieveRecommendedBooks();
+    }
+
+    @Test
+    void recommendBooksReturnsBook500WhenNoCacheAndAladinRefreshFails() {
+        TestUser user = createUser();
+
+        when(redisValueOperations.get(REDIS_KEY)).thenReturn(null);
+        when(recommendationRefreshClient.retrieveRecommendedBooks())
+                .thenThrow(new RuntimeException("aladin unavailable"));
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/v1/books/recommend")
+                .then()
+                .statusCode(500)
+                .body("isSuccess", equalTo(false))
+                .body("code", equalTo("BOOK_500"));
+    }
+
+    @Test
+    void recommendBooksReturnsFreshCacheWithoutRefreshingAladin() {
+        TestUser user = createUser();
+        BookResponseDTO.BookList freshCache = bookList("fresh", 4);
+
+        when(redisValueOperations.get(REDIS_KEY)).thenReturn(freshCache);
+        when(redisValueOperations.get(REDIS_UPDATED_AT_KEY)).thenReturn(LocalDate.now().toString());
+        when(aladinApiService.applyLikedByMe(freshCache, user.id())).thenReturn(freshCache);
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/v1/books/recommend")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true))
+                .body("code", equalTo("COMMON200"))
+                .body("result.detailInfoList.size()", equalTo(4));
+
+        verify(recommendationRefreshClient, never()).retrieveRecommendedBooks();
+    }
+
+    private static BookResponseDTO.BookList bookList(String prefix, int size) {
+        List<DetailInfo> books = IntStream.rangeClosed(1, size)
+                .mapToObj(index -> DetailInfo.builder()
+                        .isbn(prefix + "-isbn-" + index)
+                        .title("추천 책 " + index)
+                        .author("테스트 저자")
+                        .imgUrl("https://example.com/book-" + index + ".jpg")
+                        .publisher("테스트 출판사")
+                        .description("테스트 설명")
+                        .link("https://example.com/book-" + index)
+                        .build())
+                .toList();
+
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(books)
+                .hasNext(false)
+                .currentPage(null)
+                .totalResults(size)
+                .build();
+    }
+}

--- a/src/test/java/checkmo/book/internal/RecommendationLogSanitizerTest.java
+++ b/src/test/java/checkmo/book/internal/RecommendationLogSanitizerTest.java
@@ -3,6 +3,7 @@ package checkmo.book.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -10,6 +11,72 @@ import org.junit.jupiter.params.provider.MethodSource;
 class RecommendationLogSanitizerTest {
 
     private static final String SECRET = "SECRET";
+    private static final String ACCESS_TOKEN = "ACCESS_SECRET";
+    private static final String REFRESH_TOKEN = "REFRESH_SECRET";
+    private static final String AUTHORIZATION = "AUTH_SECRET";
+    private static final String API_KEY = "KEY_SECRET";
+    private static final String CLIENT_SECRET = "CLIENT_SECRET";
+    private static final String CLIENT_SECRET_WITH_SPACES = "CLIENT SECRET PLACEHOLDER";
+
+    @Test
+    void sanitizeReturnsNullWhenInputIsNull() {
+        String sanitized = RecommendationLogSanitizer.sanitize(null);
+
+        assertThat(sanitized).isNull();
+    }
+
+    @Test
+    void sanitizeMasksUrlQueryParameters() {
+        String sanitized = RecommendationLogSanitizer.sanitize(
+                "refresh failed https://example.test/token?access_token=ACCESS_SECRET&key=KEY_SECRET status=kept"
+        );
+
+        assertThat(sanitized)
+                .isEqualTo("refresh failed https://example.test/token?access_token=***&key=*** status=kept")
+                .doesNotContain(ACCESS_TOKEN)
+                .doesNotContain(API_KEY);
+    }
+
+    @Test
+    void sanitizeTruncatesLongMessagesAfterRedaction() {
+        String sanitized = RecommendationLogSanitizer.sanitize("a".repeat(501));
+
+        assertThat(sanitized).isEqualTo("a".repeat(500) + "...");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("jsonCredentialFieldCases")
+    void sanitizeRedactsQuotedJsonCredentialFieldsAndPreservesUnrelatedFields(
+            String displayName,
+            String raw,
+            String expected
+    ) {
+        String sanitized = RecommendationLogSanitizer.sanitize(raw);
+
+        assertThat(sanitized).isEqualTo(expected);
+        assertThat(sanitized)
+                .doesNotContain(ACCESS_TOKEN)
+                .doesNotContain(REFRESH_TOKEN)
+                .doesNotContain(AUTHORIZATION)
+                .doesNotContain(API_KEY)
+                .doesNotContain(CLIENT_SECRET)
+                .doesNotContain(CLIENT_SECRET_WITH_SPACES)
+                .contains("\"status\":\"kept\"")
+                .contains("\"count\":1");
+    }
+
+    @Test
+    void sanitizeRedactsMalformedUnterminatedQuotedJsonCredentialValue() {
+        String sanitized = RecommendationLogSanitizer.sanitize(
+                "refresh failed {\"secret\":\"CLIENT SECRET PLACEHOLDER,status=kept"
+        );
+
+        assertThat(sanitized)
+                .isEqualTo("refresh failed {\"secret\":\"***,status=kept")
+                .doesNotContain(CLIENT_SECRET_WITH_SPACES)
+                .doesNotContain("SECRET PLACEHOLDER")
+                .contains("status=kept");
+    }
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("sensitiveFieldCases")
@@ -25,6 +92,16 @@ class RecommendationLogSanitizerTest {
                 Arguments.of("auth assignment", "refresh failed auth=SECRET", "refresh failed auth=***"),
                 Arguments.of("auth header", "refresh failed Auth: Bearer SECRET", "refresh failed Auth: ***"),
                 Arguments.of(
+                        "json refresh token",
+                        "refresh failed {\"refresh_token\":\"SECRET\"}",
+                        "refresh failed {\"refresh_token\":\"***\"}"
+                ),
+                Arguments.of(
+                        "json authorization bearer",
+                        "refresh failed {\"authorization\":\"Bearer SECRET\"}",
+                        "refresh failed {\"authorization\":\"***\"}"
+                ),
+                Arguments.of(
                         "spaced verification code assignment",
                         "refresh failed verification code=SECRET",
                         "refresh failed verification code=***"
@@ -33,6 +110,29 @@ class RecommendationLogSanitizerTest {
                         "spaced verification code header",
                         "refresh failed verification code: SECRET",
                         "refresh failed verification code: ***"
+                )
+        );
+    }
+
+    private static Stream<Arguments> jsonCredentialFieldCases() {
+        return Stream.of(
+                Arguments.of(
+                        "json credential fields",
+                        """
+                        refresh failed {"access_token":"ACCESS_SECRET","refresh_token":"REFRESH_SECRET","authorization":"Bearer AUTH_SECRET","key":"KEY_SECRET","secret":"CLIENT_SECRET","status":"kept","count":1}
+                        """.strip(),
+                        """
+                        refresh failed {"access_token":"***","refresh_token":"***","authorization":"***","key":"***","secret":"***","status":"kept","count":1}
+                        """.strip()
+                ),
+                Arguments.of(
+                        "json credential field with spaces",
+                        """
+                        refresh failed {"secret":"CLIENT SECRET PLACEHOLDER","status":"kept","count":1}
+                        """.strip(),
+                        """
+                        refresh failed {"secret":"***","status":"kept","count":1}
+                        """.strip()
                 )
         );
     }

--- a/src/test/java/checkmo/book/internal/RecommendationLogSanitizerTest.java
+++ b/src/test/java/checkmo/book/internal/RecommendationLogSanitizerTest.java
@@ -1,0 +1,39 @@
+package checkmo.book.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RecommendationLogSanitizerTest {
+
+    private static final String SECRET = "SECRET";
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("sensitiveFieldCases")
+    void sanitizeRedactsCredentialFieldsOutsideUrlQueryParameters(String displayName, String raw, String expected) {
+        String sanitized = RecommendationLogSanitizer.sanitize(raw);
+
+        assertThat(sanitized).isEqualTo(expected);
+        assertThat(sanitized).doesNotContain(SECRET);
+    }
+
+    private static Stream<Arguments> sensitiveFieldCases() {
+        return Stream.of(
+                Arguments.of("auth assignment", "refresh failed auth=SECRET", "refresh failed auth=***"),
+                Arguments.of("auth header", "refresh failed Auth: Bearer SECRET", "refresh failed Auth: ***"),
+                Arguments.of(
+                        "spaced verification code assignment",
+                        "refresh failed verification code=SECRET",
+                        "refresh failed verification code=***"
+                ),
+                Arguments.of(
+                        "spaced verification code header",
+                        "refresh failed verification code: SECRET",
+                        "refresh failed verification code: ***"
+                )
+        );
+    }
+}

--- a/src/test/java/checkmo/book/internal/scheduler/BookRecommendationSchedulerTest.java
+++ b/src/test/java/checkmo/book/internal/scheduler/BookRecommendationSchedulerTest.java
@@ -17,9 +17,11 @@ import ch.qos.logback.core.read.ListAppender;
 import checkmo.book.internal.service.BookRecommendationService;
 import checkmo.book.web.dto.BookResponseDTO;
 import checkmo.common.monitoring.RecordingSentryCaptureClient;
+import java.lang.reflect.Method;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.slf4j.LoggerFactory;
 
 class BookRecommendationSchedulerTest {
@@ -72,7 +74,16 @@ class BookRecommendationSchedulerTest {
     }
 
     @Test
-    void startupMidnightAndRetryEntrypointsShareSingleFlightGuard() {
+    void updateDailyRecommendedBooksRunsAtSixAmInSeoul() throws NoSuchMethodException {
+        Method method = BookRecommendationScheduler.class.getMethod("updateDailyRecommendedBooks");
+        Scheduled scheduled = method.getAnnotation(Scheduled.class);
+
+        assertThat(scheduled.cron()).isEqualTo("0 0 6 * * ?");
+        assertThat(scheduled.zone()).isEqualTo("Asia/Seoul");
+    }
+
+    @Test
+    void startupDailyAndRetryEntrypointsShareSingleFlightGuard() {
         when(recommendationService.hasRecommendedBooks()).thenReturn(false);
         doAnswer(invocation -> {
             scheduler.updateDailyRecommendedBooks();

--- a/src/test/java/checkmo/book/internal/scheduler/BookRecommendationSchedulerTest.java
+++ b/src/test/java/checkmo/book/internal/scheduler/BookRecommendationSchedulerTest.java
@@ -1,0 +1,173 @@
+package checkmo.book.internal.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import checkmo.book.internal.service.BookRecommendationService;
+import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.common.monitoring.RecordingSentryCaptureClient;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+class BookRecommendationSchedulerTest {
+
+    private static final String SECRET_TTB_KEY = "SECRET_TTB_KEY";
+    private static final String SECRET_REFRESH_TOKEN = "SECRET_REFRESH_TOKEN";
+    private static final String SECRET_AUTHORIZATION = "Bearer SECRET_AUTHORIZATION";
+    private static final String SECRET_COOKIE = "SECRET_COOKIE";
+
+    private BookRecommendationService recommendationService;
+    private RecordingSentryCaptureClient captureClient;
+    private BookRecommendationScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        recommendationService = mock(BookRecommendationService.class);
+        captureClient = new RecordingSentryCaptureClient();
+        scheduler = new BookRecommendationScheduler(recommendationService, captureClient);
+    }
+
+    @Test
+    void retryRecommendedBooksRefreshRefreshesWhenCacheIsMissing() {
+        when(recommendationService.hasRecommendedBooks()).thenReturn(false);
+        when(recommendationService.refreshDailyRecommendedBooks()).thenReturn(bookList());
+
+        scheduler.retryRecommendedBooksRefresh();
+
+        verify(recommendationService).refreshDailyRecommendedBooks();
+    }
+
+    @Test
+    void retryRecommendedBooksRefreshRefreshesWhenCacheIsStale() {
+        when(recommendationService.hasRecommendedBooks()).thenReturn(true);
+        when(recommendationService.isRecommendedBooksStale()).thenReturn(true);
+        when(recommendationService.refreshDailyRecommendedBooks()).thenReturn(bookList());
+
+        scheduler.retryRecommendedBooksRefresh();
+
+        verify(recommendationService).refreshDailyRecommendedBooks();
+    }
+
+    @Test
+    void retryRecommendedBooksRefreshSkipsWhenCacheIsFresh() {
+        when(recommendationService.hasRecommendedBooks()).thenReturn(true);
+        when(recommendationService.isRecommendedBooksStale()).thenReturn(false);
+
+        scheduler.retryRecommendedBooksRefresh();
+
+        verify(recommendationService, never()).refreshDailyRecommendedBooks();
+    }
+
+    @Test
+    void startupMidnightAndRetryEntrypointsShareSingleFlightGuard() {
+        when(recommendationService.hasRecommendedBooks()).thenReturn(false);
+        doAnswer(invocation -> {
+            scheduler.updateDailyRecommendedBooks();
+            scheduler.retryRecommendedBooksRefresh();
+            return bookList();
+        }).when(recommendationService).refreshDailyRecommendedBooks();
+
+        scheduler.initializeRecommendedBooks();
+
+        verify(recommendationService).refreshDailyRecommendedBooks();
+    }
+
+    @Test
+    void refreshFailureIsCapturedSwallowedAndNextRetryCanRunAgain() {
+        RuntimeException failure = new RuntimeException("scheduler refresh failed");
+        when(recommendationService.hasRecommendedBooks()).thenReturn(false);
+        doThrow(failure)
+                .doReturn(bookList())
+                .when(recommendationService)
+                .refreshDailyRecommendedBooks();
+
+        assertDoesNotThrow(scheduler::retryRecommendedBooksRefresh);
+        assertDoesNotThrow(scheduler::retryRecommendedBooksRefresh);
+
+        verify(recommendationService, times(2)).refreshDailyRecommendedBooks();
+        assertThat(captureClient.captured()).containsExactly(failure);
+    }
+
+    @Test
+    void refreshFailureDoesNotLogRawThrowableOrCredentialBearingMessages() {
+        RuntimeException failure = credentialBearingFailure();
+        when(recommendationService.hasRecommendedBooks()).thenReturn(false);
+        when(recommendationService.refreshDailyRecommendedBooks()).thenThrow(failure);
+        ListAppender<ILoggingEvent> appender = attachSchedulerLogAppender();
+
+        try {
+            assertDoesNotThrow(scheduler::retryRecommendedBooksRefresh);
+
+            assertThat(captureClient.captured()).containsExactly(failure);
+            assertThat(appender.list)
+                    .filteredOn(event -> event.getLevel().equals(Level.ERROR))
+                    .singleElement()
+                    .satisfies(event -> {
+                        assertThat(event.getFormattedMessage()).doesNotContain(SECRET_TTB_KEY);
+                        assertThat(event.getFormattedMessage()).doesNotContain(SECRET_REFRESH_TOKEN);
+                        assertThat(event.getFormattedMessage()).doesNotContain(SECRET_AUTHORIZATION);
+                        assertThat(event.getFormattedMessage()).doesNotContain(SECRET_COOKIE);
+                        assertThat(event.getFormattedMessage()).doesNotContain("ttbkey=" + SECRET_TTB_KEY);
+                        assertThat(event.getFormattedMessage()).contains("ttbkey=***");
+                        assertThat(event.getFormattedMessage()).contains("Authorization: ***");
+                        assertThat(event.getFormattedMessage()).contains("Cookie: ***");
+                        assertThat(event.getFormattedMessage()).contains("refresh_token=***");
+                        assertThat(event.getThrowableProxy()).isNull();
+                    });
+        } finally {
+            detachSchedulerLogAppender(appender);
+        }
+    }
+
+    private static BookResponseDTO.BookList bookList() {
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(List.of(BookResponseDTO.DetailInfo.builder()
+                        .isbn("9791169213882")
+                        .title("테스트 책")
+                        .build()))
+                .hasNext(false)
+                .currentPage(null)
+                .build();
+    }
+
+    private static RuntimeException credentialBearingFailure() {
+        return new RuntimeException(
+                "outer failure https://www.aladin.co.kr/ttb/api/ItemList.aspx?ttbkey="
+                        + SECRET_TTB_KEY
+                        + "&refresh_token="
+                        + SECRET_REFRESH_TOKEN
+                        + " Authorization: "
+                        + SECRET_AUTHORIZATION,
+                new IllegalStateException(
+                        "inner failure Cookie: " + SECRET_COOKIE
+                )
+        );
+    }
+
+    private static ListAppender<ILoggingEvent> attachSchedulerLogAppender() {
+        Logger logger = (Logger) LoggerFactory.getLogger(BookRecommendationScheduler.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        return appender;
+    }
+
+    private static void detachSchedulerLogAppender(ListAppender<ILoggingEvent> appender) {
+        Logger logger = (Logger) LoggerFactory.getLogger(BookRecommendationScheduler.class);
+        logger.detachAppender(appender);
+        appender.stop();
+    }
+}

--- a/src/test/java/checkmo/book/internal/service/BookRecommendationServiceTest.java
+++ b/src/test/java/checkmo/book/internal/service/BookRecommendationServiceTest.java
@@ -1,0 +1,443 @@
+package checkmo.book.internal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import checkmo.book.internal.config.properties.AladinProperties;
+import checkmo.book.internal.exception.BookErrorStatus;
+import checkmo.book.internal.exception.BookException;
+import checkmo.book.internal.service.query.AladinApiService;
+import checkmo.book.internal.util.DayOfWeekUtils;
+import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import checkmo.common.monitoring.RecordingSentryCaptureClient;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.web.client.RestClientException;
+
+class BookRecommendationServiceTest {
+
+    private static final String MEMBER_ID = "member-1";
+    private static final String REDIS_KEY = "book:recommendations:daily";
+    private static final String REDIS_UPDATED_AT_KEY = "book:recommendations:daily:updated_at";
+    private static final String SECRET_TTB_KEY = "SECRET_TTB_KEY";
+    private static final String SECRET_REFRESH_TOKEN = "SECRET_REFRESH_TOKEN";
+    private static final String SECRET_AUTHORIZATION = "Bearer SECRET_AUTHORIZATION";
+    private static final String SECRET_COOKIE = "SECRET_COOKIE";
+
+    private RedisTemplate<String, Object> redisTemplate;
+    private ValueOperations<String, Object> valueOperations;
+    private AladinApiService aladinApiService;
+    private RecordingSentryCaptureClient captureClient;
+    private BookRecommendationService service;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        redisTemplate = mock(RedisTemplate.class);
+        valueOperations = mock(ValueOperations.class);
+        aladinApiService = mock(AladinApiService.class);
+        captureClient = new RecordingSentryCaptureClient();
+        AladinRecommendationRefreshClient refreshClient = new AladinRecommendationRefreshClient(
+                aladinApiService,
+                retryProperties(),
+                backOffPeriod -> {
+                }
+        );
+        service = new BookRecommendationService(redisTemplate, aladinApiService, refreshClient, captureClient);
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void retrieveRecommendedBooksRetriesTransientAladinAccessFailuresThenSavesTodayRecommendationWhenRefreshEventuallySucceeds() {
+        BookResponseDTO.BookList aladinBooks = bookListOfSize(todayRequiredBookCount());
+        BookException firstFailure = new BookException(
+                BookErrorStatus.ALADIN_API_ERROR,
+                new RestClientException("first transient failure")
+        );
+        BookException secondFailure = new BookException(
+                BookErrorStatus.ALADIN_API_ERROR,
+                new IOException("second transient failure")
+        );
+        when(valueOperations.get(REDIS_KEY)).thenReturn(null);
+        when(aladinApiService.retrieveRecommendedBooks())
+                .thenThrow(firstFailure)
+                .thenThrow(secondFailure)
+                .thenReturn(aladinBooks);
+        when(aladinApiService.applyLikedByMe(any(BookResponseDTO.BookList.class), eq(MEMBER_ID)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        BookResponseDTO.BookList response = service.retrieveRecommendedBooks(MEMBER_ID);
+
+        assertThat(response.getDetailInfoList()).hasSize(4);
+        verify(aladinApiService, times(3)).retrieveRecommendedBooks();
+        verify(valueOperations).set(eq(REDIS_KEY), any(BookResponseDTO.BookList.class));
+        verify(valueOperations).set(REDIS_UPDATED_AT_KEY, LocalDate.now().toString());
+        assertThat(captureClient.count()).isZero();
+    }
+
+    @Test
+    void retrieveRecommendedBooksThrowsBook500AfterThreeFailedRetryAttemptsWhenCacheIsNotUsable() {
+        BookException finalFailure = new BookException(
+                BookErrorStatus.ALADIN_API_ERROR,
+                new RestClientException("aladin unavailable")
+        );
+        when(valueOperations.get(REDIS_KEY)).thenReturn(null);
+        when(aladinApiService.retrieveRecommendedBooks()).thenThrow(finalFailure);
+
+        assertThatThrownBy(() -> service.retrieveRecommendedBooks(MEMBER_ID))
+                .isInstanceOfSatisfying(BookException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(BookErrorStatus.ALADIN_API_ERROR)
+                )
+                .hasCause(finalFailure);
+        verify(aladinApiService, times(3)).retrieveRecommendedBooks();
+        verify(aladinApiService, never()).applyLikedByMe(any(), any());
+        assertThat(captureClient.count()).isZero();
+    }
+
+    @Test
+    void retrieveRecommendedBooksDoesNotRetryGenericRuntimeFailureWhenCacheIsNotUsable() {
+        RuntimeException failure = new RuntimeException("local mapping failure");
+        when(valueOperations.get(REDIS_KEY)).thenReturn(null);
+        when(aladinApiService.retrieveRecommendedBooks()).thenThrow(failure);
+
+        assertThatThrownBy(() -> service.retrieveRecommendedBooks(MEMBER_ID))
+                .isInstanceOfSatisfying(BookException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(BookErrorStatus.ALADIN_API_ERROR)
+                )
+                .hasCause(failure);
+        verify(aladinApiService).retrieveRecommendedBooks();
+        verify(aladinApiService, never()).applyLikedByMe(any(), any());
+        assertThat(captureClient.count()).isZero();
+    }
+
+    @Test
+    void retrieveRecommendedBooksDoesNotRetryBookApiErrorWhenCauseIsGenericRuntimeFailureAndCacheIsNotUsable() {
+        BookException failure = new BookException(
+                BookErrorStatus.ALADIN_API_ERROR,
+                new RuntimeException("non-transient recommendation failure")
+        );
+        when(valueOperations.get(REDIS_KEY)).thenReturn(null);
+        when(aladinApiService.retrieveRecommendedBooks()).thenThrow(failure);
+
+        assertThatThrownBy(() -> service.retrieveRecommendedBooks(MEMBER_ID))
+                .isInstanceOfSatisfying(BookException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(BookErrorStatus.ALADIN_API_ERROR)
+                )
+                .hasCause(failure);
+        verify(aladinApiService).retrieveRecommendedBooks();
+        verify(aladinApiService, never()).applyLikedByMe(any(), any());
+        assertThat(captureClient.count()).isZero();
+    }
+
+    @Test
+    void retrieveRecommendedBooksDoesNotRetryLocalValidationFailureWhenCacheIsNotUsable() {
+        IllegalArgumentException failure = new IllegalArgumentException("invalid recommendation request");
+        when(valueOperations.get(REDIS_KEY)).thenReturn(null);
+        when(aladinApiService.retrieveRecommendedBooks()).thenThrow(failure);
+
+        assertThatThrownBy(() -> service.retrieveRecommendedBooks(MEMBER_ID))
+                .isInstanceOfSatisfying(BookException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(BookErrorStatus.ALADIN_API_ERROR)
+                )
+                .hasCause(failure);
+        verify(aladinApiService).retrieveRecommendedBooks();
+        verify(aladinApiService, never()).applyLikedByMe(any(), any());
+        assertThat(captureClient.count()).isZero();
+    }
+
+    @Test
+    void retrieveRecommendedBooksReturnsStaleCacheAndCapturesFailureWhenRefreshFails() {
+        BookResponseDTO.BookList staleCache = bookList("9791169213882", false);
+        BookResponseDTO.BookList likedStaleCache = bookList("9791169213882", true);
+        RuntimeException failure = new RuntimeException("aladin unavailable");
+        when(valueOperations.get(REDIS_KEY)).thenReturn(staleCache);
+        when(valueOperations.get(REDIS_UPDATED_AT_KEY)).thenReturn(LocalDate.now().minusDays(1).toString());
+        when(aladinApiService.retrieveRecommendedBooks()).thenThrow(failure);
+        when(aladinApiService.applyLikedByMe(staleCache, MEMBER_ID)).thenReturn(likedStaleCache);
+
+        BookResponseDTO.BookList response = service.retrieveRecommendedBooks(MEMBER_ID);
+
+        assertThat(response).isSameAs(likedStaleCache);
+        assertThat(captureClient.captured()).containsExactly(failure);
+        verify(aladinApiService).applyLikedByMe(staleCache, MEMBER_ID);
+    }
+
+    @Test
+    void retrieveRecommendedBooksDoesNotLogRawCredentialBearingRefreshFailureWhenReturningStaleCache() {
+        BookResponseDTO.BookList staleCache = bookList("9791169213882", false);
+        BookResponseDTO.BookList likedStaleCache = bookList("9791169213882", true);
+        RuntimeException failure = credentialBearingFailure();
+        when(valueOperations.get(REDIS_KEY)).thenReturn(staleCache);
+        when(valueOperations.get(REDIS_UPDATED_AT_KEY)).thenReturn(LocalDate.now().minusDays(1).toString());
+        when(aladinApiService.retrieveRecommendedBooks()).thenThrow(failure);
+        when(aladinApiService.applyLikedByMe(staleCache, MEMBER_ID)).thenReturn(likedStaleCache);
+        ListAppender<ILoggingEvent> appender = attachServiceLogAppender();
+
+        try {
+            BookResponseDTO.BookList response = service.retrieveRecommendedBooks(MEMBER_ID);
+
+            assertThat(response).isSameAs(likedStaleCache);
+            assertThat(captureClient.captured()).containsExactly(failure);
+            assertRefreshFailureLogsAreSanitized(appender, Level.WARN);
+        } finally {
+            detachServiceLogAppender(appender);
+        }
+    }
+
+    @Test
+    void refreshDailyRecommendedBooksDoesNotLogRawCredentialBearingRefreshFailureWhenReturningEmptyFallback() {
+        RuntimeException failure = credentialBearingFailure();
+        when(valueOperations.get(REDIS_KEY)).thenReturn(null);
+        when(aladinApiService.retrieveRecommendedBooks()).thenThrow(failure);
+        ListAppender<ILoggingEvent> appender = attachServiceLogAppender();
+
+        try {
+            BookResponseDTO.BookList response = service.refreshDailyRecommendedBooks();
+
+            assertThat(response.getDetailInfoList()).isEmpty();
+            assertThat(captureClient.captured()).containsExactly(failure);
+            assertRefreshFailureLogsAreSanitized(appender, Level.ERROR);
+        } finally {
+            detachServiceLogAppender(appender);
+        }
+    }
+
+    @Test
+    void retrieveRecommendedBooksReturnsStaleCacheAndCapturesFailureWhenRefreshReturnsUnusableBookList() {
+        BookResponseDTO.BookList staleCache = bookList("9791169213882", false);
+        BookResponseDTO.BookList likedStaleCache = bookList("9791169213882", true);
+        when(valueOperations.get(REDIS_KEY)).thenReturn(staleCache);
+        when(valueOperations.get(REDIS_UPDATED_AT_KEY)).thenReturn(LocalDate.now().minusDays(1).toString());
+        when(aladinApiService.retrieveRecommendedBooks()).thenReturn(emptyBookList());
+        when(aladinApiService.applyLikedByMe(staleCache, MEMBER_ID)).thenReturn(likedStaleCache);
+
+        BookResponseDTO.BookList response = service.retrieveRecommendedBooks(MEMBER_ID);
+
+        assertThat(response).isSameAs(likedStaleCache);
+        assertThat(captureClient.captured())
+                .singleElement()
+                .isInstanceOfSatisfying(BookException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(BookErrorStatus.ALADIN_API_ERROR)
+                );
+        verify(aladinApiService).applyLikedByMe(staleCache, MEMBER_ID);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unusableCacheCases")
+    void retrieveRecommendedBooksThrowsBook500WhenRefreshFailsAndCacheIsNotUsable(
+            String displayName,
+            Object cachedData,
+            String updatedAt,
+            boolean redisReadFails
+    ) {
+        RuntimeException failure = new RuntimeException("aladin unavailable");
+        if (redisReadFails) {
+            when(valueOperations.get(REDIS_KEY)).thenThrow(new IllegalStateException("redis read failed"));
+        } else {
+            when(valueOperations.get(REDIS_KEY)).thenReturn(cachedData);
+            when(valueOperations.get(REDIS_UPDATED_AT_KEY)).thenReturn(updatedAt);
+        }
+        when(aladinApiService.retrieveRecommendedBooks()).thenThrow(failure);
+
+        assertThatThrownBy(() -> service.retrieveRecommendedBooks(MEMBER_ID))
+                .isInstanceOfSatisfying(BookException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(BookErrorStatus.ALADIN_API_ERROR)
+                )
+                .hasCause(failure);
+        assertThat(captureClient.count()).isZero();
+        verify(aladinApiService, never()).applyLikedByMe(any(), any());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unusableAladinResponseCases")
+    void retrieveRecommendedBooksThrowsBook500AndDoesNotCaptureWhenNoUsableCacheAndRefreshReturnsUnusableBookList(
+            String displayName,
+            BookResponseDTO.BookList aladinResponse
+    ) {
+        when(valueOperations.get(REDIS_KEY)).thenReturn(null);
+        when(aladinApiService.retrieveRecommendedBooks()).thenReturn(aladinResponse);
+
+        assertThatThrownBy(() -> service.retrieveRecommendedBooks(MEMBER_ID))
+                .isInstanceOfSatisfying(BookException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(BookErrorStatus.ALADIN_API_ERROR)
+                );
+        assertThat(captureClient.count()).isZero();
+        verify(aladinApiService, never()).applyLikedByMe(any(), any());
+    }
+
+    @Test
+    void retrieveRecommendedBooksReturnsFreshCacheWithoutRefresh() {
+        BookResponseDTO.BookList freshCache = bookList("9791169213882", false);
+        BookResponseDTO.BookList likedFreshCache = bookList("9791169213882", true);
+        when(valueOperations.get(REDIS_KEY)).thenReturn(freshCache);
+        when(valueOperations.get(REDIS_UPDATED_AT_KEY)).thenReturn(LocalDate.now().toString());
+        when(aladinApiService.applyLikedByMe(freshCache, MEMBER_ID)).thenReturn(likedFreshCache);
+
+        BookResponseDTO.BookList response = service.retrieveRecommendedBooks(MEMBER_ID);
+
+        assertThat(response).isSameAs(likedFreshCache);
+        verify(aladinApiService, never()).retrieveRecommendedBooks();
+        verify(valueOperations, never()).set(any(String.class), any());
+    }
+
+    private static Stream<Arguments> unusableCacheCases() {
+        return Stream.of(
+                Arguments.of("missing key is not usable", null, LocalDate.now().minusDays(1).toString(), false),
+                Arguments.of("wrong type is not usable", "not a book list", LocalDate.now().toString(), false),
+                Arguments.of("null detail info list with today's timestamp is not usable", bookListWithNullDetailInfoList(), LocalDate.now().toString(), false),
+                Arguments.of("null detail info list with stale timestamp is not usable", bookListWithNullDetailInfoList(), LocalDate.now().minusDays(1).toString(), false),
+                Arguments.of("empty book list is not usable", emptyBookList(), LocalDate.now().toString(), false),
+                Arguments.of("redis read exception is not usable", null, null, true)
+        );
+    }
+
+    private static Stream<Arguments> unusableAladinResponseCases() {
+        return Stream.of(
+                Arguments.of("null aladin response is not usable", null),
+                Arguments.of("empty aladin response is not usable", emptyBookList()),
+                Arguments.of("fewer than today's four-book window is not usable", bookListOfSize(todayRequiredBookCount() - 1))
+        );
+    }
+
+    private static AladinProperties retryProperties() {
+        AladinProperties properties = new AladinProperties();
+        properties.getRecommendation().getRefresh().getRetry().setAttempts(3);
+        properties.getRecommendation().getRefresh().getRetry().setInitialBackoff(java.time.Duration.ofSeconds(1));
+        properties.getRecommendation().getRefresh().getRetry().setMultiplier(2);
+        properties.getRecommendation().getRefresh().getRetry().setMaxBackoff(java.time.Duration.ofSeconds(5));
+        return properties;
+    }
+
+    private static int todayRequiredBookCount() {
+        return DayOfWeekUtils.calculateStartIndexByDayOfWeek() + 4;
+    }
+
+    private static BookResponseDTO.BookList bookList(String isbn, boolean likedByMe) {
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(List.of(DetailInfo.builder()
+                        .isbn(isbn)
+                        .title("테스트 책")
+                        .author("테스트 저자")
+                        .imgUrl("https://example.com/book.jpg")
+                        .publisher("테스트 출판사")
+                        .description("테스트 설명")
+                        .link("https://example.com/book")
+                        .likedByMe(likedByMe)
+                        .build()))
+                .hasNext(false)
+                .currentPage(null)
+                .totalResults(1)
+                .build();
+    }
+
+    private static BookResponseDTO.BookList bookListOfSize(int size) {
+        List<DetailInfo> books = java.util.stream.IntStream.range(0, size)
+                .mapToObj(index -> DetailInfo.builder()
+                        .isbn("isbn-" + index)
+                        .title("테스트 책 " + index)
+                        .author("테스트 저자")
+                        .imgUrl("https://example.com/book-" + index + ".jpg")
+                        .publisher("테스트 출판사")
+                        .description("테스트 설명")
+                        .link("https://example.com/book-" + index)
+                        .build())
+                .toList();
+
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(books)
+                .hasNext(false)
+                .currentPage(null)
+                .totalResults(size)
+                .build();
+    }
+
+    private static BookResponseDTO.BookList bookListWithNullDetailInfoList() {
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(null)
+                .hasNext(false)
+                .currentPage(null)
+                .totalResults(0)
+                .build();
+    }
+
+    private static BookResponseDTO.BookList emptyBookList() {
+        return BookResponseDTO.BookList.builder()
+                .detailInfoList(List.of())
+                .hasNext(false)
+                .currentPage(null)
+                .totalResults(0)
+                .build();
+    }
+
+    private static RuntimeException credentialBearingFailure() {
+        return new RuntimeException(
+                "outer failure https://www.aladin.co.kr/ttb/api/ItemList.aspx?ttbkey="
+                        + SECRET_TTB_KEY
+                        + "&refresh_token="
+                        + SECRET_REFRESH_TOKEN
+                        + " Authorization: "
+                        + SECRET_AUTHORIZATION,
+                new RestClientException(
+                        "inner failure https://www.aladin.co.kr/ttb/api/ItemList.aspx?ttbkey="
+                                + SECRET_TTB_KEY
+                                + "&Query=java"
+                                + " Cookie: "
+                                + SECRET_COOKIE
+                )
+        );
+    }
+
+    private static ListAppender<ILoggingEvent> attachServiceLogAppender() {
+        Logger logger = (Logger) LoggerFactory.getLogger(BookRecommendationService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        return appender;
+    }
+
+    private static void detachServiceLogAppender(ListAppender<ILoggingEvent> appender) {
+        Logger logger = (Logger) LoggerFactory.getLogger(BookRecommendationService.class);
+        logger.detachAppender(appender);
+        appender.stop();
+    }
+
+    private static void assertRefreshFailureLogsAreSanitized(ListAppender<ILoggingEvent> appender, Level level) {
+        assertThat(appender.list)
+                .filteredOn(event -> event.getLevel().equals(level))
+                .anySatisfy(event -> {
+                    assertThat(event.getFormattedMessage()).doesNotContain(SECRET_TTB_KEY);
+                    assertThat(event.getFormattedMessage()).doesNotContain(SECRET_REFRESH_TOKEN);
+                    assertThat(event.getFormattedMessage()).doesNotContain(SECRET_AUTHORIZATION);
+                    assertThat(event.getFormattedMessage()).doesNotContain(SECRET_COOKIE);
+                    assertThat(event.getFormattedMessage()).doesNotContain("ttbkey=" + SECRET_TTB_KEY);
+                    assertThat(event.getFormattedMessage()).contains("ttbkey=***");
+                    assertThat(event.getFormattedMessage()).contains("refresh_token=***");
+                    assertThat(event.getFormattedMessage()).contains("Authorization: ***");
+                    assertThat(event.getFormattedMessage()).contains("Cookie: ***");
+                    assertThat(event.getThrowableProxy()).isNull();
+                });
+    }
+}

--- a/src/test/java/checkmo/book/internal/service/BookRecommendationServiceTest.java
+++ b/src/test/java/checkmo/book/internal/service/BookRecommendationServiceTest.java
@@ -23,7 +23,9 @@ import checkmo.book.web.dto.BookResponseDTO;
 import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
 import checkmo.common.monitoring.RecordingSentryCaptureClient;
 import java.io.IOException;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -95,7 +98,45 @@ class BookRecommendationServiceTest {
         verify(aladinApiService, times(3)).retrieveRecommendedBooks();
         verify(valueOperations).set(eq(REDIS_KEY), any(BookResponseDTO.BookList.class));
         verify(valueOperations).set(REDIS_UPDATED_AT_KEY, LocalDate.now().toString());
+        verify(valueOperations, never()).set(eq(REDIS_KEY), any(BookResponseDTO.BookList.class), any(Duration.class));
+        verify(valueOperations, never()).set(eq(REDIS_UPDATED_AT_KEY), any(String.class), any(Duration.class));
         assertThat(captureClient.count()).isZero();
+    }
+
+    @Test
+    void retrieveRecommendedBooksCopiesTodayRecommendationSliceBeforeSavingAndReturning() {
+        int startIndex = DayOfWeekUtils.calculateStartIndexByDayOfWeek();
+        List<DetailInfo> upstreamBooks = mutableDetailInfoList(todayRequiredBookCount());
+        DetailInfo originalFirstRecommendation = upstreamBooks.get(startIndex);
+        DetailInfo replacementBook = detailInfo("mutated-isbn", "변경된 책");
+        BookResponseDTO.BookList aladinBooks = BookResponseDTO.BookList.builder()
+                .detailInfoList(upstreamBooks)
+                .hasNext(false)
+                .currentPage(null)
+                .totalResults(upstreamBooks.size())
+                .build();
+        ArgumentCaptor<BookResponseDTO.BookList> savedBookListCaptor =
+                ArgumentCaptor.forClass(BookResponseDTO.BookList.class);
+        when(valueOperations.get(REDIS_KEY)).thenReturn(null);
+        when(aladinApiService.retrieveRecommendedBooks()).thenReturn(aladinBooks);
+        when(aladinApiService.applyLikedByMe(any(BookResponseDTO.BookList.class), eq(MEMBER_ID)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        BookResponseDTO.BookList response = service.retrieveRecommendedBooks(MEMBER_ID);
+        upstreamBooks.set(startIndex, replacementBook);
+
+        verify(valueOperations).set(eq(REDIS_KEY), savedBookListCaptor.capture());
+        BookResponseDTO.BookList savedBookList = savedBookListCaptor.getValue();
+        assertThat(response.getDetailInfoList())
+                .hasSize(4)
+                .first()
+                .isSameAs(originalFirstRecommendation);
+        assertThat(savedBookList.getDetailInfoList())
+                .hasSize(4)
+                .first()
+                .isSameAs(originalFirstRecommendation);
+        assertThat(response.getDetailInfoList()).doesNotContain(replacementBook);
+        assertThat(savedBookList.getDetailInfoList()).doesNotContain(replacementBook);
     }
 
     @Test
@@ -355,15 +396,7 @@ class BookRecommendationServiceTest {
 
     private static BookResponseDTO.BookList bookListOfSize(int size) {
         List<DetailInfo> books = java.util.stream.IntStream.range(0, size)
-                .mapToObj(index -> DetailInfo.builder()
-                        .isbn("isbn-" + index)
-                        .title("테스트 책 " + index)
-                        .author("테스트 저자")
-                        .imgUrl("https://example.com/book-" + index + ".jpg")
-                        .publisher("테스트 출판사")
-                        .description("테스트 설명")
-                        .link("https://example.com/book-" + index)
-                        .build())
+                .mapToObj(index -> detailInfo("isbn-" + index, "테스트 책 " + index))
                 .toList();
 
         return BookResponseDTO.BookList.builder()
@@ -371,6 +404,26 @@ class BookRecommendationServiceTest {
                 .hasNext(false)
                 .currentPage(null)
                 .totalResults(size)
+                .build();
+    }
+
+    private static List<DetailInfo> mutableDetailInfoList(int size) {
+        List<DetailInfo> books = new ArrayList<>();
+        for (int index = 0; index < size; index++) {
+            books.add(detailInfo("isbn-" + index, "테스트 책 " + index));
+        }
+        return books;
+    }
+
+    private static DetailInfo detailInfo(String isbn, String title) {
+        return DetailInfo.builder()
+                .isbn(isbn)
+                .title(title)
+                .author("테스트 저자")
+                .imgUrl("https://example.com/book-" + isbn + ".jpg")
+                .publisher("테스트 출판사")
+                .description("테스트 설명")
+                .link("https://example.com/book-" + isbn)
                 .build();
     }
 

--- a/src/test/java/checkmo/common/config/SentryConfigurationTest.java
+++ b/src/test/java/checkmo/common/config/SentryConfigurationTest.java
@@ -2,6 +2,7 @@ package checkmo.common.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import checkmo.book.internal.service.AladinRecommendationRefreshClient;
 import checkmo.common.monitoring.SentryCaptureClient;
 import checkmo.common.monitoring.SentrySdkCaptureClient;
 import checkmo.support.SpringTest;
@@ -16,8 +17,11 @@ import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringTest
+@TestPropertySource(properties = "aladin.api.recommendation.refresh.background.fixed-delay=5m")
 class SentryConfigurationTest {
 
     @Autowired
@@ -31,6 +35,9 @@ class SentryConfigurationTest {
 
     @Autowired
     private ListableBeanFactory beanFactory;
+
+    @MockitoBean
+    private AladinRecommendationRefreshClient aladinRecommendationRefreshClient;
 
     @Test
     void contextStartsWhenSentryDsnIsMissing() {

--- a/src/test/java/checkmo/common/config/SentryPrivacyConfigurationTest.java
+++ b/src/test/java/checkmo/common/config/SentryPrivacyConfigurationTest.java
@@ -2,6 +2,7 @@ package checkmo.common.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import checkmo.book.internal.service.AladinRecommendationRefreshClient;
 import checkmo.support.SpringTest;
 import io.sentry.SentryEvent;
 import io.sentry.SentryOptions;
@@ -13,8 +14,11 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringTest
+@TestPropertySource(properties = "aladin.api.recommendation.refresh.background.fixed-delay=5m")
 class SentryPrivacyConfigurationTest {
 
     @Autowired
@@ -22,6 +26,14 @@ class SentryPrivacyConfigurationTest {
 
     @Autowired
     private SentryOptions.BeforeSendCallback beforeSendCallback;
+
+    @MockitoBean
+    private AladinRecommendationRefreshClient aladinRecommendationRefreshClient;
+
+    @Test
+    void sentrySanitizerIsRegisteredAsBeforeSendCallbackBean() {
+        assertThat(beforeSendCallback).isInstanceOf(SentrySanitizingBeforeSendCallback.class);
+    }
 
     @Test
     void sendDefaultPiiIsDisabled() {

--- a/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
+++ b/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import checkmo.authentication.AuthenticationAPI;
+import checkmo.book.internal.config.properties.AladinProperties;
+import checkmo.book.internal.service.AladinRecommendationRefreshClient;
 import checkmo.book.internal.service.BookRecommendationService;
 import checkmo.book.internal.service.query.AladinApiService;
 import checkmo.book.internal.scheduler.BookRecommendationScheduler;
@@ -20,30 +22,56 @@ import checkmo.member.internal.entity.Member;
 import checkmo.member.internal.repository.MemberRepository;
 import checkmo.member.internal.scheduler.MemberCleanupScheduler;
 import checkmo.member.internal.service.command.MemberCommandService;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 class SentryBackgroundCaptureTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void capturesRecommendationRefreshFailureWhileReturningFallbackEmptyList() {
+    void capturesRecommendationRefreshFailureWhileReturningStaleFallback() {
         RedisTemplate<String, Object> redisTemplate = mock(RedisTemplate.class);
+        ValueOperations<String, Object> valueOperations = mock(ValueOperations.class);
         AladinApiService aladinApiService = mock(AladinApiService.class);
         RecordingSentryCaptureClient captureClient = new RecordingSentryCaptureClient();
         RuntimeException failure = new RuntimeException("aladin unavailable");
+        BookResponseDTO.BookList staleCache = BookResponseDTO.BookList.builder()
+                .detailInfoList(List.of(BookResponseDTO.DetailInfo.builder()
+                        .isbn("9791169213882")
+                        .title("테스트 책")
+                        .build()))
+                .hasNext(false)
+                .currentPage(null)
+                .build();
+        BookResponseDTO.BookList likedStaleCache = BookResponseDTO.BookList.builder()
+                .detailInfoList(List.of(BookResponseDTO.DetailInfo.builder()
+                        .isbn("9791169213882")
+                        .title("테스트 책")
+                        .likedByMe(true)
+                        .build()))
+                .hasNext(false)
+                .currentPage(null)
+                .build();
         BookRecommendationService service = new BookRecommendationService(
                 redisTemplate,
                 aladinApiService,
+                new AladinRecommendationRefreshClient(aladinApiService, new AladinProperties()),
                 captureClient
         );
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("book:recommendations:daily")).thenReturn(staleCache);
+        when(valueOperations.get("book:recommendations:daily:updated_at"))
+                .thenReturn(LocalDate.now().minusDays(1).toString());
         when(aladinApiService.retrieveRecommendedBooks()).thenThrow(failure);
+        when(aladinApiService.applyLikedByMe(staleCache, "member-1")).thenReturn(likedStaleCache);
 
-        BookResponseDTO.BookList response = service.refreshDailyRecommendedBooks();
+        BookResponseDTO.BookList response = service.retrieveRecommendedBooks("member-1");
 
-        assertThat(response.getDetailInfoList()).isEmpty();
+        assertThat(response).isSameAs(likedStaleCache);
         assertThat(captureClient.captured()).containsExactly(failure);
     }
 


### PR DESCRIPTION
## Summary
- 알라딘 추천책 갱신 실패 시 bounded immediate retry와 5분 background retry를 추가했습니다.
- non-empty stale 추천 캐시는 TTL로 삭제하지 않고 `updated_at` 기준으로 stale 판단하여 갱신 실패 중에도 이전 추천책을 반환합니다.
- usable 캐시가 없는 실패는 `COMMON200 + []` 대신 `BOOK_500`으로 노출하고, Sentry capture와 로그 secret sanitization을 유지했습니다.

## Root Cause
- 기존 추천 갱신 실패 흐름은 실패 후 재갱신 루프가 약했고, usable 캐시가 없는 경우 빈 추천 목록으로 사용자 응답이 정상 처리될 수 있었습니다.

## Tests
```bash
./gradlew test --tests checkmo.book.internal.service.BookRecommendationServiceTest --tests checkmo.book.internal.scheduler.BookRecommendationSchedulerTest --tests checkmo.book.BookRecommendationApiTest --tests checkmo.book.internal.RecommendationLogSanitizerTest --tests checkmo.book.AladinConfigurationTest --tests checkmo.common.monitoring.SentryBackgroundCaptureTest --tests checkmo.common.config.SentryConfigurationTest --tests checkmo.common.config.SentryPrivacyConfigurationTest
```

Closes #240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable recommendation refresh retry settings (attempt bounds and exponential backoff) plus background retry scheduling (default 5 minutes).
* **Improvements**
  * Prevent overlapping refresh runs; daily refresh now runs at 6:00 AM (Asia/Seoul) and background retries only occur when the cache is missing or stale.
  * Stronger fallback behavior: when refresh fails and a usable cache exists, recommendations continue to be served.
  * Enhanced privacy for logs by masking sensitive values (including URL parameters) and truncating overly long messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->