### PR TITLE
feat: 모임 참여자 목록 조회 API 추가

### DIFF
--- a/src/main/java/checkmo/clubManagement/internal/converter/ClubManagementConverter.java
+++ b/src/main/java/checkmo/clubManagement/internal/converter/ClubManagementConverter.java
@@ -95,6 +95,20 @@ public class ClubManagementConverter {
         return builder.build();
     }
 
+    public static ClubResponseDTO.ClubParticipant toClubParticipantDTO(
+            ClubMember clubMember,
+            MemberExternalDTO.BasicInfoWithFollow memberInfo
+    ) {
+        return ClubResponseDTO.ClubParticipant.builder()
+                .clubMemberId(clubMember.getId())
+                .nickname(memberInfo == null ? null : memberInfo.getNickname())
+                .profileImageUrl(memberInfo == null ? null : memberInfo.getProfileImageUrl())
+                .following(memberInfo != null && memberInfo.isFollowing())
+                .clubMemberStatus(clubMember.getClubMemberStatus().name())
+                .staff(clubMember.isStaff())
+                .build();
+    }
+
     public static ClubResponseDTO.ClubDetail toClubDetailDTO(Club club, boolean isDetail) {
         ClubDetailBuilder builder = ClubResponseDTO.ClubDetail.builder()
                 .clubId(club.getId())

--- a/src/main/java/checkmo/clubManagement/internal/excepetion/ClubManagementErrorStatus.java
+++ b/src/main/java/checkmo/clubManagement/internal/excepetion/ClubManagementErrorStatus.java
@@ -27,6 +27,7 @@ public enum ClubManagementErrorStatus implements BaseErrorCode {
     CLUB_MEMBER_CANNOT_CHANGE_OWN_ROLE(HttpStatus.FORBIDDEN, "CLUB_MEMBER_409", "본인의 클럽 내 역할을 변경할 수 없습니다."),
     CLUB_OWNER_ROLE_CHANGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "CLUB_MEMBER_410", "개설자의 역할은 변경할 수 없습니다. 개설자 위임을 사용하세요."),
     CLUB_OWNER_NOT_FOUND(HttpStatus.NOT_FOUND, "CLUB_MEMBER_411", "독서 모임 개설자를 찾을 수 없습니다."),
+    CLUB_PARTICIPANTS_JOIN_REQUIRED(HttpStatus.FORBIDDEN, "CLUB_MEMBER_412", "모임 회원은 가입 후에 조회 가능합니다"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/checkmo/clubManagement/internal/repository/ClubMemberRepository.java
+++ b/src/main/java/checkmo/clubManagement/internal/repository/ClubMemberRepository.java
@@ -38,4 +38,6 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     List<ClubMember> findByClubIdAndStatuses(Long clubId, EnumSet<ClubMemberStatus> statuses, Long cursorId, Pageable pageable);
 
     List<ClubMember> findAllByMemberIdAndClubIdIn(String memberId, List<Long> clubIds);
+
+    long countByClubIdAndClubMemberStatusIn(Long clubId, EnumSet<ClubMemberStatus> statuses);
 }

--- a/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
@@ -216,6 +216,50 @@ public class ClubManagementQueryFacade {
                 .build();
     }
 
+    public ClubResponseDTO.ClubParticipantList retrieveClubParticipantList(
+            Long clubId,
+            String requesterId,
+            Long cursorId
+    ) {
+        Club club = clubManagementQueryService.validateClub(clubId);
+        validateClubParticipantListAccess(club, clubId, requesterId);
+
+        CursorResult<ClubMember> clubMemberCursorResult = CursorPagingHelper.getPage(
+                size -> clubMemberQueryService.retrieveClubMembers(clubId, ClubMemberStatus.activeStatuses(), cursorId, size),
+                ClubMember::getId,
+                DEFAULT_PAGE_SIZE
+        );
+        List<ClubMember> clubMembers = clubMemberCursorResult.content();
+        List<String> memberIds = ExtractHelper.extractDistinctList(clubMembers, ClubMember::getMemberId);
+
+        Map<String, MemberExternalDTO.BasicInfoWithFollow> memberInfoMap =
+                memberAPI.fetchMemberBasicInfoWithFollowByMemberId(memberIds, requesterId);
+
+        List<ClubResponseDTO.ClubParticipant> dtoList = clubMembers.stream()
+                .map(cm -> ClubManagementConverter.toClubParticipantDTO(cm, memberInfoMap.get(cm.getMemberId())))
+                .toList();
+
+        return ClubResponseDTO.ClubParticipantList.builder()
+                .clubMembers(dtoList)
+                .totalCount(clubMemberQueryService.countActiveClubMembers(clubId))
+                .hasNext(clubMemberCursorResult.hasNext())
+                .nextCursor(clubMemberCursorResult.nextCursor())
+                .build();
+    }
+
+    private void validateClubParticipantListAccess(Club club, Long clubId, String requesterId) {
+        if (club.isOpen()) {
+            return;
+        }
+
+        boolean activeMember = clubMemberQueryService.findClubMember(clubId, requesterId)
+                .map(ClubMember::isActive)
+                .orElse(false);
+        if (!activeMember) {
+            throw new ClubManagementException(ClubManagementErrorStatus.CLUB_PARTICIPANTS_JOIN_REQUIRED);
+        }
+    }
+
     public ClubRecommendationList recommend(String memberId) {
         List<String> memberInterestCategories = memberAPI.fetchInterestCategory(memberId).getCategories();
         EnumSet<ClubInterestCategory> interestCategories = mapToClubInterestCategories(memberInterestCategories);

--- a/src/main/java/checkmo/clubManagement/internal/service/query/ClubMemberQueryService.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/query/ClubMemberQueryService.java
@@ -75,6 +75,10 @@ public class ClubMemberQueryService {
         return clubMemberRepository.findByClubIdAndStatuses(clubId, statuses, null, Pageable.unpaged());
     }
 
+    public long countActiveClubMembers(Long clubId) {
+        return clubMemberRepository.countByClubIdAndClubMemberStatusIn(clubId, ClubMemberStatus.activeStatuses());
+    }
+
     public List<String> retrieveActiveMemberIds(Long clubId) {
         return clubMemberRepository.findByClubIdAndStatuses(clubId, ClubMemberStatus.activeStatuses(), null,
                         Pageable.unpaged())

--- a/src/main/java/checkmo/clubManagement/web/controller/ClubController.java
+++ b/src/main/java/checkmo/clubManagement/web/controller/ClubController.java
@@ -239,6 +239,26 @@ public class ClubController {
         return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveClubMemberList(clubId, memberId, status, cursorId));
     }
 
+    @Operation(summary = "독서 모임 참여자 목록 조회", description = "공개 모임은 로그인 회원이 조회할 수 있고, 비공개 모임은 가입한 모임 회원만 조회할 수 있습니다.")
+    @Parameters({
+            @Parameter(name = "clubId", description = "조회할 독서 모임 ID", required = true, example = "1"),
+            @Parameter(name = "cursorId", description = "커서 기반 페이지네이션을 위한 마지막 독서 모임 회원 ID", required = false, example = "10"),
+    })
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "비공개 모임의 회원 목록은 가입 후 조회할 수 있습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 독서 모임입니다."),
+    })
+    @GetMapping("/{clubId}/participants")
+    public ApiResponse<ClubResponseDTO.ClubParticipantList> getClubParticipants(
+            @PathVariable Long clubId,
+            @RequestParam(required = false) Long cursorId,
+            @CurrentId String memberId
+    ) {
+        return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveClubParticipantList(clubId, memberId, cursorId));
+    }
+
     @Operation(summary = "[운영진] 독서 모임 회원 등급 수정", description = "독서 모임 회원의 등급을 수정합니다.")
     @Parameters({
             @Parameter(name = "clubId", description = "수정할 독서 모임 ID", required = true, example = "1"),

--- a/src/main/java/checkmo/clubManagement/web/dto/ClubResponseDTO.java
+++ b/src/main/java/checkmo/clubManagement/web/dto/ClubResponseDTO.java
@@ -186,6 +186,30 @@ public class ClubResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
+    public static class ClubParticipantList {
+        private List<ClubParticipant> clubMembers;
+        private long totalCount;
+        private boolean hasNext;
+        private Long nextCursor;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ClubParticipant {
+        private Long clubMemberId;
+        private String nickname;
+        private String profileImageUrl;
+        private boolean following;
+        private String clubMemberStatus;
+        private boolean staff;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
     public static class ClubRecommendationList {
         private List<ClubRecommendation> recommendations;
     }

--- a/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
+++ b/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
@@ -176,6 +176,81 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
     }
 
     @Test
+    void publicClubParticipantsCanBeViewedByLoggedInNonMemberWithFollowStatus() {
+        TestUser owner = createUser();
+        TestUser member = createUser();
+        TestUser viewer = createUser();
+        Club club = createClub(owner, "participants-open-" + uniqueSuffix(owner));
+        joinClub(member, club.getId());
+
+        given().cookie(accessTokenCookie(viewer))
+                .when().post("/api/v1/members/{memberNickname}/following", member.nickName())
+                .then().statusCode(200);
+
+        Response response = given().cookie(accessTokenCookie(viewer))
+                .when().get("/api/v1/clubs/{clubId}/participants", club.getId())
+                .then().statusCode(200)
+                .body("result.totalCount", equalTo(2))
+                .body("result.hasNext", equalTo(false))
+                .extract().response();
+
+        List<Map<String, Object>> participants = response.jsonPath().getList("result.clubMembers");
+        assertThat(participants).hasSize(2);
+        assertThat(participants).allSatisfy(participant ->
+                assertThat(participant.keySet()).contains(
+                        "clubMemberId",
+                        "nickname",
+                        "profileImageUrl",
+                        "following",
+                        "clubMemberStatus",
+                        "staff"
+                )
+        );
+        assertThat(participants).anySatisfy(participant -> {
+            assertThat(participant).containsEntry("nickname", owner.nickName());
+            assertThat(participant).containsEntry("following", false);
+            assertThat(participant).containsEntry("clubMemberStatus", "OWNER");
+            assertThat(participant).containsEntry("staff", true);
+        });
+        assertThat(participants).anySatisfy(participant -> {
+            assertThat(participant).containsEntry("nickname", member.nickName());
+            assertThat(participant).containsEntry("following", true);
+            assertThat(participant).containsEntry("clubMemberStatus", "MEMBER");
+            assertThat(participant).containsEntry("staff", false);
+        });
+
+        given().cookie(accessTokenCookie(member))
+                .queryParam("status", "ACTIVE")
+                .when().get("/api/v1/clubs/{clubId}/members", club.getId())
+                .then().statusCode(403);
+    }
+
+    @Test
+    void privateClubParticipantsRequireActiveClubMember() {
+        TestUser owner = createUser();
+        TestUser pendingMember = createUser();
+        TestUser outsider = createUser();
+        Club club = createClub(owner, "participants-private-" + uniqueSuffix(owner), false);
+        joinClub(pendingMember, club.getId());
+
+        Response response = given().cookie(accessTokenCookie(owner))
+                .when().get("/api/v1/clubs/{clubId}/participants", club.getId())
+                .then().statusCode(200)
+                .body("result.totalCount", equalTo(1))
+                .extract().response();
+
+        List<Map<String, Object>> participants = response.jsonPath().getList("result.clubMembers");
+        assertThat(participants).hasSize(1);
+        assertThat(participants.getFirst())
+                .containsEntry("nickname", owner.nickName())
+                .containsEntry("clubMemberStatus", "OWNER")
+                .containsEntry("staff", true);
+
+        assertParticipantsJoinRequired(pendingMember, club.getId());
+        assertParticipantsJoinRequired(outsider, club.getId());
+    }
+
+    @Test
     void bookshelfMeetingTopicReviewAndChatFlowCoversRestEndpoints() {
         TestUser owner = createUser();
         Club club = createClub(owner, "bookshelf" + uniqueSuffix(owner));
@@ -393,6 +468,21 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
                 .filter(club -> club.getName().equals(name))
                 .findFirst()
                 .orElseThrow();
+    }
+
+    private void joinClub(TestUser user, Long clubId) {
+        given().cookie(accessTokenCookie(user))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("joinMessage", "함께 읽고 싶습니다."))
+                .when().post("/api/v1/clubs/{clubId}/join", clubId)
+                .then().statusCode(200);
+    }
+
+    private void assertParticipantsJoinRequired(TestUser user, Long clubId) {
+        given().cookie(accessTokenCookie(user))
+                .when().get("/api/v1/clubs/{clubId}/participants", clubId)
+                .then().statusCode(403)
+                .body("message", equalTo("모임 회원은 가입 후에 조회 가능합니다"));
     }
 
     private Meeting createMeeting(TestUser owner, Long clubId) {


### PR DESCRIPTION
## 🚀 변경사항
<!-- 뭘 구현했는지/수정했는지 간단히 -->

## 🔗 관련 이슈
- Closes #이슈번호

## ✅ 체크리스트
- [ ] 로컬에서 테스트 완료
- [ ] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a participants view for clubs, including paginated results and participant details such as nickname, profile image, follow state, status, and staff role.
  * Private clubs now restrict participant viewing to members only, with clear access-denied responses for non-members.
* **Bug Fixes**
  * Improved participant list behavior to return accurate totals and pagination info.
  * Added support for showing whether a participant is being followed by the current user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->