### PR TITLE
feat: 앱 소셜 로그인 딥링크 콜백 지원 (#263)

### DIFF
--- a/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
+++ b/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package checkmo.authentication.internal.config;
 
 import checkmo.authentication.internal.security.auth.ProfileCompletionAuthorizationFilter;
 import checkmo.authentication.internal.security.jwt.JwtAuthenticationFilter;
+import checkmo.authentication.internal.security.oauth2.AppAwareOAuth2AuthorizationRequestResolver;
 import checkmo.authentication.internal.security.oauth2.CustomOAuth2UserService;
 import checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationFailureHandler;
 import checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationSuccessHandler;
@@ -18,6 +19,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -34,7 +36,8 @@ public class SecurityConfig {
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http,
+            ClientRegistrationRepository clientRegistrationRepository) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
@@ -76,6 +79,10 @@ public class SecurityConfig {
         // OAuth2 로그인 설정
         http
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authorization -> authorization
+                                .authorizationRequestResolver(
+                                        new AppAwareOAuth2AuthorizationRequestResolver(clientRegistrationRepository))
+                        )
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService)
                         )
                         .successHandler(oAuth2AuthenticationSuccessHandler) // 로그인 성공 핸들러 설정

--- a/src/main/java/checkmo/authentication/internal/exception/AuthErrorStatus.java
+++ b/src/main/java/checkmo/authentication/internal/exception/AuthErrorStatus.java
@@ -31,7 +31,8 @@ public enum AuthErrorStatus implements BaseErrorCode {
     PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "AUTH_409", "새 비밀번호가 기존 비밀번호와 동일합니다."),
     NICKNAME_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH_410", "닉네임은 필수입니다."),
     SIGNUP_INCOMPLETE(HttpStatus.CONFLICT, "AUTH_411", "이미 가입 진행 중인 이메일입니다. 로그인 후 프로필을 완성해주세요."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_412", "유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요.")
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_412", "유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요."),
+    INVALID_OAUTH_CODE(HttpStatus.UNAUTHORIZED, "AUTH_413", "유효하지 않거나 만료된 인증 코드입니다. 다시 로그인해주세요.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/checkmo/authentication/internal/security/jwt/TokenCacheService.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/TokenCacheService.java
@@ -22,6 +22,13 @@ public class TokenCacheService {
 
     private static final String REFRESH_TOKEN_PREFIX = "refreshToken::";
     private static final String BLACKLIST_PREFIX = "blacklist::";
+    private static final String OAUTH_CODE_PREFIX = "oauthCode::";
+    private static final long OAUTH_CODE_TTL_MS = 120_000L; // 앱 소셜 로그인 일회용 코드 2분
+    private static final String CONSUME_OAUTH_CODE_SCRIPT = """
+            local v = redis.call('GET', KEYS[1])
+            if v then redis.call('DEL', KEYS[1]) end
+            return v
+            """;
     private static final String COMPARE_AND_ROTATE_REFRESH_TOKEN_SCRIPT = """
             local current = redis.call('GET', KEYS[1])
             if current == ARGV[1] or current == ARGV[2] then
@@ -93,6 +100,33 @@ public class TokenCacheService {
         byte[] expected = serialize(expectedRefreshToken);
         byte[] legacyExpected = serializeLegacyValue(expectedRefreshToken);
         return executeBooleanScript(DELETE_REFRESH_TOKEN_IF_MATCHES_SCRIPT, key, expected, legacyExpected);
+    }
+
+    // 앱 소셜 로그인 일회용 코드 저장 (단기 TTL). value는 "isProfileCompleted|refreshToken" 형태.
+    public void saveOAuthExchangeCode(String code, String value) {
+        byte[] key = serialize(OAUTH_CODE_PREFIX + code);
+        redisTemplate.execute((RedisCallback<Boolean>) connection ->
+                connection.stringCommands().set(
+                        key,
+                        serialize(value),
+                        Expiration.milliseconds(OAUTH_CODE_TTL_MS),
+                        SetOption.upsert()
+                )
+        );
+    }
+
+    // 일회용 코드를 원자적으로 조회+삭제 (1회만 사용 가능). 없으면 null.
+    public String consumeOAuthExchangeCode(String code) {
+        byte[] key = serialize(OAUTH_CODE_PREFIX + code);
+        byte[] value = redisTemplate.execute((RedisCallback<byte[]>) connection ->
+                connection.scriptingCommands().eval(
+                        CONSUME_OAUTH_CODE_SCRIPT.getBytes(StandardCharsets.UTF_8),
+                        ReturnType.VALUE,
+                        1,
+                        key
+                )
+        );
+        return value == null ? null : STRING_SERIALIZER.deserialize(value);
     }
 
     private boolean executeBooleanScript(String script, byte[] key, byte[]... args) {

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppAwareOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppAwareOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,54 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+/**
+ * 네이티브 앱에서 시작한 소셜 로그인을 식별하는 Authorization Request Resolver.
+ * <p>
+ * 앱은 {@code /oauth2/authorization/{provider}?client=app} 으로 진입한다. 이때 세션에 클라이언트
+ * 타입을 저장해 두면, OAuth2 round-trip 후 성공/실패 핸들러가 이를 읽어 웹(쿠키) 대신
+ * {@code checkmo://} 딥링크로 응답할 수 있다. (BE 이슈 #263)
+ * <p>
+ * SecurityConfig가 STATELESS여도 OAuth2 authorization request 저장을 위해 세션은 생성되므로
+ * 동일 세션에 플래그를 함께 보관한다.
+ */
+public class AppAwareOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    public static final String SESSION_CLIENT_TYPE = "OAUTH2_CLIENT_TYPE";
+    public static final String CLIENT_TYPE_APP = "app";
+    private static final String CLIENT_PARAM = "client";
+
+    private final DefaultOAuth2AuthorizationRequestResolver delegate;
+
+    public AppAwareOAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        this.delegate = new DefaultOAuth2AuthorizationRequestResolver(
+                clientRegistrationRepository, "/oauth2/authorization");
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request);
+        captureClientType(request, authorizationRequest);
+        return authorizationRequest;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request, clientRegistrationId);
+        captureClientType(request, authorizationRequest);
+        return authorizationRequest;
+    }
+
+    private void captureClientType(HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest) {
+        if (authorizationRequest == null) {
+            return;
+        }
+        if (CLIENT_TYPE_APP.equalsIgnoreCase(request.getParameter(CLIENT_PARAM))) {
+            request.getSession().setAttribute(SESSION_CLIENT_TYPE, CLIENT_TYPE_APP);
+        }
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -2,8 +2,10 @@ package checkmo.authentication.internal.security.oauth2;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -11,11 +13,15 @@ import org.springframework.stereotype.Component;
 /**
  * 소셜 로그인 실패 시 실패 처리 핸들러
  * <p>
- * OAuth2 인증 실패 시 적절한 에러 페이지로 리다이렉트하거나 메인 페이지로 리다이렉트
+ * OAuth2 인증 실패 시 적절한 에러 페이지로 리다이렉트한다. 앱(네이티브)에서 시작한 경우
+ * (세션에 OAUTH2_CLIENT_TYPE=app)에는 checkmo:// 딥링크로 에러를 전달한다. (BE 이슈 #263)
  */
 @Slf4j
 @Component
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Value("${app.oauth2.redirect.app-uri}")
+    private String appUri;
 
     @Override
     public void onAuthenticationFailure(
@@ -24,7 +30,18 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
         log.error("소셜 로그인 인증 실패: {}", exception.getMessage());
 
-        // 실패 시 리다이렉트 URL 설정
+        HttpSession session = request.getSession(false);
+        boolean isApp = session != null && AppAwareOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP
+                .equals(session.getAttribute(AppAwareOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE));
+
+        // 앱: 딥링크로 에러 전달
+        if (isApp) {
+            session.removeAttribute(AppAwareOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE);
+            getRedirectStrategy().sendRedirect(request, response, appUri + "?error=login_failed");
+            return;
+        }
+
+        // 웹: 기존 실패 리다이렉트
         getRedirectStrategy().sendRedirect(request, response, "/login?error=true");
     }
 }

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -3,10 +3,12 @@ package checkmo.authentication.internal.security.oauth2;
 import checkmo.authentication.internal.entity.AuthUser;
 import checkmo.authentication.internal.security.auth.PrincipalDetails;
 import checkmo.authentication.internal.security.jwt.JwtLoginProcessor;
+import checkmo.authentication.internal.security.jwt.TokenCacheService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -26,6 +28,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtLoginProcessor jwtLoginProcessor;
+    private final TokenCacheService tokenCacheService;
 
     @Value("${app.oauth2.redirect.base-uri}")
     private String baseUri;
@@ -51,12 +54,14 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         clearAuthenticationAttributes(request);
 
-        // 앱: 쿠키/웹 대신 딥링크로 토큰 전달
+        // 앱: 보안상 refreshToken을 딥링크에 직접 싣지 않고, 단기 일회용 코드만 전달한다.
+        // 앱은 이 코드를 POST /auth/app/oauth/exchange 로 보내 refreshToken(바디)으로 교환한다. (이메일 /app/login과 동일 구조)
         if (isApp) {
             session.removeAttribute(AppAwareOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE);
+            String oneTimeCode = UUID.randomUUID().toString().replace("-", "");
+            tokenCacheService.saveOAuthExchangeCode(oneTimeCode, user.isProfileCompleted() + "|" + refreshToken);
             String appTargetUrl = UriComponentsBuilder.fromUriString(appUri)
-                    .queryParam("refreshToken", refreshToken)
-                    .queryParam("isProfileCompleted", user.isProfileCompleted())
+                    .queryParam("code", oneTimeCode)
                     .build()
                     .encode()
                     .toUriString();

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -5,6 +5,7 @@ import checkmo.authentication.internal.security.auth.PrincipalDetails;
 import checkmo.authentication.internal.security.jwt.JwtLoginProcessor;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,7 +17,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 /**
  * 소셜 로그인 성공 후의 성공 처리 핸들러
  * <p>
- * CustomOAuth2UserService에서 인증 성공 후 이 Success Handler로 요청이 자동으로 넘어와서 JWT 토큰 생성, 쿠키 설정등등 작업 수행
+ * CustomOAuth2UserService에서 인증 성공 후 이 Success Handler로 요청이 자동으로 넘어와서 JWT 토큰 생성, 쿠키 설정등등 작업 수행.
+ * 앱(네이티브)에서 시작한 경우(세션에 OAUTH2_CLIENT_TYPE=app)에는 웹 리다이렉트 대신
+ * checkmo:// 딥링크로 refreshToken을 전달한다. (BE 이슈 #263)
  */
 @Component
 @RequiredArgsConstructor
@@ -27,20 +30,42 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     @Value("${app.oauth2.redirect.base-uri}")
     private String baseUri;
 
+    @Value("${app.oauth2.redirect.app-uri}")
+    private String appUri;
+
     @Override
     public void onAuthenticationSuccess(
             HttpServletRequest request, HttpServletResponse response,
             Authentication authentication
     ) throws IOException {
 
-        // JWT 토큰 생성 및 쿠키 설정
-        jwtLoginProcessor.processLogin(response, authentication);
+        // JWT 토큰 생성 및 쿠키 설정 + refreshToken 확보
+        String refreshToken = jwtLoginProcessor.processLogin(response, authentication);
 
         PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
         AuthUser user = principalDetails.getUser();
 
-        String targetUrl;
+        HttpSession session = request.getSession(false);
+        boolean isApp = session != null && AppAwareOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP
+                .equals(session.getAttribute(AppAwareOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE));
 
+        clearAuthenticationAttributes(request);
+
+        // 앱: 쿠키/웹 대신 딥링크로 토큰 전달
+        if (isApp) {
+            session.removeAttribute(AppAwareOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE);
+            String appTargetUrl = UriComponentsBuilder.fromUriString(appUri)
+                    .queryParam("refreshToken", refreshToken)
+                    .queryParam("isProfileCompleted", user.isProfileCompleted())
+                    .build()
+                    .encode()
+                    .toUriString();
+            getRedirectStrategy().sendRedirect(request, response, appTargetUrl);
+            return;
+        }
+
+        // 웹: 기존 쿠키 + 웹 리다이렉트
+        String targetUrl;
         if (user.isProfileCompleted()) {
             targetUrl = UriComponentsBuilder.fromUriString(baseUri)
                     .path("/")
@@ -54,8 +79,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                     .toUriString();
         }
 
-        // 성공 후 리다이렉트 URL 설정
-        clearAuthenticationAttributes(request);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/checkmo/authentication/internal/service/AuthFacade.java
+++ b/src/main/java/checkmo/authentication/internal/service/AuthFacade.java
@@ -8,7 +8,11 @@ import checkmo.authentication.internal.service.result.AuthTokenRotationResult;
 import checkmo.authentication.internal.service.command.AuthSessionCommandService;
 import checkmo.authentication.internal.service.command.AuthUserCommandService;
 import checkmo.authentication.internal.service.result.AuthSignUpResult;
+import checkmo.authentication.internal.exception.AuthErrorStatus;
+import checkmo.authentication.internal.exception.AuthException;
+import checkmo.authentication.internal.security.jwt.TokenCacheService;
 import checkmo.authentication.web.dto.AuthRequestDTO;
+import checkmo.authentication.web.dto.AuthResponseDTO;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +27,7 @@ public class AuthFacade {
     private final AuthSessionCommandService authSessionCommandService;
     private final AuthTokenRotationService authTokenRotationService;
     private final JwtLoginProcessor jwtLoginProcessor;
+    private final TokenCacheService tokenCacheService;
 
     public AuthSignUpResult signUp(AuthRequestDTO.SignUp request, HttpServletResponse response) {
         AuthUser user = authUserCommandService.signUp(request);
@@ -41,6 +46,21 @@ public class AuthFacade {
 
         // JWT 토큰 생성 및 쿠키 설정, Refresh Token 반환
         return jwtLoginProcessor.processLogin(response, authentication);
+    }
+
+    // 앱 소셜 로그인: 딥링크로 받은 일회용 코드를 refreshToken으로 교환 (이메일 /app/login과 동일하게 바디로 반환)
+    public AuthResponseDTO.AppOAuthLogin exchangeOAuthCode(String code) {
+        String stored = tokenCacheService.consumeOAuthExchangeCode(code);
+        if (stored == null || stored.indexOf('|') < 0) {
+            throw new AuthException(AuthErrorStatus.INVALID_OAUTH_CODE);
+        }
+        int separator = stored.indexOf('|');
+        boolean isProfileCompleted = "true".equals(stored.substring(0, separator));
+        String refreshToken = stored.substring(separator + 1);
+        return AuthResponseDTO.AppOAuthLogin.builder()
+                .refreshToken(refreshToken)
+                .isProfileCompleted(isProfileCompleted)
+                .build();
     }
 
     public void logout(HttpServletRequest request, HttpServletResponse response) {

--- a/src/main/java/checkmo/authentication/web/controller/AuthController.java
+++ b/src/main/java/checkmo/authentication/web/controller/AuthController.java
@@ -107,6 +107,18 @@ public class AuthController {
         return ApiResponse.onSuccess(AuthResponseDTO.Login.builder().refreshToken(refreshToken).build());
     }
 
+    @Operation(summary = "앱 소셜 로그인 코드 교환", description = "딥링크로 받은 일회용 코드를 refreshToken으로 교환합니다.")
+    @PostMapping("/app/oauth/exchange")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않거나 만료된 인증 코드입니다.")
+    })
+    public ApiResponse<AuthResponseDTO.AppOAuthLogin> appOAuthExchange(
+            @Valid @RequestBody AuthRequestDTO.OAuthExchange request
+    ) {
+        return ApiResponse.onSuccess(authFacade.exchangeOAuthCode(request.getCode()));
+    }
+
     @Operation(summary = "앱 토큰 재발급", description = "앱에서 리프레시 토큰을 회전하고 새 토큰을 발급받습니다.")
     @PostMapping("/app/refresh")
     @io.swagger.v3.oas.annotations.responses.ApiResponses({

--- a/src/main/java/checkmo/authentication/web/dto/AuthRequestDTO.java
+++ b/src/main/java/checkmo/authentication/web/dto/AuthRequestDTO.java
@@ -68,4 +68,13 @@ public class AuthRequestDTO {
         @NotBlank(message = "인증 코드는 필수입니다")
         private String verificationCode;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OAuthExchange {
+        @NotBlank(message = "코드는 필수입니다")
+        @Schema(description = "딥링크로 전달받은 일회용 코드")
+        private String code;
+    }
 }

--- a/src/main/java/checkmo/authentication/web/dto/AuthResponseDTO.java
+++ b/src/main/java/checkmo/authentication/web/dto/AuthResponseDTO.java
@@ -23,4 +23,13 @@ public class AuthResponseDTO {
     public static class Login {
         private String refreshToken;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AppOAuthLogin {
+        private String refreshToken;
+        private boolean isProfileCompleted;
+    }
 }

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -2,6 +2,7 @@ app:
   oauth2:
     redirect:
       base-uri: ${FRONTEND_BASE_URI}
+      app-uri: ${APP_OAUTH2_REDIRECT_URI:checkmo://oauth-callback}
 
 spring:
   security:


### PR DESCRIPTION
네이티브 앱에서 시작한 소셜 로그인(?client=app)을 식별해, 웹 쿠키 리다이렉트 대신 checkmo:// 딥링크로 refreshToken을 전달한다. 기존 웹 OAuth2 플로우는 그대로 유지.

- AppAwareOAuth2AuthorizationRequestResolver: ?client=app를 세션에 저장
- 성공 핸들러: 앱이면 checkmo://oauth-callback?refreshToken=&isProfileCompleted= 로 리다이렉트
- 실패 핸들러: 앱이면 checkmo://oauth-callback?error=login_failed
- application-oauth2.yml: app-uri 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for app-based OAuth2 login flows, including deep-link redirects back to the mobile app.
  * Login flows now preserve whether the sign-in started from the app or web, enabling different post-login destinations.

* **Bug Fixes**
  * Improved OAuth2 failure handling so app logins return to the app with a clear error message instead of the standard web login page.
  * Web and app users now receive the appropriate redirect after authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->