### PR TITLE
fix: 사용자 입력 길이 검증과 엔티티 컬럼 길이 정렬

### DIFF
--- a/src/main/java/checkmo/bookStory/internal/entity/Comment.java
+++ b/src/main/java/checkmo/bookStory/internal/entity/Comment.java
@@ -3,6 +3,7 @@ package checkmo.bookStory.internal.entity;
 import checkmo.bookStory.internal.exception.BookStoryErrorStatus;
 import checkmo.bookStory.internal.exception.BookStoryException;
 import checkmo.common.BaseEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -32,6 +33,7 @@ public class Comment extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(length = 300)
     private String content;
 
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/checkmo/bookStory/web/dto/BookStoryRequestDTO.java
+++ b/src/main/java/checkmo/bookStory/web/dto/BookStoryRequestDTO.java
@@ -3,6 +3,7 @@ package checkmo.bookStory.web.dto;
 import checkmo.bookStory.internal.entity.BookStoryStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,8 +21,10 @@ public class BookStoryRequestDTO {
         private String isbn;
 
         @NotBlank(message = "책 이야기에 제목을 입력해주세요.")
+        @Size(max = 100, message = "책 이야기 제목은 100자 이하로 입력해주세요.")
         private String title;
 
+        @Size(max = 5000, message = "책 이야기 본문은 5000자 이하로 입력해주세요.")
         private String description;
 
         private BookStoryStatus status;
@@ -34,8 +37,10 @@ public class BookStoryRequestDTO {
         private String isbn;
 
         @NotBlank(message = "책 이야기에 수정할 제목을 입력해주세요.")
+        @Size(max = 100, message = "책 이야기 제목은 100자 이하로 입력해주세요.")
         private String title;
 
+        @Size(max = 5000, message = "책 이야기 본문은 5000자 이하로 입력해주세요.")
         private String description;
 
         private BookStoryStatus status;
@@ -45,6 +50,7 @@ public class BookStoryRequestDTO {
     @NoArgsConstructor
     public static class CommentCreate {
         @NotBlank(message = "댓글 내용을 입력해주세요.")
+        @Size(max = 300, message = "댓글은 300자 이하로 입력해주세요.")
         private String content;
     }
 
@@ -52,6 +58,7 @@ public class BookStoryRequestDTO {
     @NoArgsConstructor
     public static class CommentUpdate {
         @NotBlank(message = "수정할 댓글 내용을 입력해주세요.")
+        @Size(max = 300, message = "댓글은 300자 이하로 입력해주세요.")
         private String content;
     }
 }

--- a/src/main/java/checkmo/clubManagement/internal/entity/Club.java
+++ b/src/main/java/checkmo/clubManagement/internal/entity/Club.java
@@ -39,6 +39,7 @@ public class Club extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String name;
 
+    @Column(length = 500)
     private String description;
 
     private String profileImgUrl;

--- a/src/main/java/checkmo/clubManagement/internal/entity/ClubMember.java
+++ b/src/main/java/checkmo/clubManagement/internal/entity/ClubMember.java
@@ -35,6 +35,7 @@ public class ClubMember extends BaseEntity {
     @Column(nullable = false)
     private ClubMemberStatus clubMemberStatus;
 
+    @Column(length = 300)
     private String joinMessage;
 
     private LocalDateTime appliedAt; // 이번 가입 신청일

--- a/src/main/java/checkmo/clubMeeting/internal/entity/BookReview.java
+++ b/src/main/java/checkmo/clubMeeting/internal/entity/BookReview.java
@@ -28,6 +28,7 @@ public class BookReview extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(length = 300, nullable = false)
     private String description;
 
     private double rate;

--- a/src/main/java/checkmo/clubMeeting/internal/entity/Topic.java
+++ b/src/main/java/checkmo/clubMeeting/internal/entity/Topic.java
@@ -34,6 +34,7 @@ public class Topic extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(length = 300, nullable = false)
     private String description;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/checkmo/clubNotice/web/dto/ClubNoticeRequestDTO.java
+++ b/src/main/java/checkmo/clubNotice/web/dto/ClubNoticeRequestDTO.java
@@ -127,6 +127,7 @@ public class ClubNoticeRequestDTO {
     @NoArgsConstructor
     public static class CreateClubNoticeComment {
         @NotBlank(message = "공지사항 댓글 내용은 필수입니다.")
+        @Size(max = 300, message = "공지사항 댓글은 300자 이하로 입력해주세요.")
         private String content;
     }
 }


### PR DESCRIPTION
## 변경사항
- 사용자 입력 길이 정책에 맞춰 BE DTO validation을 추가했습니다.
  - 책이야기 제목: 100자
  - 책이야기 본문: 5000자
  - 책이야기 댓글/대댓글: 300자
  - 공지 댓글: 300자
- DB 저장 길이와 맞도록 entity 컬럼 길이를 명시했습니다.
  - 모임 소개글: 500자
  - 모임 가입 메시지: 300자
  - 책이야기 댓글: 300자
  - 발제/한줄평: 300자
- DB migration 파일은 포함하지 않았습니다. 운영 DB ALTER는 별도 수동 적용 예정입니다.

## 관련 이슈
- Closes #261

## 체크리스트
- [x] 로컬에서 컴파일 완료
- [x] Modulith 검증 테스트 완료
- [x] 코드 리뷰 준비 완료

## 특이사항
배포 전 운영 DB에 아래 ALTER를 먼저 적용해야 합니다.

```sql
ALTER TABLE club MODIFY COLUMN description VARCHAR(500);
ALTER TABLE club_member MODIFY COLUMN join_message VARCHAR(300);
ALTER TABLE comment MODIFY COLUMN content VARCHAR(300);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added length limits and validation for story, review, notice, club, and comment text fields to prevent oversized submissions.
  * Strengthened required content rules in several areas so empty or overly long text is rejected earlier.
  * Updated stored text limits for descriptions and messages to better match what the app accepts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->