### PR TITLE
refactor: 컨버터 컨벤션 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ checkmo/
 
 - Split work into the smallest practical stages so the user can keep understanding the code as it changes.
 - Each stage should have one clear purpose, such as a shared DTO, one module endpoint, one focused test change, or one documentation update.
+- Keep stage scope intentionally small: prefer one module, one file group, one behavior, or one cleanup category per stage.
+- If two changes can be reviewed, verified, or reverted independently, split them into separate stages instead of grouping them for convenience.
 - Avoid changing multiple modules in the same stage when the work can be split by module.
 - After completing each stage, report:
   - changed files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,11 @@ checkmo/
   - verification result
   - remaining risk
   - recommended commit message
-- Wait for the user's confirmation before committing that stage, then continue to the next stage.
-- Do not implement multiple future commit stages ahead of user confirmation. Finish one stage, stop, report, wait for confirmation, commit, then start the next stage.
+- Default workflow is stage-by-stage report, user commit, then wait for the user's explicit request to continue to the next stage.
+- Do not batch all stages into one final commit unless the user explicitly overrides this rule for the current task.
+- After reporting a stage, stop. The user owns committing that stage by default; do not continue into the next stage until the user says they committed or explicitly asks to continue.
+- If the user explicitly asks the agent to commit a stage, commit only that completed stage after confirmation, then stop again and wait for the next-stage request.
+- Do not implement multiple future commit stages ahead of user confirmation. Finish one stage, stop, report, wait for the user's commit or explicit commit instruction, then start the next stage only when requested.
 - Keep commits as close to one stage per commit as practical.
 - Prefer small commits, but do not create commits that leave the project uncompilable or contain meaningless micro-changes.
 - Each commit should be understandable as a standalone review unit.

--- a/src/main/java/checkmo/bookStory/internal/converter/BookStoryConverter.java
+++ b/src/main/java/checkmo/bookStory/internal/converter/BookStoryConverter.java
@@ -2,6 +2,7 @@ package checkmo.bookStory.internal.converter;
 
 import checkmo.book.BookExternalDTO;
 import checkmo.bookStory.internal.entity.BookStory;
+import checkmo.bookStory.internal.entity.BookStoryStatus;
 import checkmo.bookStory.internal.entity.Comment;
 import checkmo.bookStory.internal.repository.projection.BookStoryPrevNextProjection;
 import checkmo.bookStory.web.dto.BookStoryRequestDTO;
@@ -9,6 +10,7 @@ import checkmo.bookStory.web.dto.BookStoryResponseDTO;
 import checkmo.member.MemberExternalDTO;
 import checkmo.member.MemberExternalDTO.BasicInfoWithFollow;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -22,9 +24,9 @@ public class BookStoryConverter {
             BookStoryRequestDTO.BookStoryCreate request,
             String memberId,
             String bookId,
-            checkmo.bookStory.internal.entity.BookStoryStatus status
+            BookStoryStatus status
     ) {
-        return checkmo.bookStory.internal.entity.BookStory.builder()
+        return BookStory.builder()
                 .title(request.getTitle())
                 .description(request.getDescription())
                 .status(status)
@@ -104,7 +106,7 @@ public class BookStoryConverter {
     public static List<BookStoryResponseDTO.CommentInfo> toCommentDetailList(
             List<Comment> comments,
             String currentMemberId,
-            java.util.Map<String, MemberExternalDTO.BasicInfo> memberInfoMap,
+            Map<String, MemberExternalDTO.BasicInfo> memberInfoMap,
             Set<String> blockedMemberIds
     ) {
         return comments.stream()

--- a/src/main/java/checkmo/clubManagement/internal/ClubManagementAPIImpl.java
+++ b/src/main/java/checkmo/clubManagement/internal/ClubManagementAPIImpl.java
@@ -137,7 +137,7 @@ public class ClubManagementAPIImpl implements ClubManagementAPI {
         if (clubMembers.size() != clubMemberIds.size()) {
             throw new ClubManagementException(ClubManagementErrorStatus.CLUB_MEMBER_NOT_FOUND);
         }
-        return ClubManagementConverter.toMembereshipDTOMap(clubMembers);
+        return ClubManagementConverter.toMembershipDTOMap(clubMembers);
     }
 
     @Override

--- a/src/main/java/checkmo/clubManagement/internal/converter/ClubManagementConverter.java
+++ b/src/main/java/checkmo/clubManagement/internal/converter/ClubManagementConverter.java
@@ -59,7 +59,7 @@ public class ClubManagementConverter {
                 .build();
     }
 
-    public static Map<Long, MembershipInfo> toMembereshipDTOMap(
+    public static Map<Long, MembershipInfo> toMembershipDTOMap(
             List<ClubMember> clubMembers
     ) {
         return clubMembers.stream()
@@ -81,15 +81,15 @@ public class ClubManagementConverter {
             ClubMember clubMember,
             MemberExternalDTO.DetailInfo memberInfo
     ) {
-        ClubMemberStatus staus = clubMember.getClubMemberStatus();
+        ClubMemberStatus status = clubMember.getClubMemberStatus();
         ClubMemberBuilder builder = ClubResponseDTO.ClubMember.builder()
                 .clubMemberId(clubMember.getId())
                 .detailInfo(memberInfo)
-                .clubMemberStatus(staus.name());
-        if (staus.isJoinInProgress()) {
+                .clubMemberStatus(status.name());
+        if (status.isJoinInProgress()) {
             builder.joinMessage(clubMember.getJoinMessage())
                     .appliedAt(clubMember.getAppliedAt());
-        } else if (staus.isActive()) {
+        } else if (status.isActive()) {
             builder.joinedAt(clubMember.getJoinedAt());
         }
         return builder.build();

--- a/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
+++ b/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
@@ -27,7 +27,7 @@ import java.util.Set;
 public class ClubMeetingConverter {
 
     // =====================================================
-    // ?? -> 엔티티 변환
+    // BookShelf 요청 DTO -> 엔티티 변환
     // =====================================================
 
     public static Meeting toMeeting(BookShelfCreate request, Long clubId, String bookId) {
@@ -68,7 +68,7 @@ public class ClubMeetingConverter {
     }
 
     // =====================================================
-    // ?? -> BookshelfDTO 변환
+    // 엔티티/외부 정보 -> Bookshelf 응답 DTO 변환
     // =====================================================
 
     public static BookShelfResponseDTO.TopicDetail toTopicDetailDTO(
@@ -130,7 +130,7 @@ public class ClubMeetingConverter {
     }
 
     // =====================================================
-    // ?? -> MeetingResponseDTO 변환
+    // 엔티티/모임 구성 정보 -> MeetingResponseDTO 변환
     // =====================================================
 
     public static MeetingResponseDTO.Topic toTopicDTO(
@@ -230,7 +230,7 @@ public class ClubMeetingConverter {
     }
 
     // =====================================================
-    // ?? -> ClubMeetingExternalDTO 변환
+    // 엔티티/도서 정보 -> ClubMeetingExternalDTO 변환
     // =====================================================
     public static DetailInfo toMeetingInfoExternalDTO(
             Meeting meeting,

--- a/src/main/java/checkmo/member/internal/converter/MemberConverter.java
+++ b/src/main/java/checkmo/member/internal/converter/MemberConverter.java
@@ -1,6 +1,5 @@
 package checkmo.member.internal.converter;
 
-import checkmo.member.MemberExternalDTO;
 import checkmo.member.internal.entity.Member;
 import checkmo.member.internal.entity.MemberBlock;
 import checkmo.member.web.dto.MemberResponseDTO.*;
@@ -9,14 +8,6 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberConverter {
-
-    public static BasicInfoWithDescription toMemberProfileWithProfileImage(Member member) {
-        return BasicInfoWithDescription.builder()
-                .nickname(member.getNickName())
-                .description(member.getDescription())
-                .profileImageUrl(member.getImgUrl())
-                .build();
-    }
 
     public static DetailInfo toMemberProfileWithCategory(Member member) {
         return DetailInfo.builder()
@@ -42,16 +33,6 @@ public class MemberConverter {
                 .following(isFollowing)
                 .followerCount(followerCount)
                 .followingCount(followingCount)
-                .build();
-    }
-
-    public static MemberExternalDTO.BasicInfoWithFollow toMemberProfileWithFollowStatus(
-            BasicInfoWithFollow profile
-    ) {
-        return MemberExternalDTO.BasicInfoWithFollow.builder()
-                .nickname(profile.getNickname())
-                .profileImageUrl(profile.getProfileImageUrl())
-                .following(profile.isFollowing())
                 .build();
     }
 

--- a/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
+++ b/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
@@ -13,13 +13,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NotificationConverter {
 
-    public static BasicInfoPreviewList convertToPreviewListDTO(
+    public static BasicInfoPreviewList toPreviewListDTO(
             List<Notification> notifications,
             Map<String, String> senderNicknameMap,
             Map<Long, String> clubNameMap
     ) {
         List<BasicInfo> previewList = notifications.stream()
-                .map(notification -> convertToBasicInfo(notification, senderNicknameMap, clubNameMap))
+                .map(notification -> toBasicInfo(notification, senderNicknameMap, clubNameMap))
                 .toList();
 
         return BasicInfoPreviewList.builder()
@@ -27,7 +27,7 @@ public class NotificationConverter {
                 .build();
     }
 
-    public static BasicInfoList convertToNotificationListDTO(
+    public static BasicInfoList toNotificationListDTO(
             List<Notification> notifications,
             Map<String, String> senderNicknameMap,
             Map<Long, String> clubNameMap,
@@ -35,7 +35,7 @@ public class NotificationConverter {
             int pageSize
     ) {
         var notificationList = notifications.stream()
-                .map(notification -> convertToBasicInfo(notification, senderNicknameMap, clubNameMap))
+                .map(notification -> toBasicInfo(notification, senderNicknameMap, clubNameMap))
                 .toList();
 
         return BasicInfoList.builder()
@@ -46,7 +46,7 @@ public class NotificationConverter {
                 .build();
     }
 
-    private static BasicInfo convertToBasicInfo(
+    private static BasicInfo toBasicInfo(
             Notification notification,
             Map<String, String> senderNicknameMap,
             Map<Long, String> clubNameMap

--- a/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
+++ b/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
@@ -40,7 +40,7 @@ public class NotificationQueryFacade {
         Map<String, String> senderNicknameMap = fetchSenderNicknameMap(notifications);
         Map<Long, String> clubNameMap = fetchClubNameMap(notifications);
 
-        return NotificationConverter.convertToPreviewListDTO(notifications, senderNicknameMap, clubNameMap);
+        return NotificationConverter.toPreviewListDTO(notifications, senderNicknameMap, clubNameMap);
     }
 
     public BasicInfoList retrieveNotifications(String memberId, Long cursorId) {
@@ -54,7 +54,7 @@ public class NotificationQueryFacade {
         Map<String, String> senderNicknameMap = fetchSenderNicknameMap(notifications);
         Map<Long, String> clubNameMap = fetchClubNameMap(notifications);
 
-        return NotificationConverter.convertToNotificationListDTO(
+        return NotificationConverter.toNotificationListDTO(
                 notifications,
                 senderNicknameMap,
                 clubNameMap,


### PR DESCRIPTION
## Summary
- 컨버터 stage 작업 흐름 규칙을 AGENTS.md에 명시했습니다.
- BookStory/ClubManagement/Notification/ClubMeeting 컨버터의 타입 참조, 오타, 메서드명, 섹션 주석을 정리했습니다.
- MemberConverter에서 호출되지 않는 변환 메서드 2개를 제거했습니다.

## Verification
- ./gradlew compileJava
- ./gradlew test --tests checkmo.CheckmoApplicationTests
- converter grep/scope audit: MapStruct/@Mapper 신규 도입 없음, 기존 Jackson ObjectMapper/XmlMapper 참조만 확인

Closes #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error in club membership information retrieval that was preventing correct data from being fetched.
  * Corrected a variable naming issue affecting club member status handling.

* **Refactor**
  * Updated internal code structure and method naming conventions across converter modules for consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->