### PR TITLE
feat(app-version): 앱 버전 정책 조회 API 추가

### DIFF
--- a/docs/api-test/coverage-matrix.md
+++ b/docs/api-test/coverage-matrix.md
@@ -17,6 +17,7 @@
 | 컨트롤러 | 메서드 | 경로 | 상태 | 테스트를 추가하는 이유 |
 | --- | --- | --- | --- | --- |
 | HealthCheckController | GET | `/health` | 완료 | 인증 없이 서비스 상태를 확인하는 기준점이다. |
+| AppVersionController | GET | `/api/v1/app/version` | 완료 | 앱 부팅/로그인 전 버전 정책 공개 조회, 플랫폼별 응답, 잘못된 platform, 정책 없음 실패를 검증한다. |
 | AuthController | POST | `/api/v1/auth/email-verification` | 완료 | 회원가입 전 이메일 인증 요청의 성공, 이메일 형식 오류, 중복 요청을 검증한다. |
 | AuthController | POST | `/api/v1/auth/email-verification/confirm` | 완료 | 인증 코드 일치, 만료, 불일치 상태를 검증한다. |
 | AuthController | POST | `/api/v1/auth/signup` | 완료 | 가입 성공, 중복 이메일/닉네임, 검증 실패 payload를 검증한다. |

--- a/docs/api-test/test-rationale.md
+++ b/docs/api-test/test-rationale.md
@@ -15,6 +15,15 @@
 | `incompleteProfileFixtureIsBlockedBeforeProtectedApiExecution` | 프로필 미완료 사용자가 보호 API에서 403으로 차단되는 전역 필터 계약을 고정한다. |
 | `adminFixtureCanIssueJwtCookies` | 관리자 API 배치를 만들기 전에 `ROLE_ADMIN` JWT fixture가 정상 생성되는지 확인한다. |
 
+## AppVersionApiTest
+
+| 테스트 | 추가 이유 |
+| --- | --- |
+| `앱_버전_정책은_로그인_없이_플랫폼별로_조회된다` | 앱 부팅/로그인 전 호출되는 iOS 버전 정책 API가 인증 없이 공통 응답 계약으로 내려오는지 검증한다. |
+| `앱_버전_정책은_android_플랫폼도_조회된다` | Android 앱이 별도 스토어 URL과 버전 기준값을 받을 수 있는지 검증한다. |
+| `지원하지_않는_platform은_거절된다` | 클라이언트가 `ios/android` 외 platform을 보내면 정책 조회가 400으로 실패하는 계약을 고정한다. |
+| `활성_버전_정책이_없으면_404를_반환한다` | 운영 DB에 활성 정책이 없을 때 잘못된 기본값 대신 명시적 실패를 반환하는지 검증한다. |
+
 ## AuthApiTest
 
 | 테스트 | 추가 이유 |

--- a/src/main/java/checkmo/appVersion/internal/converter/AppVersionConverter.java
+++ b/src/main/java/checkmo/appVersion/internal/converter/AppVersionConverter.java
@@ -1,0 +1,18 @@
+package checkmo.appVersion.internal.converter;
+
+import checkmo.appVersion.internal.entity.AppVersionPolicy;
+import checkmo.appVersion.web.dto.AppVersionResponseDTO.VersionPolicy;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AppVersionConverter {
+
+    public static VersionPolicy toVersionPolicy(AppVersionPolicy policy) {
+        return VersionPolicy.builder()
+                .minSupportedVersion(policy.getMinSupportedVersion())
+                .latestVersion(policy.getLatestVersion())
+                .storeUrl(policy.getStoreUrl())
+                .build();
+    }
+}

--- a/src/main/java/checkmo/appVersion/internal/entity/AppPlatform.java
+++ b/src/main/java/checkmo/appVersion/internal/entity/AppPlatform.java
@@ -1,0 +1,19 @@
+package checkmo.appVersion.internal.entity;
+
+import checkmo.appVersion.internal.exception.AppVersionErrorStatus;
+import checkmo.appVersion.internal.exception.AppVersionException;
+import java.util.Arrays;
+
+public enum AppPlatform {
+    IOS,
+    ANDROID;
+
+    public static AppPlatform from(String value) {
+        String normalized = value == null ? "" : value.trim();
+
+        return Arrays.stream(values())
+                .filter(platform -> platform.name().equalsIgnoreCase(normalized))
+                .findFirst()
+                .orElseThrow(() -> new AppVersionException(AppVersionErrorStatus.INVALID_PLATFORM));
+    }
+}

--- a/src/main/java/checkmo/appVersion/internal/entity/AppVersionPolicy.java
+++ b/src/main/java/checkmo/appVersion/internal/entity/AppVersionPolicy.java
@@ -1,0 +1,47 @@
+package checkmo.appVersion.internal.entity;
+
+import checkmo.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(name = "UK_app_version_policy_platform", columnNames = "platform")
+})
+public class AppVersionPolicy extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private AppPlatform platform;
+
+    @Column(nullable = false, length = 32)
+    private String minSupportedVersion;
+
+    @Column(nullable = false, length = 32)
+    private String latestVersion;
+
+    @Column(nullable = false, length = 500)
+    private String storeUrl;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+}

--- a/src/main/java/checkmo/appVersion/internal/exception/AppVersionErrorStatus.java
+++ b/src/main/java/checkmo/appVersion/internal/exception/AppVersionErrorStatus.java
@@ -1,0 +1,38 @@
+package checkmo.appVersion.internal.exception;
+
+import checkmo.common.apiPayload.code.BaseErrorCode;
+import checkmo.common.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AppVersionErrorStatus implements BaseErrorCode {
+
+    INVALID_PLATFORM(HttpStatus.BAD_REQUEST, "APP_VERSION_400", "platform은 ios 또는 android만 가능합니다."),
+    POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "APP_VERSION_404", "앱 버전 정책을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .httpStatus(httpStatus)
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+}

--- a/src/main/java/checkmo/appVersion/internal/exception/AppVersionException.java
+++ b/src/main/java/checkmo/appVersion/internal/exception/AppVersionException.java
@@ -1,0 +1,9 @@
+package checkmo.appVersion.internal.exception;
+
+import checkmo.common.apiPayload.exception.GeneralException;
+
+public class AppVersionException extends GeneralException {
+    public AppVersionException(AppVersionErrorStatus errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/checkmo/appVersion/internal/repository/AppVersionPolicyRepository.java
+++ b/src/main/java/checkmo/appVersion/internal/repository/AppVersionPolicyRepository.java
@@ -1,0 +1,10 @@
+package checkmo.appVersion.internal.repository;
+
+import checkmo.appVersion.internal.entity.AppPlatform;
+import checkmo.appVersion.internal.entity.AppVersionPolicy;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppVersionPolicyRepository extends JpaRepository<AppVersionPolicy, Long> {
+    Optional<AppVersionPolicy> findByPlatformAndActiveTrue(AppPlatform platform);
+}

--- a/src/main/java/checkmo/appVersion/internal/service/query/AppVersionQueryService.java
+++ b/src/main/java/checkmo/appVersion/internal/service/query/AppVersionQueryService.java
@@ -1,0 +1,25 @@
+package checkmo.appVersion.internal.service.query;
+
+import checkmo.appVersion.internal.entity.AppPlatform;
+import checkmo.appVersion.internal.entity.AppVersionPolicy;
+import checkmo.appVersion.internal.exception.AppVersionErrorStatus;
+import checkmo.appVersion.internal.exception.AppVersionException;
+import checkmo.appVersion.internal.repository.AppVersionPolicyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppVersionQueryService {
+
+    private final AppVersionPolicyRepository appVersionPolicyRepository;
+
+    public AppVersionPolicy retrieveActivePolicy(String platformValue) {
+        AppPlatform platform = AppPlatform.from(platformValue);
+
+        return appVersionPolicyRepository.findByPlatformAndActiveTrue(platform)
+                .orElseThrow(() -> new AppVersionException(AppVersionErrorStatus.POLICY_NOT_FOUND));
+    }
+}

--- a/src/main/java/checkmo/appVersion/package-info.java
+++ b/src/main/java/checkmo/appVersion/package-info.java
@@ -1,0 +1,4 @@
+@org.springframework.modulith.ApplicationModule(
+        allowedDependencies = {"common"}
+)
+package checkmo.appVersion;

--- a/src/main/java/checkmo/appVersion/web/controller/AppVersionController.java
+++ b/src/main/java/checkmo/appVersion/web/controller/AppVersionController.java
@@ -1,0 +1,42 @@
+package checkmo.appVersion.web.controller;
+
+import checkmo.appVersion.internal.converter.AppVersionConverter;
+import checkmo.appVersion.internal.service.query.AppVersionQueryService;
+import checkmo.appVersion.web.dto.AppVersionResponseDTO.VersionPolicy;
+import checkmo.common.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/app")
+@RequiredArgsConstructor
+@Tag(name = "앱 버전", description = "앱 버전 정책 조회 API")
+public class AppVersionController {
+
+    private final AppVersionQueryService appVersionQueryService;
+
+    @Operation(
+            summary = "앱 버전 정책 조회",
+            description = "iOS/Android 앱이 부팅 또는 로그인 시 호출하는 버전 정책을 조회합니다. 버전 비교는 앱에서 수행합니다."
+    )
+    @GetMapping("/version")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "platform은 ios 또는 android만 가능합니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "앱 버전 정책을 찾을 수 없습니다.")
+    })
+    public ApiResponse<VersionPolicy> getVersionPolicy(
+            @Parameter(description = "앱 플랫폼", example = "ios")
+            @RequestParam String platform
+    ) {
+        return ApiResponse.onSuccess(AppVersionConverter.toVersionPolicy(
+                appVersionQueryService.retrieveActivePolicy(platform)
+        ));
+    }
+}

--- a/src/main/java/checkmo/appVersion/web/dto/AppVersionResponseDTO.java
+++ b/src/main/java/checkmo/appVersion/web/dto/AppVersionResponseDTO.java
@@ -1,0 +1,26 @@
+package checkmo.appVersion.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AppVersionResponseDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "앱 버전 정책 응답")
+    public static class VersionPolicy {
+        @Schema(description = "강제 업데이트가 필요한 최소 지원 버전", example = "1.0.2")
+        private String minSupportedVersion;
+
+        @Schema(description = "스토어에 배포된 최신 권장 버전", example = "1.1.0")
+        private String latestVersion;
+
+        @Schema(description = "플랫폼별 스토어 이동 URL", example = "https://apps.apple.com/app/id000000000")
+        private String storeUrl;
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
+++ b/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
@@ -51,6 +51,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/book-stories", "/api/v1/book-stories/sitemap", "/api/v1/book-stories/*", "/api/v1/book-stories/search/*", "/api/v1/book-stories/members/*").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/news/me").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/news/sitemap", "/api/v1/news/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/app/version").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/terms").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/members/me", "/api/v1/members/me/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/members/*").permitAll()

--- a/src/main/resources/db/migration/V20260628__create_app_version_policy.sql
+++ b/src/main/resources/db/migration/V20260628__create_app_version_policy.sql
@@ -1,0 +1,41 @@
+CREATE TABLE IF NOT EXISTS app_version_policy (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    platform VARCHAR(20) NOT NULL,
+    min_supported_version VARCHAR(32) NOT NULL,
+    latest_version VARCHAR(32) NOT NULL,
+    store_url VARCHAR(500) NOT NULL,
+    is_active BIT NOT NULL,
+    created_at DATETIME(6),
+    updated_at DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT UK_app_version_policy_platform UNIQUE (platform)
+) ENGINE=InnoDB;
+
+INSERT INTO app_version_policy (
+    platform,
+    min_supported_version,
+    latest_version,
+    store_url,
+    is_active,
+    created_at,
+    updated_at
+)
+VALUES
+    (
+        'IOS',
+        '1.0.2',
+        '1.0.2',
+        'https://apps.apple.com/app/id000000000',
+        true,
+        CURRENT_TIMESTAMP(6),
+        CURRENT_TIMESTAMP(6)
+    ),
+    (
+        'ANDROID',
+        '1.0.2',
+        '1.0.2',
+        'https://play.google.com/store/apps/details?id=kr.co.checkmo.app',
+        true,
+        CURRENT_TIMESTAMP(6),
+        CURRENT_TIMESTAMP(6)
+    );

--- a/src/test/java/checkmo/appVersion/AppVersionApiTest.java
+++ b/src/test/java/checkmo/appVersion/AppVersionApiTest.java
@@ -1,0 +1,92 @@
+package checkmo.appVersion;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import checkmo.appVersion.internal.entity.AppPlatform;
+import checkmo.appVersion.internal.entity.AppVersionPolicy;
+import checkmo.appVersion.internal.repository.AppVersionPolicyRepository;
+import checkmo.support.ApiTestSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class AppVersionApiTest extends ApiTestSupport {
+
+    @Autowired
+    AppVersionPolicyRepository appVersionPolicyRepository;
+
+    @Test
+    void 앱_버전_정책은_로그인_없이_플랫폼별로_조회된다() {
+        savePolicy(AppPlatform.IOS, "1.0.2", "1.1.0", "https://apps.apple.com/app/id000000000");
+
+        given()
+                .queryParam("platform", "ios")
+                .when()
+                .get("/api/v1/app/version")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true))
+                .body("result.minSupportedVersion", equalTo("1.0.2"))
+                .body("result.latestVersion", equalTo("1.1.0"))
+                .body("result.storeUrl", equalTo("https://apps.apple.com/app/id000000000"));
+    }
+
+    @Test
+    void 앱_버전_정책은_android_플랫폼도_조회된다() {
+        savePolicy(
+                AppPlatform.ANDROID,
+                "1.0.0",
+                "1.0.3",
+                "https://play.google.com/store/apps/details?id=kr.co.checkmo.app"
+        );
+
+        given()
+                .queryParam("platform", "android")
+                .when()
+                .get("/api/v1/app/version")
+                .then()
+                .statusCode(200)
+                .body("result.minSupportedVersion", equalTo("1.0.0"))
+                .body("result.latestVersion", equalTo("1.0.3"))
+                .body("result.storeUrl", equalTo("https://play.google.com/store/apps/details?id=kr.co.checkmo.app"));
+    }
+
+    @Test
+    void 지원하지_않는_platform은_거절된다() {
+        given()
+                .queryParam("platform", "web")
+                .when()
+                .get("/api/v1/app/version")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false))
+                .body("code", equalTo("APP_VERSION_400"));
+    }
+
+    @Test
+    void 활성_버전_정책이_없으면_404를_반환한다() {
+        given()
+                .queryParam("platform", "ios")
+                .when()
+                .get("/api/v1/app/version")
+                .then()
+                .statusCode(404)
+                .body("isSuccess", equalTo(false))
+                .body("code", equalTo("APP_VERSION_404"));
+    }
+
+    private AppVersionPolicy savePolicy(
+            AppPlatform platform,
+            String minSupportedVersion,
+            String latestVersion,
+            String storeUrl
+    ) {
+        return appVersionPolicyRepository.save(AppVersionPolicy.builder()
+                .platform(platform)
+                .minSupportedVersion(minSupportedVersion)
+                .latestVersion(latestVersion)
+                .storeUrl(storeUrl)
+                .active(true)
+                .build());
+    }
+}


### PR DESCRIPTION
## 🚀 변경사항
- 앱 부팅/로그인 전 호출 가능한 버전 정책 조회 API를 추가했습니다.
- `GET /api/v1/app/version?platform=ios|android` 엔드포인트를 추가하고 인증 없이 접근 가능하도록 설정했습니다.
- `app_version_policy` 테이블과 iOS/Android 초기 정책 seed를 추가했습니다.
- 플랫폼별 버전 정책 응답, 잘못된 platform, 정책 없음 케이스를 API 테스트로 검증했습니다.
- API 테스트 커버리지 문서를 업데이트했습니다.

## 🔗 관련 이슈
- Closes #264

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
- 버전 비교 로직은 이슈 요구사항대로 앱(RN)에서 수행하고, BE는 기준값만 내려줍니다.
- iOS `storeUrl`은 현재 placeholder(`https://apps.apple.com/app/id000000000`)로 seed 되어 있어 실제 App Store ID 확정 후 DB 값만 갱신하면 됩니다.
- 로컬 설정 변경 파일인 `application.yml`, `application-redis.yml`은 커밋에 포함하지 않았습니다.

## 🧪 테스트
```bash
./gradlew test --tests checkmo.appVersion.AppVersionApiTest
./gradlew test --tests checkmo.CheckmoApplicationTests.Spring_Modulith_Test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public app version endpoint so mobile apps can retrieve platform-specific version policy details without logging in.
  * Added support for iOS and Android policy storage and initial data.
* **Bug Fixes**
  * Returns clear errors for unsupported platforms and when no active policy is available.
* **Tests**
  * Added API coverage for successful lookups, invalid platform handling, and missing policy cases.
* **Documentation**
  * Updated API coverage and test rationale docs to reflect the new version policy endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->