### PR TITLE
feat(auth): Apple 소셜 로그인 지원

### DIFF
--- a/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
+++ b/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
@@ -2,9 +2,12 @@ package checkmo.authentication.internal.config;
 
 import checkmo.authentication.internal.security.auth.ProfileCompletionAuthorizationFilter;
 import checkmo.authentication.internal.security.jwt.JwtAuthenticationFilter;
-import checkmo.authentication.internal.security.oauth2.CustomOAuth2UserService;
+import checkmo.authentication.internal.security.apple.AppleClientSecretGenerator;
+import checkmo.authentication.internal.security.oauth2.AppleClientSecretTokenRequestParametersConverter;
+import checkmo.authentication.internal.security.oauth2.AppleOAuth2AuthorizationRequestResolver;
 import checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationFailureHandler;
 import checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import checkmo.authentication.internal.security.oauth2.SocialOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,6 +19,10 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.endpoint.RestClientAuthorizationCodeTokenResponseClient;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -29,12 +36,16 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final ProfileCompletionAuthorizationFilter profileCompletionAuthorizationFilter;
-    private final CustomOAuth2UserService customOAuth2UserService;
+    private final SocialOAuth2UserService socialOAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(
+            HttpSecurity http,
+            ClientRegistrationRepository clientRegistrationRepository,
+            OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient
+    ) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
@@ -76,7 +87,15 @@ public class SecurityConfig {
         // OAuth2 로그인 설정
         http
                 .oauth2Login(oauth2 -> oauth2
-                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService)
+                        .authorizationEndpoint(authorization -> authorization
+                                .authorizationRequestResolver(
+                                        new AppleOAuth2AuthorizationRequestResolver(clientRegistrationRepository)
+                                )
+                        )
+                        .tokenEndpoint(token -> token
+                                .accessTokenResponseClient(accessTokenResponseClient)
+                        )
+                        .userInfoEndpoint(userInfo -> userInfo.userService(socialOAuth2UserService)
                         )
                         .successHandler(oAuth2AuthenticationSuccessHandler) // 로그인 성공 핸들러 설정
                         .failureHandler(oAuth2AuthenticationFailureHandler) // 로그인 실패 핸들러 설정
@@ -88,6 +107,18 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> accessTokenResponseClient(
+            AppleClientSecretGenerator appleClientSecretGenerator
+    ) {
+        RestClientAuthorizationCodeTokenResponseClient client =
+                new RestClientAuthorizationCodeTokenResponseClient();
+        client.setParametersConverter(
+                new AppleClientSecretTokenRequestParametersConverter(appleClientSecretGenerator)
+        );
+        return client;
     }
 
     @Bean

--- a/src/main/java/checkmo/authentication/internal/config/properties/AppleOAuthProperties.java
+++ b/src/main/java/checkmo/authentication/internal/config/properties/AppleOAuthProperties.java
@@ -1,0 +1,20 @@
+package checkmo.authentication.internal.config.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.oauth2.apple")
+public class AppleOAuthProperties {
+
+    private String teamId;
+    private String keyId;
+    private String webClientId;
+    private String iosClientId;
+    private String privateKeyBase64;
+    private String webRedirectUri;
+}

--- a/src/main/java/checkmo/authentication/internal/converter/AuthConverter.java
+++ b/src/main/java/checkmo/authentication/internal/converter/AuthConverter.java
@@ -17,7 +17,7 @@ public class AuthConverter {
     }
 
     public static AuthUser toOAuth2User(OAuth2Attributes attributes, String registrationId) {
-        String newMemberId = registrationId.toUpperCase() + "_" + attributes.getProviderId();
+        String newMemberId = toOAuth2MemberId(registrationId, attributes.getProviderId());
 
         return AuthUser.builder()
                 .id(newMemberId)
@@ -27,6 +27,10 @@ public class AuthConverter {
                 .deactivatedAt(null)
                 .profileCompleted(false)
                 .build();
+    }
+
+    public static String toOAuth2MemberId(String registrationId, String providerId) {
+        return registrationId.toUpperCase() + "_" + providerId;
     }
 
     public static AuthUser toLocalUser(AuthRequestDTO.SignUp request, String encodedPassword) {

--- a/src/main/java/checkmo/authentication/internal/entity/Provider.java
+++ b/src/main/java/checkmo/authentication/internal/entity/Provider.java
@@ -5,6 +5,7 @@ public abstract class Provider {
     public static final String GOOGLE = "google";
     public static final String KAKAO = "kakao";
     public static final String NAVER = "naver";
+    public static final String APPLE = "apple";
 
     public static abstract class Google {
         public static final String EMAIL = "email";
@@ -21,5 +22,10 @@ public abstract class Provider {
         public static final String RESPONSE = "response";
         public static final String EMAIL = "email";
         public static final String PROVIDER_ID = "id";
+    }
+
+    public static abstract class Apple {
+        public static final String EMAIL = "email";
+        public static final String PROVIDER_ID = "sub";
     }
 }

--- a/src/main/java/checkmo/authentication/internal/exception/AuthErrorStatus.java
+++ b/src/main/java/checkmo/authentication/internal/exception/AuthErrorStatus.java
@@ -34,7 +34,8 @@ public enum AuthErrorStatus implements BaseErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_412", "유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요."),
     APPLE_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH_413", "Apple 최초 로그인에는 이메일 정보가 필요합니다."),
     SOCIAL_ACCOUNT_EMAIL_CONFLICT(HttpStatus.CONFLICT, "AUTH_414", "이미 다른 계정으로 가입된 이메일입니다."),
-    APPLE_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_415", "유효하지 않은 Apple 인증 정보입니다.")
+    APPLE_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_415", "유효하지 않은 Apple 인증 정보입니다."),
+    INVALID_OAUTH_CODE(HttpStatus.UNAUTHORIZED, "AUTH_416", "유효하지 않거나 만료된 인증 코드입니다. 다시 로그인해주세요.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/checkmo/authentication/internal/exception/AuthErrorStatus.java
+++ b/src/main/java/checkmo/authentication/internal/exception/AuthErrorStatus.java
@@ -31,7 +31,9 @@ public enum AuthErrorStatus implements BaseErrorCode {
     PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "AUTH_409", "새 비밀번호가 기존 비밀번호와 동일합니다."),
     NICKNAME_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH_410", "닉네임은 필수입니다."),
     SIGNUP_INCOMPLETE(HttpStatus.CONFLICT, "AUTH_411", "이미 가입 진행 중인 이메일입니다. 로그인 후 프로필을 완성해주세요."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_412", "유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요.")
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_412", "유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요."),
+    APPLE_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH_413", "Apple 최초 로그인에는 이메일 정보가 필요합니다."),
+    SOCIAL_ACCOUNT_EMAIL_CONFLICT(HttpStatus.CONFLICT, "AUTH_414", "이미 다른 계정으로 가입된 이메일입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/checkmo/authentication/internal/exception/AuthErrorStatus.java
+++ b/src/main/java/checkmo/authentication/internal/exception/AuthErrorStatus.java
@@ -33,7 +33,8 @@ public enum AuthErrorStatus implements BaseErrorCode {
     SIGNUP_INCOMPLETE(HttpStatus.CONFLICT, "AUTH_411", "이미 가입 진행 중인 이메일입니다. 로그인 후 프로필을 완성해주세요."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_412", "유효하지 않은 리프레시 토큰입니다. 다시 로그인해주세요."),
     APPLE_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH_413", "Apple 최초 로그인에는 이메일 정보가 필요합니다."),
-    SOCIAL_ACCOUNT_EMAIL_CONFLICT(HttpStatus.CONFLICT, "AUTH_414", "이미 다른 계정으로 가입된 이메일입니다.")
+    SOCIAL_ACCOUNT_EMAIL_CONFLICT(HttpStatus.CONFLICT, "AUTH_414", "이미 다른 계정으로 가입된 이메일입니다."),
+    APPLE_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_415", "유효하지 않은 Apple 인증 정보입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleClientSecretException.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleClientSecretException.java
@@ -1,0 +1,12 @@
+package checkmo.authentication.internal.security.apple;
+
+public class AppleClientSecretException extends RuntimeException {
+
+    public AppleClientSecretException(String message) {
+        super(message);
+    }
+
+    public AppleClientSecretException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleClientSecretGenerator.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleClientSecretGenerator.java
@@ -1,0 +1,74 @@
+package checkmo.authentication.internal.security.apple;
+
+import checkmo.authentication.internal.config.properties.AppleOAuthProperties;
+import io.jsonwebtoken.Jwts;
+import java.security.interfaces.ECPrivateKey;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class AppleClientSecretGenerator {
+
+    private static final String APPLE_AUDIENCE = "https://appleid.apple.com";
+    private static final Duration TOKEN_VALIDITY = Duration.ofDays(30);
+    private static final Duration REFRESH_SKEW = Duration.ofMinutes(5);
+
+    private final AppleOAuthProperties properties;
+    private final Clock clock;
+    private ECPrivateKey privateKey;
+    private CachedClientSecret cachedClientSecret;
+
+    @Autowired
+    public AppleClientSecretGenerator(AppleOAuthProperties properties) {
+        this(properties, Clock.systemUTC());
+    }
+
+    AppleClientSecretGenerator(AppleOAuthProperties properties, Clock clock) {
+        this.properties = properties;
+        this.clock = clock;
+    }
+
+    public synchronized String generateClientSecret() {
+        Instant now = clock.instant();
+        if (cachedClientSecret != null && now.isBefore(cachedClientSecret.refreshAt())) {
+            return cachedClientSecret.value();
+        }
+
+        Instant expiration = now.plus(TOKEN_VALIDITY);
+        String clientSecret = Jwts.builder()
+                .header()
+                .keyId(required(properties.getKeyId(), "Apple key ID is required"))
+                .and()
+                .issuer(required(properties.getTeamId(), "Apple team ID is required"))
+                .subject(required(properties.getWebClientId(), "Apple web client ID is required"))
+                .claim("aud", APPLE_AUDIENCE)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(expiration))
+                .signWith(privateKey(), Jwts.SIG.ES256)
+                .compact();
+        cachedClientSecret = new CachedClientSecret(clientSecret, expiration.minus(REFRESH_SKEW));
+        return clientSecret;
+    }
+
+    private ECPrivateKey privateKey() {
+        if (privateKey == null) {
+            privateKey = ApplePrivateKeyLoader.load(properties.getPrivateKeyBase64());
+        }
+        return privateKey;
+    }
+
+    private String required(String value, String message) {
+        if (!StringUtils.hasText(value)) {
+            throw new AppleClientSecretException(message);
+        }
+        return value;
+    }
+
+    private record CachedClientSecret(String value, Instant refreshAt) {
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleHttpJwksClient.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleHttpJwksClient.java
@@ -1,0 +1,64 @@
+package checkmo.authentication.internal.security.apple;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppleHttpJwksClient implements AppleJwksClient {
+
+    private static final URI APPLE_JWKS_URI = URI.create("https://appleid.apple.com/auth/keys");
+    private static final Duration TIMEOUT = Duration.ofSeconds(3);
+    private static final int MAX_ATTEMPTS = 2;
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public AppleHttpJwksClient(ObjectMapper objectMapper) {
+        this(HttpClient.newBuilder()
+                .connectTimeout(TIMEOUT)
+                .build(), objectMapper);
+    }
+
+    AppleHttpJwksClient(HttpClient httpClient, ObjectMapper objectMapper) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public AppleJwks fetch() {
+        HttpRequest request = HttpRequest.newBuilder(APPLE_JWKS_URI)
+                .timeout(TIMEOUT)
+                .GET()
+                .build();
+        AppleJwksFetchException lastFailure = new AppleJwksFetchException("Apple JWKS could not be fetched");
+
+        for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+            try {
+                HttpResponse<String> response = httpClient.send(
+                        request,
+                        HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)
+                );
+                if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                    return objectMapper.readValue(response.body(), AppleJwks.class);
+                }
+                lastFailure = new AppleJwksFetchException("Apple JWKS response was not successful");
+            } catch (IOException e) {
+                lastFailure = new AppleJwksFetchException("Apple JWKS could not be fetched", e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AppleJwksFetchException("Apple JWKS fetch was interrupted", e);
+            }
+        }
+
+        throw lastFailure;
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenParts.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenParts.java
@@ -1,8 +1,0 @@
-package checkmo.authentication.internal.security.apple;
-
-record AppleIdTokenParts(String header, String payload, String signature) {
-
-    String signingInput() {
-        return header + "." + payload;
-    }
-}

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenParts.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenParts.java
@@ -1,0 +1,8 @@
+package checkmo.authentication.internal.security.apple;
+
+record AppleIdTokenParts(String header, String payload, String signature) {
+
+    String signingInput() {
+        return header + "." + payload;
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifier.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifier.java
@@ -18,10 +18,12 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+@Slf4j
 @Component
 public class AppleIdTokenVerifier {
 
@@ -138,16 +140,20 @@ public class AppleIdTokenVerifier {
 
     private synchronized RSAPublicKey publicKey(String kid) {
         Instant now = clock.instant();
-        if (!now.isBefore(cacheExpiresAt)) {
-            refreshKeys(now);
-        }
-
         RSAPublicKey publicKey = cachedKeys.get(kid);
-        if (publicKey != null) {
+        if (publicKey != null && now.isBefore(cacheExpiresAt)) {
             return publicKey;
         }
 
-        refreshKeys(now);
+        try {
+            refreshKeys(now);
+        } catch (InvalidAppleIdentityTokenException e) {
+            if (publicKey != null) {
+                return publicKey;
+            }
+            throw e;
+        }
+
         publicKey = cachedKeys.get(kid);
         if (publicKey == null) {
             throw new InvalidAppleIdentityTokenException();
@@ -173,7 +179,11 @@ public class AppleIdTokenVerifier {
         Map<String, RSAPublicKey> keys = new HashMap<>();
         for (AppleJwk jwk : jwks.keys()) {
             if (isSignatureKey(jwk)) {
-                keys.put(jwk.kid(), toPublicKey(jwk));
+                try {
+                    keys.put(jwk.kid(), toPublicKey(jwk));
+                } catch (InvalidAppleIdentityTokenException e) {
+                    log.warn("Skipping malformed Apple JWKS key. kid={}", jwk.kid(), e);
+                }
             }
         }
         return Map.copyOf(keys);
@@ -226,7 +236,7 @@ public class AppleIdTokenVerifier {
             throw new InvalidAppleIdentityTokenException();
         }
         Instant expiresAt = epochSecondsClaim(claims, "exp");
-        if (!expiresAt.isAfter(now)) {
+        if (!expiresAt.plus(ALLOWED_CLOCK_SKEW).isAfter(now)) {
             throw new InvalidAppleIdentityTokenException();
         }
         Instant issuedAt = epochSecondsClaim(claims, "iat");

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifier.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifier.java
@@ -27,6 +27,8 @@ public class AppleIdTokenVerifier {
 
     private static final String APPLE_ISSUER = "https://appleid.apple.com";
     private static final String APPLE_PROVIDER_PREFIX = "APPLE_";
+    private static final String EXPECTED_KEY_TYPE = "RSA";
+    private static final String EXPECTED_KEY_USE = "sig";
     private static final String EXPECTED_ALGORITHM = "RS256";
     private static final String PRIVATE_RELAY_DOMAIN = "privaterelay.appleid.com";
     private static final Duration JWKS_CACHE_TTL = Duration.ofHours(6);
@@ -170,11 +172,19 @@ public class AppleIdTokenVerifier {
 
         Map<String, RSAPublicKey> keys = new HashMap<>();
         for (AppleJwk jwk : jwks.keys()) {
-            if (jwk != null && StringUtils.hasText(jwk.kid()) && EXPECTED_ALGORITHM.equals(jwk.alg())) {
+            if (isSignatureKey(jwk)) {
                 keys.put(jwk.kid(), toPublicKey(jwk));
             }
         }
         return Map.copyOf(keys);
+    }
+
+    private boolean isSignatureKey(AppleJwk jwk) {
+        return jwk != null
+                && StringUtils.hasText(jwk.kid())
+                && EXPECTED_KEY_TYPE.equals(jwk.kty())
+                && EXPECTED_KEY_USE.equals(jwk.use())
+                && EXPECTED_ALGORITHM.equals(jwk.alg());
     }
 
     private RSAPublicKey toPublicKey(AppleJwk jwk) {

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifier.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifier.java
@@ -288,4 +288,10 @@ public class AppleIdTokenVerifier {
         return email != null && email.toLowerCase().endsWith(PRIVATE_RELAY_DOMAIN);
     }
 
+    private record AppleIdTokenParts(String header, String payload, String signature) {
+
+        String signingInput() {
+            return header + "." + payload;
+        }
+    }
 }

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifier.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifier.java
@@ -1,0 +1,281 @@
+package checkmo.authentication.internal.security.apple;
+
+import checkmo.authentication.internal.config.properties.AppleOAuthProperties;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.Signature;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class AppleIdTokenVerifier {
+
+    private static final String APPLE_ISSUER = "https://appleid.apple.com";
+    private static final String APPLE_PROVIDER_PREFIX = "APPLE_";
+    private static final String EXPECTED_ALGORITHM = "RS256";
+    private static final String PRIVATE_RELAY_DOMAIN = "privaterelay.appleid.com";
+    private static final Duration JWKS_CACHE_TTL = Duration.ofHours(6);
+    private static final Duration ALLOWED_CLOCK_SKEW = Duration.ofSeconds(60);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> JSON_OBJECT = new TypeReference<>() {};
+
+    private final AppleJwksClient jwksClient;
+    private final AppleOAuthProperties properties;
+    private final Clock clock;
+    private Map<String, RSAPublicKey> cachedKeys = Map.of();
+    private Instant cacheExpiresAt = Instant.EPOCH;
+
+    @Autowired
+    public AppleIdTokenVerifier(AppleJwksClient jwksClient, AppleOAuthProperties properties) {
+        this(jwksClient, properties, Clock.systemUTC());
+    }
+
+    AppleIdTokenVerifier(AppleJwksClient jwksClient, AppleOAuthProperties properties, Clock clock) {
+        this.jwksClient = jwksClient;
+        this.properties = properties;
+        this.clock = clock;
+    }
+
+    public AppleIdentity verifyWebToken(String identityToken) {
+        return verify(identityToken, properties.getWebClientId(), null);
+    }
+
+    public AppleIdentity verifyIosToken(String identityToken, String rawNonce) {
+        if (!StringUtils.hasText(rawNonce)) {
+            throw new InvalidAppleIdentityTokenException();
+        }
+        return verify(identityToken, properties.getIosClientId(), rawNonce);
+    }
+
+    static String sha256Hex(String value) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+    }
+
+    private AppleIdentity verify(String identityToken, String expectedAudience, String rawNonce) {
+        try {
+            if (!StringUtils.hasText(identityToken) || !StringUtils.hasText(expectedAudience)) {
+                throw new InvalidAppleIdentityTokenException();
+            }
+
+            AppleIdTokenParts tokenParts = parseTokenParts(identityToken);
+            Map<String, Object> header = decodeJson(tokenParts.header());
+            String kid = stringClaim(header, "kid");
+            String alg = stringClaim(header, "alg");
+            if (!StringUtils.hasText(kid) || !EXPECTED_ALGORITHM.equals(alg)) {
+                throw new InvalidAppleIdentityTokenException();
+            }
+
+            RSAPublicKey publicKey = publicKey(kid);
+            verifySignature(tokenParts, publicKey);
+
+            Map<String, Object> claims = decodeJson(tokenParts.payload());
+            validateClaims(claims, expectedAudience, rawNonce);
+            String subject = stringClaim(claims, "sub");
+            String email = optionalStringClaim(claims, "email");
+            boolean emailVerified = booleanClaim(claims, "email_verified");
+            boolean privateEmail = booleanClaim(claims, "is_private_email") || isPrivateRelayEmail(email);
+            return new AppleIdentity(
+                    subject,
+                    APPLE_PROVIDER_PREFIX + subject,
+                    email,
+                    emailVerified,
+                    privateEmail,
+                    expectedAudience
+            );
+        } catch (InvalidAppleIdentityTokenException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InvalidAppleIdentityTokenException(e);
+        }
+    }
+
+    private AppleIdTokenParts parseTokenParts(String identityToken) {
+        String[] parts = identityToken.split("\\.", -1);
+        if (parts.length != 3
+                || !StringUtils.hasText(parts[0])
+                || !StringUtils.hasText(parts[1])
+                || !StringUtils.hasText(parts[2])) {
+            throw new InvalidAppleIdentityTokenException();
+        }
+        return new AppleIdTokenParts(parts[0], parts[1], parts[2]);
+    }
+
+    private Map<String, Object> decodeJson(String base64UrlValue) {
+        try {
+            byte[] bytes = Base64.getUrlDecoder().decode(base64UrlValue);
+            return OBJECT_MAPPER.readValue(bytes, JSON_OBJECT);
+        } catch (Exception e) {
+            throw new InvalidAppleIdentityTokenException(e);
+        }
+    }
+
+    private synchronized RSAPublicKey publicKey(String kid) {
+        Instant now = clock.instant();
+        if (!now.isBefore(cacheExpiresAt)) {
+            refreshKeys(now);
+        }
+
+        RSAPublicKey publicKey = cachedKeys.get(kid);
+        if (publicKey != null) {
+            return publicKey;
+        }
+
+        refreshKeys(now);
+        publicKey = cachedKeys.get(kid);
+        if (publicKey == null) {
+            throw new InvalidAppleIdentityTokenException();
+        }
+        return publicKey;
+    }
+
+    private void refreshKeys(Instant now) {
+        try {
+            AppleJwks jwks = jwksClient.fetch();
+            cachedKeys = toPublicKeys(jwks);
+            cacheExpiresAt = now.plus(JWKS_CACHE_TTL);
+        } catch (Exception e) {
+            throw new InvalidAppleIdentityTokenException(e);
+        }
+    }
+
+    private Map<String, RSAPublicKey> toPublicKeys(AppleJwks jwks) {
+        if (jwks == null || jwks.keys() == null) {
+            throw new InvalidAppleIdentityTokenException();
+        }
+
+        Map<String, RSAPublicKey> keys = new HashMap<>();
+        for (AppleJwk jwk : jwks.keys()) {
+            if (jwk != null && StringUtils.hasText(jwk.kid()) && EXPECTED_ALGORITHM.equals(jwk.alg())) {
+                keys.put(jwk.kid(), toPublicKey(jwk));
+            }
+        }
+        return Map.copyOf(keys);
+    }
+
+    private RSAPublicKey toPublicKey(AppleJwk jwk) {
+        try {
+            BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(jwk.n()));
+            BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(jwk.e()));
+            return (RSAPublicKey) KeyFactory.getInstance("RSA")
+                    .generatePublic(new RSAPublicKeySpec(modulus, exponent));
+        } catch (Exception e) {
+            throw new InvalidAppleIdentityTokenException(e);
+        }
+    }
+
+    private void verifySignature(AppleIdTokenParts tokenParts, RSAPublicKey publicKey) {
+        try {
+            Signature signature = Signature.getInstance("SHA256withRSA");
+            signature.initVerify(publicKey);
+            signature.update(tokenParts.signingInput().getBytes(StandardCharsets.US_ASCII));
+            byte[] signatureBytes = Base64.getUrlDecoder().decode(tokenParts.signature());
+            if (!signature.verify(signatureBytes)) {
+                throw new InvalidAppleIdentityTokenException();
+            }
+        } catch (InvalidAppleIdentityTokenException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InvalidAppleIdentityTokenException(e);
+        }
+    }
+
+    private void validateClaims(Map<String, Object> claims, String expectedAudience, String rawNonce) {
+        Instant now = clock.instant();
+        if (!APPLE_ISSUER.equals(stringClaim(claims, "iss"))) {
+            throw new InvalidAppleIdentityTokenException();
+        }
+        if (!audienceMatches(claims.get("aud"), expectedAudience)) {
+            throw new InvalidAppleIdentityTokenException();
+        }
+        if (!StringUtils.hasText(stringClaim(claims, "sub"))) {
+            throw new InvalidAppleIdentityTokenException();
+        }
+        Instant expiresAt = epochSecondsClaim(claims, "exp");
+        if (!expiresAt.isAfter(now)) {
+            throw new InvalidAppleIdentityTokenException();
+        }
+        Instant issuedAt = epochSecondsClaim(claims, "iat");
+        if (issuedAt.isAfter(now.plus(ALLOWED_CLOCK_SKEW))) {
+            throw new InvalidAppleIdentityTokenException();
+        }
+        if (StringUtils.hasText(rawNonce)
+                && !sha256Hex(rawNonce).equals(stringClaim(claims, "nonce"))) {
+            throw new InvalidAppleIdentityTokenException();
+        }
+    }
+
+    private boolean audienceMatches(Object audience, String expectedAudience) {
+        if (audience instanceof String value) {
+            return expectedAudience.equals(value);
+        }
+        if (audience instanceof List<?> values) {
+            return values.stream().anyMatch(expectedAudience::equals);
+        }
+        return false;
+    }
+
+    private Instant epochSecondsClaim(Map<String, Object> claims, String name) {
+        Object value = claims.get(name);
+        if (value instanceof Number number) {
+            return Instant.ofEpochSecond(number.longValue());
+        }
+        throw new InvalidAppleIdentityTokenException();
+    }
+
+    private String stringClaim(Map<String, Object> claims, String name) {
+        String value = optionalStringClaim(claims, name);
+        if (!StringUtils.hasText(value)) {
+            throw new InvalidAppleIdentityTokenException();
+        }
+        return value;
+    }
+
+    private String optionalStringClaim(Map<String, Object> claims, String name) {
+        Object value = claims.get(name);
+        if (value instanceof String stringValue) {
+            return stringValue;
+        }
+        return null;
+    }
+
+    private boolean booleanClaim(Map<String, Object> claims, String name) {
+        Object value = claims.get(name);
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        if (value instanceof String stringValue) {
+            return Boolean.parseBoolean(stringValue);
+        }
+        return false;
+    }
+
+    private boolean isPrivateRelayEmail(String email) {
+        return email != null && email.toLowerCase().endsWith(PRIVATE_RELAY_DOMAIN);
+    }
+
+}

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleIdentity.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleIdentity.java
@@ -1,5 +1,9 @@
 package checkmo.authentication.internal.security.apple;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.util.StringUtils;
+
 public record AppleIdentity(
         String subject,
         String providerId,
@@ -8,4 +12,18 @@ public record AppleIdentity(
         boolean privateEmail,
         String audience
 ) {
+
+    private static final String EMAIL_VERIFIED = "email_verified";
+    private static final String PRIVATE_EMAIL = "is_private_email";
+
+    public Map<String, Object> toOAuth2Attributes() {
+        Map<String, Object> attributes = new LinkedHashMap<>();
+        attributes.put("sub", subject);
+        if (StringUtils.hasText(email)) {
+            attributes.put("email", email);
+        }
+        attributes.put(EMAIL_VERIFIED, emailVerified);
+        attributes.put(PRIVATE_EMAIL, privateEmail);
+        return Map.copyOf(attributes);
+    }
 }

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleIdentity.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleIdentity.java
@@ -1,0 +1,11 @@
+package checkmo.authentication.internal.security.apple;
+
+public record AppleIdentity(
+        String subject,
+        String providerId,
+        String email,
+        boolean emailVerified,
+        boolean privateEmail,
+        String audience
+) {
+}

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleJwk.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleJwk.java
@@ -1,0 +1,12 @@
+package checkmo.authentication.internal.security.apple;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AppleJwk(
+        String kid,
+        String alg,
+        String n,
+        String e
+) {
+}

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleJwk.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleJwk.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record AppleJwk(
         String kid,
+        String kty,
+        String use,
         String alg,
         String n,
         String e

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleJwks.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleJwks.java
@@ -1,0 +1,8 @@
+package checkmo.authentication.internal.security.apple;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AppleJwks(List<AppleJwk> keys) {
+}

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleJwksClient.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleJwksClient.java
@@ -1,0 +1,6 @@
+package checkmo.authentication.internal.security.apple;
+
+public interface AppleJwksClient {
+
+    AppleJwks fetch();
+}

--- a/src/main/java/checkmo/authentication/internal/security/apple/AppleJwksFetchException.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/AppleJwksFetchException.java
@@ -1,0 +1,12 @@
+package checkmo.authentication.internal.security.apple;
+
+class AppleJwksFetchException extends RuntimeException {
+
+    AppleJwksFetchException(String message) {
+        super(message);
+    }
+
+    AppleJwksFetchException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/apple/ApplePrivateKeyLoader.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/ApplePrivateKeyLoader.java
@@ -44,7 +44,7 @@ final class ApplePrivateKeyLoader {
 
     private static byte[] decodeOuterBase64(String privateKeyBase64) {
         try {
-            return Base64.getDecoder().decode(privateKeyBase64.trim());
+            return Base64.getDecoder().decode(StringUtils.trimAllWhitespace(privateKeyBase64));
         } catch (IllegalArgumentException e) {
             throw new AppleClientSecretException("Apple private key base64 is invalid", e);
         }

--- a/src/main/java/checkmo/authentication/internal/security/apple/ApplePrivateKeyLoader.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/ApplePrivateKeyLoader.java
@@ -1,0 +1,73 @@
+package checkmo.authentication.internal.security.apple;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.util.StringUtils;
+
+final class ApplePrivateKeyLoader {
+
+    private static final String BEGIN_MARKER = "-----BEGIN " + "PRIVATE KEY-----";
+    private static final String END_MARKER = "-----END " + "PRIVATE KEY-----";
+    private static final Pattern PRIVATE_KEY_PATTERN = Pattern.compile(
+            "\\A\\s*" + Pattern.quote(BEGIN_MARKER)
+                    + "\\s*([A-Za-z0-9+/=\\s]+)\\s*"
+                    + Pattern.quote(END_MARKER) + "\\s*\\z",
+            Pattern.DOTALL
+    );
+
+    private ApplePrivateKeyLoader() {
+    }
+
+    static ECPrivateKey load(String privateKeyBase64) {
+        if (!StringUtils.hasText(privateKeyBase64)) {
+            throw new AppleClientSecretException("Apple private key base64 is required");
+        }
+
+        byte[] pemBytes = decodeOuterBase64(privateKeyBase64);
+        String pem = new String(pemBytes, StandardCharsets.UTF_8);
+        Matcher matcher = PRIVATE_KEY_PATTERN.matcher(pem);
+        if (!matcher.matches()) {
+            throw new AppleClientSecretException("Apple private key PEM is malformed");
+        }
+
+        byte[] keyBytes = decodePemBody(matcher.group(1));
+        return parseEcPrivateKey(keyBytes);
+    }
+
+    private static byte[] decodeOuterBase64(String privateKeyBase64) {
+        try {
+            return Base64.getDecoder().decode(privateKeyBase64.trim());
+        } catch (IllegalArgumentException e) {
+            throw new AppleClientSecretException("Apple private key base64 is invalid", e);
+        }
+    }
+
+    private static byte[] decodePemBody(String keyBody) {
+        try {
+            return Base64.getMimeDecoder().decode(keyBody);
+        } catch (IllegalArgumentException e) {
+            throw new AppleClientSecretException("Apple private key PEM is malformed", e);
+        }
+    }
+
+    private static ECPrivateKey parseEcPrivateKey(byte[] keyBytes) {
+        try {
+            PrivateKey privateKey = KeyFactory.getInstance("EC")
+                    .generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
+            if (privateKey instanceof ECPrivateKey ecPrivateKey) {
+                return ecPrivateKey;
+            }
+            throw new AppleClientSecretException("Apple private key could not be parsed");
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new AppleClientSecretException("Apple private key could not be parsed", e);
+        }
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/apple/InvalidAppleIdentityTokenException.java
+++ b/src/main/java/checkmo/authentication/internal/security/apple/InvalidAppleIdentityTokenException.java
@@ -1,0 +1,14 @@
+package checkmo.authentication.internal.security.apple;
+
+public class InvalidAppleIdentityTokenException extends RuntimeException {
+
+    private static final String MESSAGE = "Invalid Apple identity token";
+
+    public InvalidAppleIdentityTokenException() {
+        super(MESSAGE);
+    }
+
+    public InvalidAppleIdentityTokenException(Throwable cause) {
+        super(MESSAGE, cause);
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtLoginProcessor.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtLoginProcessor.java
@@ -18,6 +18,23 @@ public class JwtLoginProcessor {
 
     // 로그인 성공 시 JWT 토큰 생성 및 쿠키 설정, Refresh Token 반환
     public String processLogin(HttpServletResponse response, Authentication authentication) {
+        JwtToken jwtToken = issueToken(authentication);
+
+        int accessTokenMaxAge = (int) (jwtTokenProvider.getAccessTokenExpirationTime() / 1000L); // ms → sec
+        int refreshTokenMaxAge = (int) (jwtTokenProvider.getRefreshTokenExpirationTime() / 1000L);
+
+        jwtCookieUtil.addTokenToCookie(response, "accessToken", jwtToken.getAccessToken(), accessTokenMaxAge);
+        jwtCookieUtil.addTokenToCookie(response, "refreshToken", jwtToken.getRefreshToken(), refreshTokenMaxAge);
+
+        return jwtToken.getRefreshToken();
+    }
+
+    public String processLoginWithoutCookies(Authentication authentication) {
+        JwtToken jwtToken = issueToken(authentication);
+        return jwtToken.getRefreshToken();
+    }
+
+    private JwtToken issueToken(Authentication authentication) {
         String userId = ((PrincipalDetails) authentication.getPrincipal()).getUser().getId();
 
         // 인증 성공 시점에만 계정 자동 복구
@@ -26,15 +43,8 @@ public class JwtLoginProcessor {
         // JWT 토큰 생성
         JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
 
-        int accessTokenMaxAge = (int) (jwtTokenProvider.getAccessTokenExpirationTime() / 1000L); // ms → sec
-        int refreshTokenMaxAge = (int) (jwtTokenProvider.getRefreshTokenExpirationTime() / 1000L);
-
-        jwtCookieUtil.addTokenToCookie(response, "accessToken", jwtToken.getAccessToken(), accessTokenMaxAge);
-        jwtCookieUtil.addTokenToCookie(response, "refreshToken", jwtToken.getRefreshToken(), refreshTokenMaxAge);
-
         // RefreshToken Redis에 저장
         tokenCacheService.saveRefreshToken(userId, jwtToken.getRefreshToken());
-
-        return jwtToken.getRefreshToken();
+        return jwtToken;
     }
 }

--- a/src/main/java/checkmo/authentication/internal/security/jwt/TokenCacheService.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/TokenCacheService.java
@@ -22,6 +22,8 @@ public class TokenCacheService {
 
     private static final String REFRESH_TOKEN_PREFIX = "refreshToken::";
     private static final String BLACKLIST_PREFIX = "blacklist::";
+    private static final String OAUTH_CODE_PREFIX = "oauthCode::";
+    private static final long OAUTH_CODE_TTL_MS = 120_000L;
     private static final String COMPARE_AND_ROTATE_REFRESH_TOKEN_SCRIPT = """
             local current = redis.call('GET', KEYS[1])
             if current == ARGV[1] or current == ARGV[2] then
@@ -37,6 +39,13 @@ public class TokenCacheService {
                 return 1
             end
             return 0
+            """;
+    private static final String CONSUME_OAUTH_CODE_SCRIPT = """
+            local value = redis.call('GET', KEYS[1])
+            if value then
+                redis.call('DEL', KEYS[1])
+            end
+            return value
             """;
     private static final StringRedisSerializer STRING_SERIALIZER = new StringRedisSerializer();
 
@@ -93,6 +102,32 @@ public class TokenCacheService {
         byte[] expected = serialize(expectedRefreshToken);
         byte[] legacyExpected = serializeLegacyValue(expectedRefreshToken);
         return executeBooleanScript(DELETE_REFRESH_TOKEN_IF_MATCHES_SCRIPT, key, expected, legacyExpected);
+    }
+
+    public void saveOAuthExchangeCode(String code, String value) {
+        byte[] key = serialize(OAUTH_CODE_PREFIX + code);
+        byte[] serializedValue = serialize(value);
+        redisTemplate.execute((RedisCallback<Boolean>) connection ->
+                connection.stringCommands().set(
+                        key,
+                        serializedValue,
+                        Expiration.milliseconds(OAUTH_CODE_TTL_MS),
+                        SetOption.upsert()
+                )
+        );
+    }
+
+    public String consumeOAuthExchangeCode(String code) {
+        byte[] key = serialize(OAUTH_CODE_PREFIX + code);
+        byte[] value = redisTemplate.execute((RedisCallback<byte[]>) connection ->
+                connection.scriptingCommands().eval(
+                        CONSUME_OAUTH_CODE_SCRIPT.getBytes(StandardCharsets.UTF_8),
+                        ReturnType.VALUE,
+                        1,
+                        key
+                )
+        );
+        return value == null ? null : STRING_SERIALIZER.deserialize(value);
     }
 
     private boolean executeBooleanScript(String script, byte[] key, byte[]... args) {

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleAppLoginService.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleAppLoginService.java
@@ -7,7 +7,6 @@ import checkmo.authentication.internal.security.apple.AppleIdentity;
 import checkmo.authentication.internal.security.apple.InvalidAppleIdentityTokenException;
 import checkmo.authentication.internal.security.auth.PrincipalDetails;
 import checkmo.authentication.internal.security.jwt.JwtLoginProcessor;
-import checkmo.authentication.web.dto.AuthRequestDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +27,8 @@ public class AppleAppLoginService {
     private final JwtLoginProcessor jwtLoginProcessor;
 
     @Transactional
-    public String login(AuthRequestDTO.AppleAppLogin request, HttpServletResponse response) {
-        AppleIdentity identity = verifyIdentity(request);
+    public String login(String identityToken, String rawNonce, HttpServletResponse response) {
+        AppleIdentity identity = verifyIdentity(identityToken, rawNonce);
         Map<String, Object> attributes = identity.toOAuth2Attributes();
         SocialAccountResolution result = socialAccountResolver.resolve(
                 OAuth2Attributes.of(REGISTRATION_ID, attributes),
@@ -50,9 +49,9 @@ public class AppleAppLoginService {
         return jwtLoginProcessor.processLogin(response, authentication);
     }
 
-    private AppleIdentity verifyIdentity(AuthRequestDTO.AppleAppLogin request) {
+    private AppleIdentity verifyIdentity(String identityToken, String rawNonce) {
         try {
-            return appleIdTokenVerifier.verifyIosToken(request.getIdentityToken(), request.getRawNonce());
+            return appleIdTokenVerifier.verifyIosToken(identityToken, rawNonce);
         } catch (InvalidAppleIdentityTokenException e) {
             throw new AuthException(AuthErrorStatus.APPLE_INVALID_TOKEN);
         }

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleAppLoginService.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleAppLoginService.java
@@ -1,0 +1,75 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import checkmo.authentication.internal.exception.AuthErrorStatus;
+import checkmo.authentication.internal.exception.AuthException;
+import checkmo.authentication.internal.security.apple.AppleIdTokenVerifier;
+import checkmo.authentication.internal.security.apple.AppleIdentity;
+import checkmo.authentication.internal.security.apple.InvalidAppleIdentityTokenException;
+import checkmo.authentication.internal.security.auth.PrincipalDetails;
+import checkmo.authentication.internal.security.jwt.JwtLoginProcessor;
+import checkmo.authentication.web.dto.AuthRequestDTO;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class AppleAppLoginService {
+
+    private static final String REGISTRATION_ID = "apple";
+    private static final String EMAIL_VERIFIED = "email_verified";
+    private static final String PRIVATE_EMAIL = "is_private_email";
+
+    private final AppleIdTokenVerifier appleIdTokenVerifier;
+    private final SocialAccountResolver socialAccountResolver;
+    private final JwtLoginProcessor jwtLoginProcessor;
+
+    @Transactional
+    public String login(AuthRequestDTO.AppleAppLogin request, HttpServletResponse response) {
+        AppleIdentity identity = verifyIdentity(request);
+        Map<String, Object> attributes = toAttributes(identity);
+        SocialAccountResolution result = socialAccountResolver.resolve(
+                OAuth2Attributes.of(REGISTRATION_ID, attributes),
+                REGISTRATION_ID
+        );
+
+        PrincipalDetails principalDetails = new PrincipalDetails(
+                result.user(),
+                attributes,
+                result.newSocialSignUp()
+        );
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                principalDetails,
+                null,
+                principalDetails.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        return jwtLoginProcessor.processLogin(response, authentication);
+    }
+
+    private AppleIdentity verifyIdentity(AuthRequestDTO.AppleAppLogin request) {
+        try {
+            return appleIdTokenVerifier.verifyIosToken(request.getIdentityToken(), request.getRawNonce());
+        } catch (InvalidAppleIdentityTokenException e) {
+            throw new AuthException(AuthErrorStatus.APPLE_INVALID_TOKEN);
+        }
+    }
+
+    private Map<String, Object> toAttributes(AppleIdentity identity) {
+        Map<String, Object> attributes = new LinkedHashMap<>();
+        attributes.put("sub", identity.subject());
+        if (StringUtils.hasText(identity.email())) {
+            attributes.put("email", identity.email());
+        }
+        attributes.put(EMAIL_VERIFIED, identity.emailVerified());
+        attributes.put(PRIVATE_EMAIL, identity.privateEmail());
+        return Map.copyOf(attributes);
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleAppLoginService.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleAppLoginService.java
@@ -9,7 +9,6 @@ import checkmo.authentication.internal.security.auth.PrincipalDetails;
 import checkmo.authentication.internal.security.jwt.JwtLoginProcessor;
 import checkmo.authentication.web.dto.AuthRequestDTO;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,15 +16,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 public class AppleAppLoginService {
 
     private static final String REGISTRATION_ID = "apple";
-    private static final String EMAIL_VERIFIED = "email_verified";
-    private static final String PRIVATE_EMAIL = "is_private_email";
 
     private final AppleIdTokenVerifier appleIdTokenVerifier;
     private final SocialAccountResolver socialAccountResolver;
@@ -34,7 +30,7 @@ public class AppleAppLoginService {
     @Transactional
     public String login(AuthRequestDTO.AppleAppLogin request, HttpServletResponse response) {
         AppleIdentity identity = verifyIdentity(request);
-        Map<String, Object> attributes = toAttributes(identity);
+        Map<String, Object> attributes = identity.toOAuth2Attributes();
         SocialAccountResolution result = socialAccountResolver.resolve(
                 OAuth2Attributes.of(REGISTRATION_ID, attributes),
                 REGISTRATION_ID
@@ -60,16 +56,5 @@ public class AppleAppLoginService {
         } catch (InvalidAppleIdentityTokenException e) {
             throw new AuthException(AuthErrorStatus.APPLE_INVALID_TOKEN);
         }
-    }
-
-    private Map<String, Object> toAttributes(AppleIdentity identity) {
-        Map<String, Object> attributes = new LinkedHashMap<>();
-        attributes.put("sub", identity.subject());
-        if (StringUtils.hasText(identity.email())) {
-            attributes.put("email", identity.email());
-        }
-        attributes.put(EMAIL_VERIFIED, identity.emailVerified());
-        attributes.put(PRIVATE_EMAIL, identity.privateEmail());
-        return Map.copyOf(attributes);
     }
 }

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleClientSecretTokenRequestParametersConverter.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleClientSecretTokenRequestParametersConverter.java
@@ -1,0 +1,32 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import checkmo.authentication.internal.entity.Provider;
+import checkmo.authentication.internal.security.apple.AppleClientSecretGenerator;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.oauth2.client.endpoint.DefaultOAuth2TokenRequestParametersConverter;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.util.MultiValueMap;
+
+public class AppleClientSecretTokenRequestParametersConverter
+        implements Converter<OAuth2AuthorizationCodeGrantRequest, MultiValueMap<String, String>> {
+
+    private final DefaultOAuth2TokenRequestParametersConverter<OAuth2AuthorizationCodeGrantRequest> delegate =
+            new DefaultOAuth2TokenRequestParametersConverter<>();
+    private final AppleClientSecretGenerator appleClientSecretGenerator;
+
+    public AppleClientSecretTokenRequestParametersConverter(
+            AppleClientSecretGenerator appleClientSecretGenerator
+    ) {
+        this.appleClientSecretGenerator = appleClientSecretGenerator;
+    }
+
+    @Override
+    public MultiValueMap<String, String> convert(OAuth2AuthorizationCodeGrantRequest grantRequest) {
+        MultiValueMap<String, String> parameters = delegate.convert(grantRequest);
+        if (Provider.APPLE.equals(grantRequest.getClientRegistration().getRegistrationId())) {
+            parameters.set(OAuth2ParameterNames.CLIENT_SECRET, appleClientSecretGenerator.generateClientSecret());
+        }
+        return parameters;
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,57 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import checkmo.authentication.internal.entity.Provider;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+
+public class AppleOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+    private static final String AUTHORIZATION_REQUEST_BASE_URI = "/oauth2/authorization";
+    private static final String RESPONSE_MODE = "response_mode";
+    private static final String FORM_POST = "form_post";
+
+    private final OAuth2AuthorizationRequestResolver delegate;
+
+    public AppleOAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        this.delegate = new DefaultOAuth2AuthorizationRequestResolver(
+                clientRegistrationRepository,
+                AUTHORIZATION_REQUEST_BASE_URI
+        );
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        return customize(delegate.resolve(request));
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        return customize(delegate.resolve(request, clientRegistrationId));
+    }
+
+    private OAuth2AuthorizationRequest customize(OAuth2AuthorizationRequest authorizationRequest) {
+        if (authorizationRequest == null || !isAppleRegistration(authorizationRequest)) {
+            return authorizationRequest;
+        }
+
+        Map<String, Object> additionalParameters = new LinkedHashMap<>(
+                authorizationRequest.getAdditionalParameters()
+        );
+        additionalParameters.put(RESPONSE_MODE, FORM_POST);
+
+        return OAuth2AuthorizationRequest.from(authorizationRequest)
+                .additionalParameters(additionalParameters)
+                .build();
+    }
+
+    private boolean isAppleRegistration(OAuth2AuthorizationRequest authorizationRequest) {
+        Object registrationId = authorizationRequest.getAttribute(OAuth2ParameterNames.REGISTRATION_ID);
+        return Provider.APPLE.equals(registrationId);
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolver.java
@@ -2,6 +2,7 @@ package checkmo.authentication.internal.security.oauth2;
 
 import checkmo.authentication.internal.entity.Provider;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -15,6 +16,9 @@ public class AppleOAuth2AuthorizationRequestResolver implements OAuth2Authorizat
     private static final String AUTHORIZATION_REQUEST_BASE_URI = "/oauth2/authorization";
     private static final String RESPONSE_MODE = "response_mode";
     private static final String FORM_POST = "form_post";
+    private static final String CLIENT_PARAM = "client";
+    public static final String SESSION_CLIENT_TYPE = "OAUTH2_CLIENT_TYPE";
+    public static final String CLIENT_TYPE_APP = "app";
 
     private final OAuth2AuthorizationRequestResolver delegate;
 
@@ -27,12 +31,32 @@ public class AppleOAuth2AuthorizationRequestResolver implements OAuth2Authorizat
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
-        return customize(delegate.resolve(request));
+        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request);
+        captureClientType(request, authorizationRequest);
+        return customize(authorizationRequest);
     }
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
-        return customize(delegate.resolve(request, clientRegistrationId));
+        OAuth2AuthorizationRequest authorizationRequest = delegate.resolve(request, clientRegistrationId);
+        captureClientType(request, authorizationRequest);
+        return customize(authorizationRequest);
+    }
+
+    private void captureClientType(HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest) {
+        if (authorizationRequest == null) {
+            return;
+        }
+
+        if (CLIENT_TYPE_APP.equalsIgnoreCase(request.getParameter(CLIENT_PARAM))) {
+            request.getSession().setAttribute(SESSION_CLIENT_TYPE, CLIENT_TYPE_APP);
+            return;
+        }
+
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.removeAttribute(SESSION_CLIENT_TYPE);
+        }
     }
 
     private OAuth2AuthorizationRequest customize(OAuth2AuthorizationRequest authorizationRequest) {

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolver.java
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.client.web.DefaultOAuth2Authorization
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.util.StringUtils;
 
 public class AppleOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
 
@@ -17,7 +18,7 @@ public class AppleOAuth2AuthorizationRequestResolver implements OAuth2Authorizat
     private static final String RESPONSE_MODE = "response_mode";
     private static final String FORM_POST = "form_post";
     private static final String CLIENT_PARAM = "client";
-    public static final String SESSION_CLIENT_TYPE = "OAUTH2_CLIENT_TYPE";
+    private static final String SESSION_CLIENT_TYPE_PREFIX = "OAUTH2_CLIENT_TYPE:";
     public static final String CLIENT_TYPE_APP = "app";
 
     private final OAuth2AuthorizationRequestResolver delegate;
@@ -49,14 +50,28 @@ public class AppleOAuth2AuthorizationRequestResolver implements OAuth2Authorizat
         }
 
         if (CLIENT_TYPE_APP.equalsIgnoreCase(request.getParameter(CLIENT_PARAM))) {
-            request.getSession().setAttribute(SESSION_CLIENT_TYPE, CLIENT_TYPE_APP);
-            return;
+            String state = authorizationRequest.getState();
+            if (StringUtils.hasText(state)) {
+                request.getSession().setAttribute(sessionClientTypeKey(state), CLIENT_TYPE_APP);
+            }
+        }
+    }
+
+    static boolean consumeAppClientType(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        String state = request.getParameter(OAuth2ParameterNames.STATE);
+        if (session == null || !StringUtils.hasText(state)) {
+            return false;
         }
 
-        HttpSession session = request.getSession(false);
-        if (session != null) {
-            session.removeAttribute(SESSION_CLIENT_TYPE);
-        }
+        String attributeName = sessionClientTypeKey(state);
+        Object clientType = session.getAttribute(attributeName);
+        session.removeAttribute(attributeName);
+        return CLIENT_TYPE_APP.equals(clientType);
+    }
+
+    static String sessionClientTypeKey(String state) {
+        return SESSION_CLIENT_TYPE_PREFIX + state;
     }
 
     private OAuth2AuthorizationRequest customize(OAuth2AuthorizationRequest authorizationRequest) {

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2UserService.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2UserService.java
@@ -1,0 +1,77 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import checkmo.authentication.internal.exception.AuthException;
+import checkmo.authentication.internal.security.apple.AppleIdTokenVerifier;
+import checkmo.authentication.internal.security.apple.AppleIdentity;
+import checkmo.authentication.internal.security.apple.InvalidAppleIdentityTokenException;
+import checkmo.authentication.internal.security.auth.PrincipalDetails;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class AppleOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private static final String INVALID_APPLE_ID_TOKEN = "invalid_apple_id_token";
+    private static final String EMAIL_VERIFIED = "email_verified";
+    private static final String PRIVATE_EMAIL = "is_private_email";
+
+    private final AppleIdTokenVerifier appleIdTokenVerifier;
+    private final SocialAccountResolver socialAccountResolver;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        AppleIdentity identity = verifyIdentity(userRequest);
+        Map<String, Object> attributes = toAttributes(identity);
+        OAuth2Attributes oAuth2Attributes = OAuth2Attributes.of("apple", attributes);
+
+        try {
+            SocialAccountResolution result = socialAccountResolver.resolve(oAuth2Attributes, "apple");
+            return new PrincipalDetails(result.user(), attributes, result.newSocialSignUp());
+        } catch (AuthException e) {
+            String code = e.getErrorReasonHttpStatus().getCode();
+            String message = e.getErrorReasonHttpStatus().getMessage();
+            throw new OAuth2AuthenticationException(new OAuth2Error(code, message, null), message, e);
+        }
+    }
+
+    private AppleIdentity verifyIdentity(OAuth2UserRequest userRequest) {
+        Object idToken = userRequest.getAdditionalParameters().get(OidcParameterNames.ID_TOKEN);
+        if (!(idToken instanceof String value) || !StringUtils.hasText(value)) {
+            throw invalidAppleIdToken(null);
+        }
+
+        try {
+            return appleIdTokenVerifier.verifyWebToken(value);
+        } catch (InvalidAppleIdentityTokenException e) {
+            throw invalidAppleIdToken(e);
+        }
+    }
+
+    private OAuth2AuthenticationException invalidAppleIdToken(Throwable cause) {
+        OAuth2Error error = new OAuth2Error(INVALID_APPLE_ID_TOKEN, "Invalid Apple identity token", null);
+        return new OAuth2AuthenticationException(error, error.getDescription(), cause);
+    }
+
+    private Map<String, Object> toAttributes(AppleIdentity identity) {
+        Map<String, Object> attributes = new LinkedHashMap<>();
+        attributes.put("sub", identity.subject());
+        if (StringUtils.hasText(identity.email())) {
+            attributes.put("email", identity.email());
+        }
+        attributes.put(EMAIL_VERIFIED, identity.emailVerified());
+        attributes.put(PRIVATE_EMAIL, identity.privateEmail());
+        return Map.copyOf(attributes);
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2UserService.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2UserService.java
@@ -5,7 +5,6 @@ import checkmo.authentication.internal.security.apple.AppleIdTokenVerifier;
 import checkmo.authentication.internal.security.apple.AppleIdentity;
 import checkmo.authentication.internal.security.apple.InvalidAppleIdentityTokenException;
 import checkmo.authentication.internal.security.auth.PrincipalDetails;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -23,8 +22,6 @@ import org.springframework.util.StringUtils;
 public class AppleOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
     private static final String INVALID_APPLE_ID_TOKEN = "invalid_apple_id_token";
-    private static final String EMAIL_VERIFIED = "email_verified";
-    private static final String PRIVATE_EMAIL = "is_private_email";
 
     private final AppleIdTokenVerifier appleIdTokenVerifier;
     private final SocialAccountResolver socialAccountResolver;
@@ -33,7 +30,7 @@ public class AppleOAuth2UserService implements OAuth2UserService<OAuth2UserReque
     @Transactional
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         AppleIdentity identity = verifyIdentity(userRequest);
-        Map<String, Object> attributes = toAttributes(identity);
+        Map<String, Object> attributes = identity.toOAuth2Attributes();
         OAuth2Attributes oAuth2Attributes = OAuth2Attributes.of("apple", attributes);
 
         try {
@@ -62,16 +59,5 @@ public class AppleOAuth2UserService implements OAuth2UserService<OAuth2UserReque
     private OAuth2AuthenticationException invalidAppleIdToken(Throwable cause) {
         OAuth2Error error = new OAuth2Error(INVALID_APPLE_ID_TOKEN, "Invalid Apple identity token", null);
         return new OAuth2AuthenticationException(error, error.getDescription(), cause);
-    }
-
-    private Map<String, Object> toAttributes(AppleIdentity identity) {
-        Map<String, Object> attributes = new LinkedHashMap<>();
-        attributes.put("sub", identity.subject());
-        if (StringUtils.hasText(identity.email())) {
-            attributes.put("email", identity.email());
-        }
-        attributes.put(EMAIL_VERIFIED, identity.emailVerified());
-        attributes.put(PRIVATE_EMAIL, identity.privateEmail());
-        return Map.copyOf(attributes);
     }
 }

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/CustomOAuth2UserService.java
@@ -1,31 +1,26 @@
 package checkmo.authentication.internal.security.oauth2;
 
-import checkmo.authentication.AuthenticationEvent;
-import checkmo.authentication.internal.converter.AuthConverter;
-import checkmo.authentication.internal.entity.AuthUser;
-import checkmo.authentication.internal.repository.AuthRepository;
+import checkmo.authentication.internal.exception.AuthException;
 import checkmo.authentication.internal.security.auth.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 /**
  * Spring Security DefaultOAuth2UserService 구현체
  * <p>
- * 소셜 로그인 시 카카오, 구글, 네이버로부터 받은 사용자 정보를 처리 기존 회원 인지 신규 회원인지에 따라 다르게 처리하기 추가 정보 입력(닉네임, 관심 도서 분야 등) 필요 여부도 결정
+ * 소셜 로그인 시 카카오, 구글, 네이버, 애플로부터 받은 사용자 정보를 처리 기존 회원 인지 신규 회원인지에 따라 다르게 처리하기 추가 정보 입력(닉네임, 관심 도서 분야 등) 필요 여부도 결정
  */
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
-    private final AuthRepository authRepository;
-    private final ApplicationEventPublisher eventPublisher;
+    private final SocialAccountResolver socialAccountResolver;
 
     @Override
     @Transactional
@@ -36,36 +31,17 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         OAuth2Attributes attributes = OAuth2Attributes.of(registrationId, oAuth2User.getAttributes());
 
-        String email = attributes.getEmail();
-
-        if (!StringUtils.hasText(email)) { // 이메일 정보가 없으면 예외
-            throw new OAuth2AuthenticationException("소셜 계정에서 이메일 정보를 가져올 수 없습니다");
-        }
-
-        // 기존 회원인지 확인, 신규 회원이면 생성
-
-        AuthUser user = authRepository.findByEmail(email).orElse(null);
-
-        boolean newSocialSignUp = false;
-
-        if (user == null) {
-            user = registerNewMember(attributes, registrationId);
-            newSocialSignUp = true;
-        }
-
-        return new PrincipalDetails(user, oAuth2User.getAttributes(), newSocialSignUp);
+        SocialAccountResolution result = resolveSocialAccount(attributes, registrationId);
+        return new PrincipalDetails(result.user(), oAuth2User.getAttributes(), result.newSocialSignUp());
     }
 
-    private AuthUser registerNewMember(OAuth2Attributes attributes, String registrationId) {
-        AuthUser newUser = AuthConverter.toOAuth2User(attributes, registrationId);
-        AuthUser savedUser = authRepository.save(newUser);
-
-        eventPublisher.publishEvent(
-            AuthenticationEvent.CreateMember.builder()
-                                            .id(savedUser.getId())
-                                            .email(savedUser.getEmail())
-                                            .build());
-
-        return savedUser;
+    SocialAccountResolution resolveSocialAccount(OAuth2Attributes attributes, String registrationId) {
+        try {
+            return socialAccountResolver.resolve(attributes, registrationId);
+        } catch (AuthException e) {
+            String code = e.getErrorReasonHttpStatus().getCode();
+            String message = e.getErrorReasonHttpStatus().getMessage();
+            throw new OAuth2AuthenticationException(new OAuth2Error(code, message, null), message, e);
+        }
     }
 }

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2Attributes.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2Attributes.java
@@ -5,6 +5,8 @@ import checkmo.authentication.internal.entity.Provider;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.util.StringUtils;
 
 @Getter
 @AllArgsConstructor
@@ -19,6 +21,7 @@ public class OAuth2Attributes {
             case Provider.GOOGLE -> ofGoogle(attributes);
             case Provider.KAKAO -> ofKakao(attributes);
             case Provider.NAVER -> ofNaver(attributes);
+            case Provider.APPLE -> ofApple(attributes);
             default -> throw new IllegalArgumentException("지원하지 않는 소셜 로그인입니다: " + registrationId);
         };
     }
@@ -43,6 +46,17 @@ public class OAuth2Attributes {
         return OAuth2Attributes.builder()
                 .email((String) response.get(Provider.Naver.EMAIL))
                 .providerId((String) response.get(Provider.Naver.PROVIDER_ID))
+                .build();
+    }
+
+    private static OAuth2Attributes ofApple(Map<String, Object> attributes) {
+        String providerId = (String) attributes.get(Provider.Apple.PROVIDER_ID);
+        if (!StringUtils.hasText(providerId)) {
+            throw new OAuth2AuthenticationException("Apple 계정 식별자를 가져올 수 없습니다");
+        }
+        return OAuth2Attributes.builder()
+                .email((String) attributes.get(Provider.Apple.EMAIL))
+                .providerId(providerId)
                 .build();
     }
 }

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -2,11 +2,14 @@ package checkmo.authentication.internal.security.oauth2;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * 소셜 로그인 실패 시 실패 처리 핸들러
@@ -17,14 +20,43 @@ import org.springframework.stereotype.Component;
 @Component
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
+    @Value("${app.oauth2.redirect.app-uri}")
+    private String appUri;
+
     @Override
     public void onAuthenticationFailure(
             HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
             throws IOException {
 
-        log.error("소셜 로그인 인증 실패: {}", exception.getMessage());
+        log.error("소셜 로그인 인증 실패: {}", exception.getClass().getSimpleName());
+
+        if (isAppClient(request)) {
+            redirectAppFailure(request, response);
+            return;
+        }
 
         // 실패 시 리다이렉트 URL 설정
         getRedirectStrategy().sendRedirect(request, response, "/login?error=true");
+    }
+
+    private boolean isAppClient(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        return session != null && AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP.equals(
+                session.getAttribute(AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE)
+        );
+    }
+
+    private void redirectAppFailure(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.removeAttribute(AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE);
+        }
+
+        String targetUrl = UriComponentsBuilder.fromUriString(appUri)
+                .queryParam("error", "login_failed")
+                .build()
+                .encode()
+                .toUriString();
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -2,7 +2,6 @@ package checkmo.authentication.internal.security.oauth2;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,7 +29,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
         log.error("소셜 로그인 인증 실패: {}", exception.getClass().getSimpleName());
 
-        if (isAppClient(request)) {
+        if (AppleOAuth2AuthorizationRequestResolver.consumeAppClientType(request)) {
             redirectAppFailure(request, response);
             return;
         }
@@ -39,19 +38,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
         getRedirectStrategy().sendRedirect(request, response, "/login?error=true");
     }
 
-    private boolean isAppClient(HttpServletRequest request) {
-        HttpSession session = request.getSession(false);
-        return session != null && AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP.equals(
-                session.getAttribute(AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE)
-        );
-    }
-
     private void redirectAppFailure(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        HttpSession session = request.getSession(false);
-        if (session != null) {
-            session.removeAttribute(AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE);
-        }
-
         String targetUrl = UriComponentsBuilder.fromUriString(appUri)
                 .queryParam("error", "login_failed")
                 .build()

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -6,7 +6,6 @@ import checkmo.authentication.internal.security.jwt.JwtLoginProcessor;
 import checkmo.authentication.internal.security.jwt.TokenCacheService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +42,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
         AuthUser user = principalDetails.getUser();
 
-        if (isAppClient(request)) {
+        if (AppleOAuth2AuthorizationRequestResolver.consumeAppClientType(request)) {
             handleAppSuccess(request, response, authentication);
             return;
         }
@@ -71,13 +70,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 
-    private boolean isAppClient(HttpServletRequest request) {
-        HttpSession session = request.getSession(false);
-        return session != null && AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP.equals(
-                session.getAttribute(AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE)
-        );
-    }
-
     private void handleAppSuccess(
             HttpServletRequest request,
             HttpServletResponse response,
@@ -89,10 +81,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         String code = UUID.randomUUID().toString().replace("-", "");
         tokenCacheService.saveOAuthExchangeCode(code, user.isProfileCompleted() + "|" + refreshToken);
 
-        HttpSession session = request.getSession(false);
-        if (session != null) {
-            session.removeAttribute(AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE);
-        }
         clearAuthenticationAttributes(request);
 
         String targetUrl = UriComponentsBuilder.fromUriString(appUri)

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -3,9 +3,12 @@ package checkmo.authentication.internal.security.oauth2;
 import checkmo.authentication.internal.entity.AuthUser;
 import checkmo.authentication.internal.security.auth.PrincipalDetails;
 import checkmo.authentication.internal.security.jwt.JwtLoginProcessor;
+import checkmo.authentication.internal.security.jwt.TokenCacheService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -23,9 +26,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtLoginProcessor jwtLoginProcessor;
+    private final TokenCacheService tokenCacheService;
 
     @Value("${app.oauth2.redirect.base-uri}")
     private String baseUri;
+
+    @Value("${app.oauth2.redirect.app-uri}")
+    private String appUri;
 
     @Override
     public void onAuthenticationSuccess(
@@ -33,11 +40,16 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             Authentication authentication
     ) throws IOException {
 
-        // JWT 토큰 생성 및 쿠키 설정
-        jwtLoginProcessor.processLogin(response, authentication);
-
         PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
         AuthUser user = principalDetails.getUser();
+
+        if (isAppClient(request)) {
+            handleAppSuccess(request, response, authentication);
+            return;
+        }
+
+        // JWT 토큰 생성 및 쿠키 설정
+        jwtLoginProcessor.processLogin(response, authentication);
 
         String targetUrl;
 
@@ -56,6 +68,38 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         // 성공 후 리다이렉트 URL 설정
         clearAuthenticationAttributes(request);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    private boolean isAppClient(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        return session != null && AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP.equals(
+                session.getAttribute(AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE)
+        );
+    }
+
+    private void handleAppSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException {
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        AuthUser user = principalDetails.getUser();
+        String refreshToken = jwtLoginProcessor.processLoginWithoutCookies(authentication);
+        String code = UUID.randomUUID().toString().replace("-", "");
+        tokenCacheService.saveOAuthExchangeCode(code, user.isProfileCompleted() + "|" + refreshToken);
+
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.removeAttribute(AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE);
+        }
+        clearAuthenticationAttributes(request);
+
+        String targetUrl = UriComponentsBuilder.fromUriString(appUri)
+                .queryParam("code", code)
+                .build()
+                .encode()
+                .toUriString();
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreator.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreator.java
@@ -1,0 +1,34 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import checkmo.authentication.AuthenticationEvent;
+import checkmo.authentication.internal.converter.AuthConverter;
+import checkmo.authentication.internal.entity.AuthUser;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+class SocialAccountCreator {
+
+    private final EntityManager entityManager;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public AuthUser create(OAuth2Attributes attributes, String registrationId) {
+        AuthUser newUser = AuthConverter.toOAuth2User(attributes, registrationId);
+        entityManager.persist(newUser);
+        entityManager.flush();
+
+        eventPublisher.publishEvent(
+                AuthenticationEvent.CreateMember.builder()
+                        .id(newUser.getId())
+                        .email(newUser.getEmail())
+                        .build());
+
+        return newUser;
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolver.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolver.java
@@ -1,0 +1,85 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import checkmo.authentication.internal.converter.AuthConverter;
+import checkmo.authentication.internal.entity.AuthUser;
+import checkmo.authentication.internal.entity.Provider;
+import checkmo.authentication.internal.exception.AuthErrorStatus;
+import checkmo.authentication.internal.exception.AuthException;
+import checkmo.authentication.internal.repository.AuthRepository;
+import jakarta.persistence.PersistenceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class SocialAccountResolver {
+
+    private final AuthRepository authRepository;
+    private final SocialAccountCreator socialAccountCreator;
+
+    public SocialAccountResolution resolve(OAuth2Attributes attributes, String registrationId) {
+        if (Provider.APPLE.equalsIgnoreCase(registrationId)) {
+            return resolveApple(attributes, registrationId);
+        }
+
+        return resolveByEmail(attributes, registrationId);
+    }
+
+    private SocialAccountResolution resolveApple(OAuth2Attributes attributes, String registrationId) {
+        if (!StringUtils.hasText(attributes.getProviderId())) {
+            throw new OAuth2AuthenticationException("소셜 계정 식별자를 가져올 수 없습니다");
+        }
+        String expectedUserId = AuthConverter.toOAuth2MemberId(registrationId, attributes.getProviderId());
+
+        return authRepository.findById(expectedUserId)
+                .map(user -> new SocialAccountResolution(user, false))
+                .orElseGet(() -> createAppleUser(attributes, registrationId, expectedUserId));
+    }
+
+    private SocialAccountResolution createAppleUser(
+            OAuth2Attributes attributes,
+            String registrationId,
+            String expectedUserId
+    ) {
+        String email = attributes.getEmail();
+        if (!StringUtils.hasText(email)) {
+            throw new AuthException(AuthErrorStatus.APPLE_EMAIL_REQUIRED);
+        }
+
+        authRepository.findByEmail(email).ifPresent(user -> {
+            throw new AuthException(AuthErrorStatus.SOCIAL_ACCOUNT_EMAIL_CONFLICT);
+        });
+
+        try {
+            AuthUser savedUser = socialAccountCreator.create(attributes, registrationId);
+            return new SocialAccountResolution(savedUser, true);
+        } catch (DataIntegrityViolationException | PersistenceException e) {
+            return refetchAppleAfterDuplicate(expectedUserId, email);
+        }
+    }
+
+    private SocialAccountResolution refetchAppleAfterDuplicate(String expectedUserId, String email) {
+        AuthUser user = authRepository.findById(expectedUserId)
+                .or(() -> authRepository.findByEmail(email).filter(foundUser -> foundUser.getId().equals(expectedUserId)))
+                .orElseThrow(() -> new AuthException(AuthErrorStatus.SOCIAL_ACCOUNT_EMAIL_CONFLICT));
+
+        return new SocialAccountResolution(user, false);
+    }
+
+    private SocialAccountResolution resolveByEmail(OAuth2Attributes attributes, String registrationId) {
+        String email = attributes.getEmail();
+        if (!StringUtils.hasText(email)) {
+            throw new OAuth2AuthenticationException("소셜 계정에서 이메일 정보를 가져올 수 없습니다");
+        }
+
+        return authRepository.findByEmail(email)
+                .map(user -> new SocialAccountResolution(user, false))
+                .orElseGet(() -> new SocialAccountResolution(socialAccountCreator.create(attributes, registrationId), true));
+    }
+}
+
+record SocialAccountResolution(AuthUser user, boolean newSocialSignUp) {
+}

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/SocialOAuth2UserService.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/SocialOAuth2UserService.java
@@ -1,0 +1,26 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import checkmo.authentication.internal.entity.Provider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SocialOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final CustomOAuth2UserService defaultOAuth2UserService;
+    private final AppleOAuth2UserService appleOAuth2UserService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        if (Provider.APPLE.equals(registrationId)) {
+            return appleOAuth2UserService.loadUser(userRequest);
+        }
+        return defaultOAuth2UserService.loadUser(userRequest);
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/service/AuthFacade.java
+++ b/src/main/java/checkmo/authentication/internal/service/AuthFacade.java
@@ -51,7 +51,7 @@ public class AuthFacade {
     }
 
     public String loginWithApple(AuthRequestDTO.AppleAppLogin request, HttpServletResponse response) {
-        return appleAppLoginService.login(request, response);
+        return appleAppLoginService.login(request.getIdentityToken(), request.getRawNonce(), response);
     }
 
     public AuthResponseDTO.AppOAuthLogin exchangeOAuthCode(AuthRequestDTO.OAuthExchange request) {

--- a/src/main/java/checkmo/authentication/internal/service/AuthFacade.java
+++ b/src/main/java/checkmo/authentication/internal/service/AuthFacade.java
@@ -3,6 +3,7 @@ package checkmo.authentication.internal.service;
 import checkmo.authentication.internal.converter.AuthConverter;
 import checkmo.authentication.internal.entity.AuthUser;
 import checkmo.authentication.internal.security.jwt.JwtLoginProcessor;
+import checkmo.authentication.internal.security.oauth2.AppleAppLoginService;
 import checkmo.authentication.internal.service.command.AuthTokenRotationService;
 import checkmo.authentication.internal.service.result.AuthTokenRotationResult;
 import checkmo.authentication.internal.service.command.AuthSessionCommandService;
@@ -23,6 +24,7 @@ public class AuthFacade {
     private final AuthSessionCommandService authSessionCommandService;
     private final AuthTokenRotationService authTokenRotationService;
     private final JwtLoginProcessor jwtLoginProcessor;
+    private final AppleAppLoginService appleAppLoginService;
 
     public AuthSignUpResult signUp(AuthRequestDTO.SignUp request, HttpServletResponse response) {
         AuthUser user = authUserCommandService.signUp(request);
@@ -41,6 +43,10 @@ public class AuthFacade {
 
         // JWT 토큰 생성 및 쿠키 설정, Refresh Token 반환
         return jwtLoginProcessor.processLogin(response, authentication);
+    }
+
+    public String loginWithApple(AuthRequestDTO.AppleAppLogin request, HttpServletResponse response) {
+        return appleAppLoginService.login(request, response);
     }
 
     public void logout(HttpServletRequest request, HttpServletResponse response) {

--- a/src/main/java/checkmo/authentication/internal/service/AuthFacade.java
+++ b/src/main/java/checkmo/authentication/internal/service/AuthFacade.java
@@ -2,14 +2,18 @@ package checkmo.authentication.internal.service;
 
 import checkmo.authentication.internal.converter.AuthConverter;
 import checkmo.authentication.internal.entity.AuthUser;
+import checkmo.authentication.internal.exception.AuthErrorStatus;
+import checkmo.authentication.internal.exception.AuthException;
 import checkmo.authentication.internal.security.jwt.JwtLoginProcessor;
+import checkmo.authentication.internal.security.jwt.TokenCacheService;
 import checkmo.authentication.internal.security.oauth2.AppleAppLoginService;
 import checkmo.authentication.internal.service.command.AuthTokenRotationService;
-import checkmo.authentication.internal.service.result.AuthTokenRotationResult;
 import checkmo.authentication.internal.service.command.AuthSessionCommandService;
 import checkmo.authentication.internal.service.command.AuthUserCommandService;
+import checkmo.authentication.internal.service.result.AuthTokenRotationResult;
 import checkmo.authentication.internal.service.result.AuthSignUpResult;
 import checkmo.authentication.web.dto.AuthRequestDTO;
+import checkmo.authentication.web.dto.AuthResponseDTO;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +29,7 @@ public class AuthFacade {
     private final AuthTokenRotationService authTokenRotationService;
     private final JwtLoginProcessor jwtLoginProcessor;
     private final AppleAppLoginService appleAppLoginService;
+    private final TokenCacheService tokenCacheService;
 
     public AuthSignUpResult signUp(AuthRequestDTO.SignUp request, HttpServletResponse response) {
         AuthUser user = authUserCommandService.signUp(request);
@@ -49,6 +54,17 @@ public class AuthFacade {
         return appleAppLoginService.login(request, response);
     }
 
+    public AuthResponseDTO.AppOAuthLogin exchangeOAuthCode(AuthRequestDTO.OAuthExchange request) {
+        OAuthExchangePayload payload = parseOAuthExchangePayload(
+                tokenCacheService.consumeOAuthExchangeCode(request.getCode())
+        );
+
+        return AuthResponseDTO.AppOAuthLogin.builder()
+                .refreshToken(payload.refreshToken())
+                .isProfileCompleted(payload.profileCompleted())
+                .build();
+    }
+
     public void logout(HttpServletRequest request, HttpServletResponse response) {
         authSessionCommandService.logout(request, response);
     }
@@ -61,5 +77,27 @@ public class AuthFacade {
         AuthTokenRotationResult rotationResult = authTokenRotationService.rotateRefreshToken(refreshToken);
         authTokenRotationService.writeTokenCookies(response, rotationResult.getJwtToken());
         return rotationResult.getJwtToken().getRefreshToken();
+    }
+
+    private OAuthExchangePayload parseOAuthExchangePayload(String stored) {
+        if (stored == null) {
+            throw new AuthException(AuthErrorStatus.INVALID_OAUTH_CODE);
+        }
+
+        int separator = stored.indexOf('|');
+        if (separator <= 0 || separator == stored.length() - 1) {
+            throw new AuthException(AuthErrorStatus.INVALID_OAUTH_CODE);
+        }
+
+        String profileCompleted = stored.substring(0, separator);
+        if (!"true".equals(profileCompleted) && !"false".equals(profileCompleted)) {
+            throw new AuthException(AuthErrorStatus.INVALID_OAUTH_CODE);
+        }
+
+        String refreshToken = stored.substring(separator + 1);
+        return new OAuthExchangePayload(Boolean.parseBoolean(profileCompleted), refreshToken);
+    }
+
+    private record OAuthExchangePayload(boolean profileCompleted, String refreshToken) {
     }
 }

--- a/src/main/java/checkmo/authentication/web/controller/AuthController.java
+++ b/src/main/java/checkmo/authentication/web/controller/AuthController.java
@@ -107,6 +107,22 @@ public class AuthController {
         return ApiResponse.onSuccess(AuthResponseDTO.Login.builder().refreshToken(refreshToken).build());
     }
 
+    @Operation(summary = "앱 Apple 로그인", description = "앱에서 Apple identityToken과 rawNonce로 로그인합니다.")
+    @PostMapping("/app/apple/login")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 Apple 인증 정보입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 다른 계정으로 가입된 이메일입니다.")
+    })
+    public ApiResponse<AuthResponseDTO.Login> appAppleLogin(
+            @Valid @RequestBody AuthRequestDTO.AppleAppLogin request,
+            HttpServletResponse response
+    ) {
+        String refreshToken = authFacade.loginWithApple(request, response);
+        return ApiResponse.onSuccess(AuthResponseDTO.Login.builder().refreshToken(refreshToken).build());
+    }
+
     @Operation(summary = "앱 토큰 재발급", description = "앱에서 리프레시 토큰을 회전하고 새 토큰을 발급받습니다.")
     @PostMapping("/app/refresh")
     @io.swagger.v3.oas.annotations.responses.ApiResponses({

--- a/src/main/java/checkmo/authentication/web/controller/AuthController.java
+++ b/src/main/java/checkmo/authentication/web/controller/AuthController.java
@@ -107,6 +107,19 @@ public class AuthController {
         return ApiResponse.onSuccess(AuthResponseDTO.Login.builder().refreshToken(refreshToken).build());
     }
 
+    @Operation(summary = "앱 소셜 로그인 코드 교환", description = "딥링크로 받은 일회용 코드를 refreshToken으로 교환합니다.")
+    @PostMapping("/app/oauth/exchange")
+    @io.swagger.v3.oas.annotations.responses.ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않거나 만료된 인증 코드입니다.")
+    })
+    public ApiResponse<AuthResponseDTO.AppOAuthLogin> appOAuthExchange(
+            @Valid @RequestBody AuthRequestDTO.OAuthExchange request
+    ) {
+        return ApiResponse.onSuccess(authFacade.exchangeOAuthCode(request));
+    }
+
     @Operation(summary = "앱 Apple 로그인", description = "앱에서 Apple identityToken과 rawNonce로 로그인합니다.")
     @PostMapping("/app/apple/login")
     @io.swagger.v3.oas.annotations.responses.ApiResponses({

--- a/src/main/java/checkmo/authentication/web/dto/AuthRequestDTO.java
+++ b/src/main/java/checkmo/authentication/web/dto/AuthRequestDTO.java
@@ -72,6 +72,15 @@ public class AuthRequestDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class OAuthExchange {
+        @NotBlank(message = "코드는 필수입니다")
+        @Schema(description = "딥링크로 전달받은 앱 OAuth 일회용 코드")
+        private String code;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class EmailVerification {
         @NotBlank(message = "이메일은 필수입니다")
         @Email(message = "유효한 이메일 형식이 아닙니다")

--- a/src/main/java/checkmo/authentication/web/dto/AuthRequestDTO.java
+++ b/src/main/java/checkmo/authentication/web/dto/AuthRequestDTO.java
@@ -59,6 +59,18 @@ public class AuthRequestDTO {
 
     @Getter
     @NoArgsConstructor
+    public static class AppleAppLogin {
+        @NotBlank(message = "Apple identityToken은 필수입니다")
+        private String identityToken;
+
+        @NotBlank(message = "Apple rawNonce는 필수입니다")
+        private String rawNonce;
+
+        private String authorizationCode;
+    }
+
+    @Getter
+    @NoArgsConstructor
     @AllArgsConstructor
     public static class EmailVerification {
         @NotBlank(message = "이메일은 필수입니다")

--- a/src/main/java/checkmo/authentication/web/dto/AuthRequestDTO.java
+++ b/src/main/java/checkmo/authentication/web/dto/AuthRequestDTO.java
@@ -65,8 +65,6 @@ public class AuthRequestDTO {
 
         @NotBlank(message = "Apple rawNonce는 필수입니다")
         private String rawNonce;
-
-        private String authorizationCode;
     }
 
     @Getter

--- a/src/main/java/checkmo/authentication/web/dto/AuthResponseDTO.java
+++ b/src/main/java/checkmo/authentication/web/dto/AuthResponseDTO.java
@@ -23,4 +23,13 @@ public class AuthResponseDTO {
     public static class Login {
         private String refreshToken;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AppOAuthLogin {
+        private String refreshToken;
+        private boolean isProfileCompleted;
+    }
 }

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -2,6 +2,13 @@ app:
   oauth2:
     redirect:
       base-uri: ${FRONTEND_BASE_URI}
+    apple:
+      team-id: ${APPLE_TEAM_ID:}
+      key-id: ${APPLE_KEY_ID:}
+      web-client-id: ${APPLE_WEB_CLIENT_ID:}
+      ios-client-id: ${APPLE_IOS_CLIENT_ID:}
+      private-key-base64: ${APPLE_PRIVATE_KEY_BASE64:}
+      web-redirect-uri: ${APPLE_WEB_REDIRECT_URI:https://api.checkmo.co.kr/login/oauth2/code/apple}
 
 spring:
   security:

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -44,6 +44,18 @@ spring:
             authorization-grant-type: authorization_code
             client-name: Naver
 
+          apple:
+            client-id: ${APPLE_WEB_CLIENT_ID:kr.co.checkmo.web}
+            client-secret: apple-client-secret-generated-at-runtime
+            client-authentication-method: client_secret_post
+            scope:
+              - openid
+              - email
+              - name
+            redirect-uri: ${APPLE_WEB_REDIRECT_URI:https://api.checkmo.co.kr/login/oauth2/code/apple}
+            authorization-grant-type: authorization_code
+            client-name: Apple
+
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
@@ -56,3 +68,7 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+
+          apple:
+            authorization-uri: https://appleid.apple.com/auth/authorize
+            token-uri: https://appleid.apple.com/auth/token

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -6,7 +6,7 @@ app:
     apple:
       team-id: ${APPLE_TEAM_ID:}
       key-id: ${APPLE_KEY_ID:}
-      web-client-id: ${APPLE_WEB_CLIENT_ID:}
+      web-client-id: ${APPLE_WEB_CLIENT_ID:kr.co.checkmo.web}
       ios-client-id: ${APPLE_IOS_CLIENT_ID:}
       private-key-base64: ${APPLE_PRIVATE_KEY_BASE64:}
       web-redirect-uri: ${APPLE_WEB_REDIRECT_URI:https://api.checkmo.co.kr/login/oauth2/code/apple}
@@ -46,14 +46,14 @@ spring:
             client-name: Naver
 
           apple:
-            client-id: ${APPLE_WEB_CLIENT_ID:kr.co.checkmo.web}
+            client-id: ${app.oauth2.apple.web-client-id}
             client-secret: apple-client-secret-generated-at-runtime
             client-authentication-method: client_secret_post
             scope:
               - openid
               - email
               - name
-            redirect-uri: ${APPLE_WEB_REDIRECT_URI:https://api.checkmo.co.kr/login/oauth2/code/apple}
+            redirect-uri: ${app.oauth2.apple.web-redirect-uri}
             authorization-grant-type: authorization_code
             client-name: Apple
 

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -2,6 +2,7 @@ app:
   oauth2:
     redirect:
       base-uri: ${FRONTEND_BASE_URI}
+      app-uri: ${APP_OAUTH2_REDIRECT_URI:checkmo://oauth-callback}
     apple:
       team-id: ${APPLE_TEAM_ID:}
       key-id: ${APPLE_KEY_ID:}

--- a/src/test/java/checkmo/authentication/AppleAppLoginApiTest.java
+++ b/src/test/java/checkmo/authentication/AppleAppLoginApiTest.java
@@ -31,8 +31,7 @@ class AppleAppLoginApiTest extends ApiTestSupport {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(Map.of(
                         "identityToken", "valid-identity-token",
-                        "rawNonce", "raw-nonce",
-                        "authorizationCode", "unused-authorization-code"
+                        "rawNonce", "raw-nonce"
                 ))
                 .when()
                 .post("/api/v1/auth/app/apple/login")

--- a/src/test/java/checkmo/authentication/AppleAppLoginApiTest.java
+++ b/src/test/java/checkmo/authentication/AppleAppLoginApiTest.java
@@ -1,0 +1,150 @@
+package checkmo.authentication;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+import checkmo.authentication.internal.security.apple.AppleIdTokenVerifier;
+import checkmo.authentication.internal.security.apple.AppleIdentity;
+import checkmo.authentication.internal.security.apple.InvalidAppleIdentityTokenException;
+import checkmo.support.ApiTestSupport;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+class AppleAppLoginApiTest extends ApiTestSupport {
+
+    @MockitoBean
+    AppleIdTokenVerifier appleIdTokenVerifier;
+
+    @Test
+    void appleAppLoginSucceedsWithRefreshTokenInResponseAndCookies() {
+        when(appleIdTokenVerifier.verifyIosToken("valid-identity-token", "raw-nonce"))
+                .thenReturn(identity("apple-sub", "apple-user@example.com"));
+
+        ExtractableResponse<Response> response = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of(
+                        "identityToken", "valid-identity-token",
+                        "rawNonce", "raw-nonce",
+                        "authorizationCode", "unused-authorization-code"
+                ))
+                .when()
+                .post("/api/v1/auth/app/apple/login")
+                .then()
+                .statusCode(200)
+                .extract();
+
+        String refreshToken = response.jsonPath().getString("result.refreshToken");
+        assertSoftly(softly -> {
+            softly.assertThat(refreshToken).isNotBlank();
+            softly.assertThat(response.cookie("refreshToken")).isEqualTo(refreshToken);
+            softly.assertThat(response.cookie("accessToken")).isNotBlank();
+            softly.assertThat(authRepository.findById("APPLE_apple-sub")).isPresent();
+        });
+    }
+
+    @Test
+    void appleAppLoginReusesExistingAppleUserWithoutEmailClaim() {
+        when(appleIdTokenVerifier.verifyIosToken("first-token", "raw-nonce"))
+                .thenReturn(identity("repeat-sub", "repeat-apple-user@example.com"));
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("identityToken", "first-token", "rawNonce", "raw-nonce"))
+                .when()
+                .post("/api/v1/auth/app/apple/login")
+                .then()
+                .statusCode(200);
+        when(appleIdTokenVerifier.verifyIosToken("repeat-token", "raw-nonce"))
+                .thenReturn(identityWithoutEmail("repeat-sub"));
+
+        ExtractableResponse<Response> response = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("identityToken", "repeat-token", "rawNonce", "raw-nonce"))
+                .when()
+                .post("/api/v1/auth/app/apple/login")
+                .then()
+                .statusCode(200)
+                .extract();
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.jsonPath().getString("result.refreshToken")).isNotBlank();
+            softly.assertThat(authRepository.findById("APPLE_repeat-sub")).isPresent();
+            softly.assertThat(authRepository.findByEmail("repeat-apple-user@example.com")).isPresent();
+        });
+    }
+
+    @Test
+    void appleAppLoginRejectsEmailCollision() {
+        TestUser existingUser = createUser();
+        when(appleIdTokenVerifier.verifyIosToken("valid-identity-token", "raw-nonce"))
+                .thenReturn(identity("new-apple-sub", existingUser.email()));
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("identityToken", "valid-identity-token", "rawNonce", "raw-nonce"))
+                .when()
+                .post("/api/v1/auth/app/apple/login")
+                .then()
+                .statusCode(409)
+                .body("isSuccess", equalTo(false))
+                .body("code", equalTo("AUTH_414"));
+
+        assertThat(authRepository.findById("APPLE_new-apple-sub")).isEmpty();
+    }
+
+    @Test
+    void appleAppLoginRejectsInvalidIdentityToken() {
+        when(appleIdTokenVerifier.verifyIosToken("invalid-identity-token", "raw-nonce"))
+                .thenThrow(new InvalidAppleIdentityTokenException());
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("identityToken", "invalid-identity-token", "rawNonce", "raw-nonce"))
+                .when()
+                .post("/api/v1/auth/app/apple/login")
+                .then()
+                .statusCode(401)
+                .body("isSuccess", equalTo(false))
+                .body("code", equalTo("AUTH_415"));
+    }
+
+    @Test
+    void appleAppLoginRejectsMissingRequiredPayload() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("identityToken", "valid-identity-token"))
+                .when()
+                .post("/api/v1/auth/app/apple/login")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    private AppleIdentity identity(String subject, String email) {
+        return new AppleIdentity(
+                subject,
+                "APPLE_" + subject,
+                email,
+                true,
+                false,
+                "kr.co.checkmo.app"
+        );
+    }
+
+    private AppleIdentity identityWithoutEmail(String subject) {
+        return new AppleIdentity(
+                subject,
+                "APPLE_" + subject,
+                null,
+                false,
+                false,
+                "kr.co.checkmo.app"
+        );
+    }
+}

--- a/src/test/java/checkmo/authentication/AuthApiTest.java
+++ b/src/test/java/checkmo/authentication/AuthApiTest.java
@@ -2,6 +2,7 @@ package checkmo.authentication;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -222,7 +223,11 @@ class AuthApiTest extends ApiTestSupport {
                 .extract();
 
         assertJwtCookiesWereSet(response);
-        assertThat(response.jsonPath().getString("result.refreshToken")).isNotBlank();
+        String responseRefreshToken = response.jsonPath().getString("result.refreshToken");
+        assertSoftly(softly -> {
+            softly.assertThat(responseRefreshToken).isNotBlank();
+            softly.assertThat(response.cookie("refreshToken")).isEqualTo(responseRefreshToken);
+        });
     }
 
     @Test

--- a/src/test/java/checkmo/authentication/AuthApiTest.java
+++ b/src/test/java/checkmo/authentication/AuthApiTest.java
@@ -231,6 +231,85 @@ class AuthApiTest extends ApiTestSupport {
     }
 
     @Test
+    void appOAuthExchangeSucceedsWithRefreshTokenInResponse() {
+        when(tokenCacheService.consumeOAuthExchangeCode("oauth-code"))
+                .thenReturn("true|refresh-token");
+
+        ExtractableResponse<Response> response = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("code", "oauth-code"))
+                .when()
+                .post("/api/v1/auth/app/oauth/exchange")
+                .then()
+                .statusCode(200)
+                .extract();
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.jsonPath().getString("result.refreshToken"))
+                    .isEqualTo("refresh-token");
+            softly.assertThat(response.jsonPath().getBoolean("result.profileCompleted"))
+                    .isTrue();
+            softly.assertThat(response.headers().getValues("Set-Cookie"))
+                    .noneMatch(header -> header.startsWith("accessToken="))
+                    .noneMatch(header -> header.startsWith("refreshToken="));
+        });
+    }
+
+    @Test
+    void appOAuthExchangeRejectsReusedCode() {
+        when(tokenCacheService.consumeOAuthExchangeCode("oauth-code"))
+                .thenReturn("false|refresh-token")
+                .thenReturn(null);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("code", "oauth-code"))
+                .when()
+                .post("/api/v1/auth/app/oauth/exchange")
+                .then()
+                .statusCode(200);
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("code", "oauth-code"))
+                .when()
+                .post("/api/v1/auth/app/oauth/exchange")
+                .then()
+                .statusCode(401)
+                .body("isSuccess", equalTo(false))
+                .body("code", equalTo("AUTH_416"))
+                .body("message", equalTo("유효하지 않거나 만료된 인증 코드입니다. 다시 로그인해주세요."));
+    }
+
+    @Test
+    void appOAuthExchangeRejectsBlankCode() {
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("code", ""))
+                .when()
+                .post("/api/v1/auth/app/oauth/exchange")
+                .then()
+                .statusCode(400)
+                .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void appOAuthExchangeRejectsMalformedStoredValue() {
+        when(tokenCacheService.consumeOAuthExchangeCode("oauth-code"))
+                .thenReturn("malformed-value");
+
+        given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("code", "oauth-code"))
+                .when()
+                .post("/api/v1/auth/app/oauth/exchange")
+                .then()
+                .statusCode(401)
+                .body("isSuccess", equalTo(false))
+                .body("code", equalTo("AUTH_416"));
+    }
+
+    @Test
     void appRefreshSucceedsWithHeaderOnlyRefreshTokenAndRejectsReplay() {
         TestUser user = createUserWithPassword("Pass123!");
         ExtractableResponse<Response> loginResponse = given()

--- a/src/test/java/checkmo/authentication/internal/config/properties/AppleOAuthPropertiesTest.java
+++ b/src/test/java/checkmo/authentication/internal/config/properties/AppleOAuthPropertiesTest.java
@@ -1,0 +1,67 @@
+package checkmo.authentication.internal.config.properties;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+class AppleOAuthPropertiesTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withInitializer(loadOAuth2Yaml())
+            .withPropertyValues(
+                    "APPLE_TEAM_ID=test-team-id",
+                    "APPLE_KEY_ID=test-key-id",
+                    "APPLE_WEB_CLIENT_ID=test-web-client-id",
+                    "APPLE_IOS_CLIENT_ID=test-ios-client-id",
+                    "APPLE_PRIVATE_KEY_BASE64=test-key"
+            )
+            .withUserConfiguration(AppleOAuthPropertiesConfiguration.class);
+
+    @Test
+    void bindsAppleOAuthPropertiesFromOAuth2Profile() {
+        contextRunner.run(context -> {
+            AppleOAuthProperties properties = context.getBean(AppleOAuthProperties.class);
+
+            assertSoftly(softly -> {
+                softly.assertThat(properties.getTeamId()).isEqualTo("test-team-id");
+                softly.assertThat(properties.getKeyId()).isEqualTo("test-key-id");
+                softly.assertThat(properties.getWebClientId()).isEqualTo("test-web-client-id");
+                softly.assertThat(properties.getIosClientId()).isEqualTo("test-ios-client-id");
+                softly.assertThat(properties.getPrivateKeyBase64()).isEqualTo("test-key");
+                softly.assertThat(properties.getWebRedirectUri())
+                        .isEqualTo("https://api.checkmo.co.kr/login/oauth2/code/apple");
+            });
+        });
+    }
+
+    private ApplicationContextInitializer<ConfigurableApplicationContext> loadOAuth2Yaml() {
+        return context -> {
+            try {
+                YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+                List<PropertySource<?>> propertySources = loader.load(
+                        "application-oauth2",
+                        new ClassPathResource("application-oauth2.yml")
+                );
+                propertySources.forEach(propertySource ->
+                        context.getEnvironment().getPropertySources().addLast(propertySource));
+            } catch (IOException e) {
+                throw new IllegalStateException("application-oauth2.yml could not be loaded", e);
+            }
+        };
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(AppleOAuthProperties.class)
+    static class AppleOAuthPropertiesConfiguration {
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/config/properties/AppleOAuthPropertiesTest.java
+++ b/src/test/java/checkmo/authentication/internal/config/properties/AppleOAuthPropertiesTest.java
@@ -19,6 +19,13 @@ class AppleOAuthPropertiesTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withInitializer(loadOAuth2Yaml())
             .withPropertyValues(
+                    "FRONTEND_BASE_URI=https://web.checkmo.test",
+                    "GOOGLE_CLIENT_ID=test-google-client-id",
+                    "GOOGLE_CLIENT_SECRET=test-google-client-secret",
+                    "KAKAO_CLIENT_ID=test-kakao-client-id",
+                    "KAKAO_CLIENT_SECRET=test-kakao-client-secret",
+                    "NAVER_CLIENT_ID=test-naver-client-id",
+                    "NAVER_CLIENT_SECRET=test-naver-client-secret",
                     "APPLE_TEAM_ID=test-team-id",
                     "APPLE_KEY_ID=test-key-id",
                     "APPLE_WEB_CLIENT_ID=test-web-client-id",
@@ -40,6 +47,34 @@ class AppleOAuthPropertiesTest {
                 softly.assertThat(properties.getPrivateKeyBase64()).isEqualTo("test-key");
                 softly.assertThat(properties.getWebRedirectUri())
                         .isEqualTo("https://api.checkmo.co.kr/login/oauth2/code/apple");
+            });
+        });
+    }
+
+    @Test
+    void bindsAppleClientRegistrationFromOAuth2Profile() {
+        contextRunner.run(context -> {
+            var environment = context.getEnvironment();
+
+            assertSoftly(softly -> {
+                softly.assertThat(environment.getProperty(
+                        "spring.security.oauth2.client.registration.apple.client-id"
+                )).isEqualTo("test-web-client-id");
+                softly.assertThat(environment.getProperty(
+                        "spring.security.oauth2.client.registration.apple.client-secret"
+                )).isEqualTo("apple-client-secret-generated-at-runtime");
+                softly.assertThat(environment.getProperty(
+                        "spring.security.oauth2.client.registration.apple.client-authentication-method"
+                )).isEqualTo("client_secret_post");
+                softly.assertThat(environment.getProperty(
+                        "spring.security.oauth2.client.registration.apple.redirect-uri"
+                )).isEqualTo("https://api.checkmo.co.kr/login/oauth2/code/apple");
+                softly.assertThat(environment.getProperty(
+                        "spring.security.oauth2.client.provider.apple.authorization-uri"
+                )).isEqualTo("https://appleid.apple.com/auth/authorize");
+                softly.assertThat(environment.getProperty(
+                        "spring.security.oauth2.client.provider.apple.token-uri"
+                )).isEqualTo("https://appleid.apple.com/auth/token");
             });
         });
     }

--- a/src/test/java/checkmo/authentication/internal/security/apple/AppleClientSecretGeneratorTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/apple/AppleClientSecretGeneratorTest.java
@@ -118,6 +118,20 @@ class AppleClientSecretGeneratorTest {
     }
 
     @Test
+    void acceptsLineWrappedPrivateKeyBase64() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+        AppleClientSecretGenerator generator = new AppleClientSecretGenerator(
+                appleProperties(encodeWrappedBase64(privateKeyPem(keyPair))),
+                Clock.fixed(NOW, ZoneId.of("UTC"))
+        );
+
+        String clientSecret = generator.generateClientSecret();
+
+        Claims claims = parseClaims(clientSecret, keyPair.getPublic());
+        assertSoftly(softly -> softly.assertThat(claims.getSubject()).isEqualTo(WEB_CLIENT_ID));
+    }
+
+    @Test
     void rejectsPrivateKeyBase64WithIgnoredInvalidCharacters() {
         String encodedPem = Base64.getEncoder().encodeToString("not a pem".getBytes(StandardCharsets.UTF_8));
         AppleOAuthProperties properties = appleProperties(encodedPem + "!!!!");
@@ -225,6 +239,11 @@ class AppleClientSecretGeneratorTest {
 
     private String encodeBase64(String value) {
         return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String encodeWrappedBase64(String value) {
+        return Base64.getMimeEncoder(32, "\n".getBytes(StandardCharsets.UTF_8))
+                .encodeToString(value.getBytes(StandardCharsets.UTF_8));
     }
 
     private String beginMarker() {

--- a/src/test/java/checkmo/authentication/internal/security/apple/AppleClientSecretGeneratorTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/apple/AppleClientSecretGeneratorTest.java
@@ -1,0 +1,279 @@
+package checkmo.authentication.internal.security.apple;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import checkmo.authentication.internal.config.properties.AppleOAuthProperties;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.spec.ECGenParameterSpec;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AppleClientSecretGeneratorTest {
+
+    private static final String TEAM_ID = "test-team-id";
+    private static final String KEY_ID = "test-key-id";
+    private static final String WEB_CLIENT_ID = "test-web-client-id";
+    private static final String AUDIENCE = "https://appleid.apple.com";
+    private static final Instant NOW = Instant.parse("2026-06-24T00:00:00Z");
+    private static final Duration TOKEN_VALIDITY = Duration.ofDays(30);
+    private static final Duration REFRESH_SKEW = Duration.ofMinutes(5);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void generatesVerifiableAppleClientSecretWithExpectedHeaderAndClaims() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+        AppleClientSecretGenerator generator = new AppleClientSecretGenerator(
+                appleProperties(keyPair),
+                Clock.fixed(NOW, ZoneId.of("UTC"))
+        );
+
+        String clientSecret = generator.generateClientSecret();
+
+        Map<String, Object> header = decodeHeader(clientSecret);
+        Claims claims = parseClaims(clientSecret, keyPair.getPublic());
+        assertSoftly(softly -> {
+            softly.assertThat(header.get("alg")).isEqualTo("ES256");
+            softly.assertThat(header.get("kid")).isEqualTo(KEY_ID);
+            softly.assertThat(claims.getIssuer()).isEqualTo(TEAM_ID);
+            softly.assertThat(claims.getSubject()).isEqualTo(WEB_CLIENT_ID);
+            softly.assertThat(claims.getAudience()).containsExactly(AUDIENCE);
+            softly.assertThat(claims.getIssuedAt()).isEqualTo(Date.from(NOW));
+            softly.assertThat(claims.getExpiration()).isEqualTo(Date.from(NOW.plus(TOKEN_VALIDITY)));
+        });
+    }
+
+    @Test
+    void reusesCachedClientSecretBeforeRefreshBoundary() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+        MutableClock clock = new MutableClock(NOW);
+        AppleClientSecretGenerator generator = new AppleClientSecretGenerator(appleProperties(keyPair), clock);
+
+        String first = generator.generateClientSecret();
+        clock.setInstant(NOW.plus(TOKEN_VALIDITY).minus(REFRESH_SKEW).minusSeconds(1));
+        String second = generator.generateClientSecret();
+
+        assertSoftly(softly -> softly.assertThat(first.equals(second)).isTrue());
+    }
+
+    @Test
+    void regeneratesClientSecretAtRefreshBoundary() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+        MutableClock clock = new MutableClock(NOW);
+        AppleClientSecretGenerator generator = new AppleClientSecretGenerator(appleProperties(keyPair), clock);
+
+        String first = generator.generateClientSecret();
+        Instant refreshBoundary = NOW.plus(TOKEN_VALIDITY).minus(REFRESH_SKEW);
+        clock.setInstant(refreshBoundary);
+        String refreshed = generator.generateClientSecret();
+
+        Claims refreshedClaims = parseClaims(refreshed, keyPair.getPublic());
+        assertSoftly(softly -> {
+            softly.assertThat(first.equals(refreshed)).isFalse();
+            softly.assertThat(refreshedClaims.getIssuedAt()).isEqualTo(Date.from(refreshBoundary));
+            softly.assertThat(refreshedClaims.getExpiration())
+                    .isEqualTo(Date.from(refreshBoundary.plus(TOKEN_VALIDITY)));
+        });
+    }
+
+    @Test
+    void rejectsBlankPrivateKeyBase64() {
+        AppleOAuthProperties properties = appleProperties(" ");
+
+        AppleClientSecretGenerator generator = new AppleClientSecretGenerator(
+                properties,
+                Clock.fixed(NOW, ZoneId.of("UTC"))
+        );
+
+        assertThatThrownBy(generator::generateClientSecret)
+                .isInstanceOf(AppleClientSecretException.class)
+                .hasMessage("Apple private key base64 is required");
+    }
+
+    @Test
+    void rejectsInvalidPrivateKeyBase64() {
+        AppleOAuthProperties properties = appleProperties("not-base64 ####");
+
+        AppleClientSecretGenerator generator = new AppleClientSecretGenerator(
+                properties,
+                Clock.fixed(NOW, ZoneId.of("UTC"))
+        );
+
+        assertThatThrownBy(generator::generateClientSecret)
+                .isInstanceOf(AppleClientSecretException.class)
+                .hasMessage("Apple private key base64 is invalid");
+    }
+
+    @Test
+    void rejectsPrivateKeyBase64WithIgnoredInvalidCharacters() {
+        String encodedPem = Base64.getEncoder().encodeToString("not a pem".getBytes(StandardCharsets.UTF_8));
+        AppleOAuthProperties properties = appleProperties(encodedPem + "!!!!");
+
+        AppleClientSecretGenerator generator = new AppleClientSecretGenerator(
+                properties,
+                Clock.fixed(NOW, ZoneId.of("UTC"))
+        );
+
+        assertThatThrownBy(generator::generateClientSecret)
+                .isInstanceOf(AppleClientSecretException.class)
+                .hasMessage("Apple private key base64 is invalid");
+    }
+
+    @Test
+    void rejectsMalformedPrivateKeyPem() {
+        String encodedPem = Base64.getEncoder().encodeToString("not a pem".getBytes(StandardCharsets.UTF_8));
+        AppleOAuthProperties properties = appleProperties(encodedPem);
+
+        AppleClientSecretGenerator generator = new AppleClientSecretGenerator(
+                properties,
+                Clock.fixed(NOW, ZoneId.of("UTC"))
+        );
+
+        assertThatThrownBy(generator::generateClientSecret)
+                .isInstanceOf(AppleClientSecretException.class)
+                .hasMessage("Apple private key PEM is malformed");
+    }
+
+    @Test
+    void rejectsPrivateKeyPemWithExtraNonWhitespaceContent() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+        String pem = "unexpected prefix\n" + privateKeyPem(keyPair) + "\nunexpected suffix";
+        AppleOAuthProperties properties = appleProperties(encodeBase64(pem));
+
+        AppleClientSecretGenerator generator = new AppleClientSecretGenerator(
+                properties,
+                Clock.fixed(NOW, ZoneId.of("UTC"))
+        );
+
+        assertThatThrownBy(generator::generateClientSecret)
+                .isInstanceOf(AppleClientSecretException.class)
+                .hasMessage("Apple private key PEM is malformed");
+    }
+
+    @Test
+    void rejectsNonParseablePkcs8PrivateKey() {
+        String pem = beginMarker() + "\n"
+                + "bm90LWtleS1tYXRlcmlhbA==\n"
+                + endMarker() + "\n";
+        AppleOAuthProperties properties = appleProperties(encodeBase64(pem));
+
+        AppleClientSecretGenerator generator = new AppleClientSecretGenerator(
+                properties,
+                Clock.fixed(NOW, ZoneId.of("UTC"))
+        );
+
+        assertThatThrownBy(generator::generateClientSecret)
+                .isInstanceOf(AppleClientSecretException.class)
+                .hasMessage("Apple private key could not be parsed");
+    }
+
+    @Test
+    void instantiatesWithoutCheckmoJwtProperties() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+        AppleClientSecretGenerator generator = new AppleClientSecretGenerator(
+                appleProperties(keyPair),
+                Clock.fixed(NOW, ZoneId.of("UTC"))
+        );
+
+        String clientSecret = generator.generateClientSecret();
+
+        Claims claims = parseClaims(clientSecret, keyPair.getPublic());
+        assertSoftly(softly -> softly.assertThat(claims.getSubject()).isEqualTo(WEB_CLIENT_ID));
+    }
+
+    private AppleOAuthProperties appleProperties(KeyPair keyPair) {
+        return appleProperties(encodePemBase64(keyPair));
+    }
+
+    private AppleOAuthProperties appleProperties(String privateKeyBase64) {
+        AppleOAuthProperties properties = new AppleOAuthProperties();
+        properties.setTeamId(TEAM_ID);
+        properties.setKeyId(KEY_ID);
+        properties.setWebClientId(WEB_CLIENT_ID);
+        properties.setPrivateKeyBase64(privateKeyBase64);
+        return properties;
+    }
+
+    private KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec("secp256r1"));
+        return generator.generateKeyPair();
+    }
+
+    private String encodePemBase64(KeyPair keyPair) {
+        return encodeBase64(privateKeyPem(keyPair));
+    }
+
+    private String privateKeyPem(KeyPair keyPair) {
+        String keyBody = Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8))
+                .encodeToString(keyPair.getPrivate().getEncoded());
+        return beginMarker() + "\n" + keyBody + "\n" + endMarker() + "\n";
+    }
+
+    private String encodeBase64(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String beginMarker() {
+        return "-----BEGIN " + "PRIVATE KEY-----";
+    }
+
+    private String endMarker() {
+        return "-----END " + "PRIVATE KEY-----";
+    }
+
+    private Map<String, Object> decodeHeader(String clientSecret) throws Exception {
+        String header = new String(Base64.getUrlDecoder().decode(clientSecret.split("\\.")[0]), StandardCharsets.UTF_8);
+        return OBJECT_MAPPER.readValue(header, new TypeReference<>() {
+        });
+    }
+
+    private Claims parseClaims(String clientSecret, PublicKey publicKey) {
+        return Jwts.parser()
+                .verifyWith(publicKey)
+                .build()
+                .parseSignedClaims(clientSecret)
+                .getPayload();
+    }
+
+    private static class MutableClock extends Clock {
+
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        private void setInstant(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return Clock.fixed(instant, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/apple/AppleHttpJwksClientTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/apple/AppleHttpJwksClientTest.java
@@ -1,0 +1,200 @@
+package checkmo.authentication.internal.security.apple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import org.junit.jupiter.api.Test;
+
+class AppleHttpJwksClientTest {
+
+    @Test
+    void sendsJwksRequestWithTimeout() {
+        CapturingHttpClient httpClient = new CapturingHttpClient(
+                TestHttpResponse.ok("{\"keys\":[]}")
+        );
+        AppleHttpJwksClient jwksClient = new AppleHttpJwksClient(httpClient, new ObjectMapper());
+
+        AppleJwks jwks = jwksClient.fetch();
+
+        assertSoftly(softly -> {
+            softly.assertThat(jwks.keys()).isEmpty();
+            softly.assertThat(httpClient.requests()).hasSize(1);
+            softly.assertThat(httpClient.requests().getFirst().uri())
+                    .isEqualTo(URI.create("https://appleid.apple.com/auth/keys"));
+            softly.assertThat(httpClient.requests().getFirst().timeout())
+                    .contains(Duration.ofSeconds(3));
+        });
+    }
+
+    @Test
+    void retriesOnceAfterJwksIoFailure() {
+        CapturingHttpClient httpClient = new CapturingHttpClient(
+                new IOException("temporary failure"),
+                TestHttpResponse.ok("{\"keys\":[]}")
+        );
+        AppleHttpJwksClient jwksClient = new AppleHttpJwksClient(httpClient, new ObjectMapper());
+
+        AppleJwks jwks = jwksClient.fetch();
+
+        assertSoftly(softly -> {
+            softly.assertThat(jwks.keys()).isEmpty();
+            softly.assertThat(httpClient.requests()).hasSize(2);
+        });
+    }
+
+    private static class CapturingHttpClient extends HttpClient {
+
+        private final Queue<Object> responses = new ArrayDeque<>();
+        private final List<HttpRequest> requests = new ArrayList<>();
+
+        CapturingHttpClient(Object... responses) {
+            this.responses.addAll(List.of(responses));
+        }
+
+        List<HttpRequest> requests() {
+            return requests;
+        }
+
+        @Override
+        public Optional<CookieHandler> cookieHandler() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Duration> connectTimeout() {
+            return Optional.of(Duration.ofSeconds(3));
+        }
+
+        @Override
+        public Redirect followRedirects() {
+            return Redirect.NEVER;
+        }
+
+        @Override
+        public Optional<ProxySelector> proxy() {
+            return Optional.empty();
+        }
+
+        @Override
+        public SSLContext sslContext() {
+            try {
+                SSLContext context = SSLContext.getInstance("TLS");
+                context.init(null, null, new SecureRandom());
+                return context;
+            } catch (Exception e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Override
+        public SSLParameters sslParameters() {
+            return new SSLParameters();
+        }
+
+        @Override
+        public Optional<Authenticator> authenticator() {
+            return Optional.empty();
+        }
+
+        @Override
+        public HttpClient.Version version() {
+            return HttpClient.Version.HTTP_2;
+        }
+
+        @Override
+        public Optional<Executor> executor() {
+            return Optional.empty();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> HttpResponse<T> send(
+                HttpRequest request,
+                HttpResponse.BodyHandler<T> responseBodyHandler
+        ) throws IOException {
+            requests.add(request);
+            Object response = responses.remove();
+            if (response instanceof IOException exception) {
+                throw exception;
+            }
+            return (HttpResponse<T>) response;
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request,
+                HttpResponse.BodyHandler<T> responseBodyHandler
+        ) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request,
+                HttpResponse.BodyHandler<T> responseBodyHandler,
+                HttpResponse.PushPromiseHandler<T> pushPromiseHandler
+        ) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private record TestHttpResponse<T>(int statusCode, T body) implements HttpResponse<T> {
+
+        static TestHttpResponse<String> ok(String body) {
+            return new TestHttpResponse<>(200, body);
+        }
+
+        @Override
+        public HttpRequest request() {
+            return null;
+        }
+
+        @Override
+        public Optional<HttpResponse<T>> previousResponse() {
+            return Optional.empty();
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return HttpHeaders.of(Map.of(), (name, value) -> true);
+        }
+
+        @Override
+        public URI uri() {
+            return URI.create("https://appleid.apple.com/auth/keys");
+        }
+
+        @Override
+        public HttpClient.Version version() {
+            return HttpClient.Version.HTTP_2;
+        }
+
+        @Override
+        public Optional<SSLSession> sslSession() {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/apple/AppleIdTokenTestFixtures.java
+++ b/src/test/java/checkmo/authentication/internal/security/apple/AppleIdTokenTestFixtures.java
@@ -62,10 +62,16 @@ final class AppleIdTokenTestFixtures {
     }
 
     static AppleJwks jwks(String kid, KeyPair keyPair) {
+        return jwks(kid, keyPair, "RSA", "sig", "RS256");
+    }
+
+    static AppleJwks jwks(String kid, KeyPair keyPair, String keyType, String keyUse, String algorithm) {
         RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
         return new AppleJwks(List.of(new AppleJwk(
                 kid,
-                "RS256",
+                keyType,
+                keyUse,
+                algorithm,
                 base64UrlUnsigned(publicKey.getModulus()),
                 base64UrlUnsigned(publicKey.getPublicExponent())
         )));

--- a/src/test/java/checkmo/authentication/internal/security/apple/AppleIdTokenTestFixtures.java
+++ b/src/test/java/checkmo/authentication/internal/security/apple/AppleIdTokenTestFixtures.java
@@ -1,0 +1,169 @@
+package checkmo.authentication.internal.security.apple;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import checkmo.authentication.internal.config.properties.AppleOAuthProperties;
+import io.jsonwebtoken.Jwts;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayDeque;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Queue;
+
+final class AppleIdTokenTestFixtures {
+
+    static final String APPLE_ISSUER = "https://appleid.apple.com";
+    static final String WEB_CLIENT_ID = "kr.co.checkmo.web";
+    static final String IOS_CLIENT_ID = "kr.co.checkmo.app";
+    static final String SUBJECT = "001234.abcdef";
+    static final String KEY_ID = "apple-key-1";
+    static final String SECOND_KEY_ID = "apple-key-2";
+    static final Instant NOW = Instant.parse("2026-06-24T00:00:00Z");
+
+    private AppleIdTokenTestFixtures() {
+    }
+
+    static AppleIdTokenVerifier verifier(AppleJwks jwks) {
+        return verifier(new FakeAppleJwksClient(jwks), Clock.fixed(NOW, ZoneId.of("UTC")));
+    }
+
+    static AppleIdTokenVerifier verifier(AppleJwksClient client) {
+        return verifier(client, Clock.fixed(NOW, ZoneId.of("UTC")));
+    }
+
+    static AppleIdTokenVerifier verifier(AppleJwksClient client, Clock clock) {
+        return new AppleIdTokenVerifier(client, appleProperties(), clock);
+    }
+
+    static io.jsonwebtoken.JwtBuilder token(String kid, KeyPair keyPair, String audience) {
+        return Jwts.builder()
+                .header()
+                .keyId(kid)
+                .and()
+                .issuer(APPLE_ISSUER)
+                .subject(SUBJECT)
+                .audience()
+                .add(audience)
+                .and()
+                .issuedAt(Date.from(NOW.minusSeconds(60)))
+                .expiration(Date.from(NOW.plusSeconds(300)))
+                .signWith(keyPair.getPrivate(), Jwts.SIG.RS256);
+    }
+
+    static AppleJwks jwks(KeyPair keyPair) {
+        return jwks(KEY_ID, keyPair);
+    }
+
+    static AppleJwks jwks(String kid, KeyPair keyPair) {
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+        return new AppleJwks(List.of(new AppleJwk(
+                kid,
+                "RS256",
+                base64UrlUnsigned(publicKey.getModulus()),
+                base64UrlUnsigned(publicKey.getPublicExponent())
+        )));
+    }
+
+    static KeyPair rsaKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return generator.generateKeyPair();
+    }
+
+    static void assertInvalidToken(ThrowingCallable callable) {
+        assertThatThrownBy(callable::call)
+                .isInstanceOf(InvalidAppleIdentityTokenException.class)
+                .hasMessage("Invalid Apple identity token");
+    }
+
+    private static AppleOAuthProperties appleProperties() {
+        AppleOAuthProperties properties = new AppleOAuthProperties();
+        properties.setWebClientId(WEB_CLIENT_ID);
+        properties.setIosClientId(IOS_CLIENT_ID);
+        return properties;
+    }
+
+    private static String base64UrlUnsigned(BigInteger value) {
+        byte[] bytes = value.toByteArray();
+        if (bytes.length > 1 && bytes[0] == 0) {
+            byte[] unsigned = new byte[bytes.length - 1];
+            System.arraycopy(bytes, 1, unsigned, 0, unsigned.length);
+            bytes = unsigned;
+        }
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    @FunctionalInterface
+    interface ThrowingCallable {
+        void call() throws Exception;
+    }
+
+    static class FakeAppleJwksClient implements AppleJwksClient {
+
+        private final Queue<AppleJwks> responses = new ArrayDeque<>();
+        private AppleJwks lastResponse;
+        private int fetchCount;
+
+        FakeAppleJwksClient(AppleJwks... responses) {
+            this.responses.addAll(List.of(responses));
+        }
+
+        @Override
+        public AppleJwks fetch() {
+            fetchCount++;
+            AppleJwks response = responses.poll();
+            if (response != null) {
+                lastResponse = response;
+                return response;
+            }
+            return lastResponse;
+        }
+
+        int fetchCount() {
+            return fetchCount;
+        }
+    }
+
+    static class FailingAppleJwksClient implements AppleJwksClient {
+
+        @Override
+        public AppleJwks fetch() {
+            throw new RuntimeException("JWKS unavailable");
+        }
+    }
+
+    static class MutableClock extends Clock {
+
+        private Instant instant;
+
+        MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        void setInstant(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return Clock.fixed(instant, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifierTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifierTest.java
@@ -88,6 +88,24 @@ class AppleIdTokenVerifierTest {
     }
 
     @Test
+    void rejectsJwksKeyWithWrongKeyType() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(KEY_ID, keyPair, "EC", "sig", "RS256"));
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID).compact();
+
+        assertInvalidToken(() -> verifier.verifyWebToken(token));
+    }
+
+    @Test
+    void rejectsJwksKeyWithoutSignatureUse() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(KEY_ID, keyPair, "RSA", "enc", "RS256"));
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID).compact();
+
+        assertInvalidToken(() -> verifier.verifyWebToken(token));
+    }
+
+    @Test
     void refreshesOnceForUnknownKidAndSucceedsWhenRefreshedJwksContainsKey() throws Exception {
         KeyPair keyPair = rsaKeyPair();
         FakeAppleJwksClient client = new FakeAppleJwksClient(

--- a/src/test/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifierTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifierTest.java
@@ -1,0 +1,255 @@
+package checkmo.authentication.internal.security.apple;
+
+import static checkmo.authentication.internal.security.apple.AppleIdTokenTestFixtures.*;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.security.KeyPair;
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AppleIdTokenVerifierTest {
+
+    @Test
+    void verifiesWebTokenAndReturnsAppleIdentity() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID)
+                .claim("email", "user@example.com")
+                .claim("email_verified", "true")
+                .compact();
+
+        AppleIdentity identity = verifier.verifyWebToken(token);
+
+        assertSoftly(softly -> {
+            softly.assertThat(identity.subject()).isEqualTo(SUBJECT);
+            softly.assertThat(identity.providerId()).isEqualTo("APPLE_" + SUBJECT);
+            softly.assertThat(identity.email()).isEqualTo("user@example.com");
+            softly.assertThat(identity.emailVerified()).isTrue();
+            softly.assertThat(identity.privateEmail()).isFalse();
+            softly.assertThat(identity.audience()).isEqualTo(WEB_CLIENT_ID);
+        });
+    }
+
+    @Test
+    void verifiesIosTokenWithMatchingNonce() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String rawNonce = "mobile-nonce";
+        String token = token(KEY_ID, keyPair, IOS_CLIENT_ID)
+                .claim("nonce", "5c224040fc94d672b643b5253b957ec929c56e983093788cb44b4c100ae3b97a")
+                .compact();
+
+        AppleIdentity identity = verifier.verifyIosToken(token, rawNonce);
+
+        assertSoftly(softly -> softly.assertThat(identity.audience()).isEqualTo(IOS_CLIENT_ID));
+    }
+
+    @Test
+    void rejectsInvalidAudience() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, "unexpected-client").compact();
+
+        assertInvalidToken(() -> verifier.verifyWebToken(token));
+    }
+
+    @Test
+    void rejectsInvalidIssuer() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID)
+                .issuer("https://example.com")
+                .compact();
+
+        assertInvalidToken(() -> verifier.verifyWebToken(token));
+    }
+
+    @Test
+    void rejectsExpiredToken() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID)
+                .expiration(Date.from(NOW.minusSeconds(1)))
+                .compact();
+
+        assertInvalidToken(() -> verifier.verifyWebToken(token));
+    }
+
+    @Test
+    void rejectsWrongSignature() throws Exception {
+        KeyPair jwksKeyPair = rsaKeyPair();
+        KeyPair signingKeyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(jwksKeyPair));
+        String token = token(KEY_ID, signingKeyPair, WEB_CLIENT_ID).compact();
+
+        assertInvalidToken(() -> verifier.verifyWebToken(token));
+    }
+
+    @Test
+    void refreshesOnceForUnknownKidAndSucceedsWhenRefreshedJwksContainsKey() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        FakeAppleJwksClient client = new FakeAppleJwksClient(
+                new AppleJwks(List.of()),
+                jwks(keyPair)
+        );
+        AppleIdTokenVerifier verifier = verifier(client);
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID).compact();
+
+        AppleIdentity identity = verifier.verifyWebToken(token);
+
+        assertSoftly(softly -> {
+            softly.assertThat(identity.subject()).isEqualTo(SUBJECT);
+            softly.assertThat(client.fetchCount()).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void refreshesOnceForUnknownKidAndFailsClosedWhenKeyStillMissing() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        FakeAppleJwksClient client = new FakeAppleJwksClient(
+                new AppleJwks(List.of()),
+                new AppleJwks(List.of())
+        );
+        AppleIdTokenVerifier verifier = verifier(client);
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID).compact();
+
+        assertInvalidToken(() -> verifier.verifyWebToken(token));
+        assertSoftly(softly -> softly.assertThat(client.fetchCount()).isEqualTo(2));
+    }
+
+    @Test
+    void rejectsMissingSubject() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID)
+                .subject("")
+                .compact();
+
+        assertInvalidToken(() -> verifier.verifyWebToken(token));
+    }
+
+    @Test
+    void acceptsMissingEmail() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID).compact();
+
+        AppleIdentity identity = verifier.verifyWebToken(token);
+
+        assertSoftly(softly -> {
+            softly.assertThat(identity.email()).isNull();
+            softly.assertThat(identity.emailVerified()).isFalse();
+        });
+    }
+
+    @Test
+    void rejectsNonceMismatch() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, IOS_CLIENT_ID)
+                .claim("nonce", "59bcb2470d7a22b8a9f227d96aaf80645e61d5055aa187c1374ed78333d10765")
+                .compact();
+
+        assertInvalidToken(() -> verifier.verifyIosToken(token, "mobile-nonce"));
+    }
+
+    @Test
+    void rejectsIosTokenWhenRawNonceIsNull() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, IOS_CLIENT_ID)
+                .claim("nonce", "5c224040fc94d672b643b5253b957ec929c56e983093788cb44b4c100ae3b97a")
+                .compact();
+
+        assertInvalidToken(() -> verifier.verifyIosToken(token, null));
+    }
+
+    @Test
+    void rejectsIosTokenWhenRawNonceIsBlank() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, IOS_CLIENT_ID)
+                .claim("nonce", "5c224040fc94d672b643b5253b957ec929c56e983093788cb44b4c100ae3b97a")
+                .compact();
+
+        assertInvalidToken(() -> verifier.verifyIosToken(token, "   "));
+    }
+
+    @Test
+    void rejectsIosTokenWhenTokenNonceIsMissing() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, IOS_CLIENT_ID).compact();
+
+        assertInvalidToken(() -> verifier.verifyIosToken(token, "mobile-nonce"));
+    }
+
+    @Test
+    void rejectsJwksClientError() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(new FailingAppleJwksClient());
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID).compact();
+
+        assertInvalidToken(() -> verifier.verifyWebToken(token));
+    }
+
+    @Test
+    void usesCachedKeyUntilCacheExpiresThenRefreshesAfterSixHours() throws Exception {
+        KeyPair firstKeyPair = rsaKeyPair();
+        KeyPair secondKeyPair = rsaKeyPair();
+        MutableClock clock = new MutableClock(NOW);
+        FakeAppleJwksClient client = new FakeAppleJwksClient(
+                jwks(KEY_ID, firstKeyPair),
+                jwks(SECOND_KEY_ID, secondKeyPair)
+        );
+        AppleIdTokenVerifier verifier = verifier(client, clock);
+        String firstToken = token(KEY_ID, firstKeyPair, WEB_CLIENT_ID)
+                .expiration(Date.from(NOW.plus(Duration.ofHours(7))))
+                .compact();
+        String secondToken = token(SECOND_KEY_ID, secondKeyPair, WEB_CLIENT_ID)
+                .issuedAt(Date.from(NOW.plus(Duration.ofHours(6))))
+                .expiration(Date.from(NOW.plus(Duration.ofHours(6)).plusSeconds(300)))
+                .compact();
+
+        verifier.verifyWebToken(firstToken);
+        clock.setInstant(NOW.plus(Duration.ofHours(6)).minusSeconds(1));
+        verifier.verifyWebToken(firstToken);
+        clock.setInstant(NOW.plus(Duration.ofHours(6)));
+        AppleIdentity refreshedIdentity = verifier.verifyWebToken(secondToken);
+
+        assertSoftly(softly -> {
+            softly.assertThat(refreshedIdentity.subject()).isEqualTo(SUBJECT);
+            softly.assertThat(client.fetchCount()).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void mapsPrivateRelayEmailToPrivateEmail() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID)
+                .claim("email", "abc@privaterelay.appleid.com")
+                .compact();
+
+        AppleIdentity identity = verifier.verifyWebToken(token);
+
+        assertSoftly(softly -> softly.assertThat(identity.privateEmail()).isTrue());
+    }
+
+    @Test
+    void mapsApplePrivateEmailClaimToPrivateEmail() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID)
+                .claim("email", "user@example.com")
+                .claim("is_private_email", "true")
+                .compact();
+
+        AppleIdentity identity = verifier.verifyWebToken(token);
+
+        assertSoftly(softly -> softly.assertThat(identity.privateEmail()).isTrue());
+    }
+
+}

--- a/src/test/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifierTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/apple/AppleIdTokenVerifierTest.java
@@ -7,6 +7,7 @@ import java.security.KeyPair;
 import java.time.Duration;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 class AppleIdTokenVerifierTest {
@@ -71,10 +72,23 @@ class AppleIdTokenVerifierTest {
         KeyPair keyPair = rsaKeyPair();
         AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
         String token = token(KEY_ID, keyPair, WEB_CLIENT_ID)
-                .expiration(Date.from(NOW.minusSeconds(1)))
+                .expiration(Date.from(NOW.minusSeconds(61)))
                 .compact();
 
         assertInvalidToken(() -> verifier.verifyWebToken(token));
+    }
+
+    @Test
+    void acceptsRecentlyExpiredTokenWithinClockSkew() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleIdTokenVerifier verifier = verifier(jwks(keyPair));
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID)
+                .expiration(Date.from(NOW.minusSeconds(1)))
+                .compact();
+
+        AppleIdentity identity = verifier.verifyWebToken(token);
+
+        assertSoftly(softly -> softly.assertThat(identity.subject()).isEqualTo(SUBJECT));
     }
 
     @Test
@@ -106,35 +120,75 @@ class AppleIdTokenVerifierTest {
     }
 
     @Test
-    void refreshesOnceForUnknownKidAndSucceedsWhenRefreshedJwksContainsKey() throws Exception {
+    void refreshesOnlyOnceForUnknownKidWhenRefreshedJwksDoesNotContainKey() throws Exception {
         KeyPair keyPair = rsaKeyPair();
         FakeAppleJwksClient client = new FakeAppleJwksClient(
-                new AppleJwks(List.of()),
-                jwks(keyPair)
-        );
-        AppleIdTokenVerifier verifier = verifier(client);
-        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID).compact();
-
-        AppleIdentity identity = verifier.verifyWebToken(token);
-
-        assertSoftly(softly -> {
-            softly.assertThat(identity.subject()).isEqualTo(SUBJECT);
-            softly.assertThat(client.fetchCount()).isEqualTo(2);
-        });
-    }
-
-    @Test
-    void refreshesOnceForUnknownKidAndFailsClosedWhenKeyStillMissing() throws Exception {
-        KeyPair keyPair = rsaKeyPair();
-        FakeAppleJwksClient client = new FakeAppleJwksClient(
-                new AppleJwks(List.of()),
                 new AppleJwks(List.of())
         );
         AppleIdTokenVerifier verifier = verifier(client);
         String token = token(KEY_ID, keyPair, WEB_CLIENT_ID).compact();
 
         assertInvalidToken(() -> verifier.verifyWebToken(token));
-        assertSoftly(softly -> softly.assertThat(client.fetchCount()).isEqualTo(2));
+        assertSoftly(softly -> softly.assertThat(client.fetchCount()).isEqualTo(1));
+    }
+
+    @Test
+    void refreshesOnceForUnknownKidAndFailsClosedWhenKeyStillMissing() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        FakeAppleJwksClient client = new FakeAppleJwksClient(
+                new AppleJwks(List.of())
+        );
+        AppleIdTokenVerifier verifier = verifier(client);
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID).compact();
+
+        assertInvalidToken(() -> verifier.verifyWebToken(token));
+        assertSoftly(softly -> softly.assertThat(client.fetchCount()).isEqualTo(1));
+    }
+
+    @Test
+    void keepsServingCachedKeyWhenRefreshFailsAfterCacheExpires() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        MutableClock clock = new MutableClock(NOW);
+        AtomicInteger fetchCount = new AtomicInteger();
+        AppleJwksClient client = () -> {
+            if (fetchCount.incrementAndGet() == 1) {
+                return jwks(keyPair);
+            }
+            throw new RuntimeException("JWKS unavailable");
+        };
+        AppleIdTokenVerifier verifier = verifier(client, clock);
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID)
+                .expiration(Date.from(NOW.plus(Duration.ofHours(7))))
+                .compact();
+
+        verifier.verifyWebToken(token);
+        clock.setInstant(NOW.plus(Duration.ofHours(6)));
+        AppleIdentity identity = verifier.verifyWebToken(token);
+
+        assertSoftly(softly -> {
+            softly.assertThat(identity.subject()).isEqualTo(SUBJECT);
+            softly.assertThat(fetchCount.get()).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void skipsMalformedJwksKeyAndUsesOtherValidKey() throws Exception {
+        KeyPair keyPair = rsaKeyPair();
+        AppleJwk malformedKey = new AppleJwk(
+                "malformed-key",
+                "RSA",
+                "sig",
+                "RS256",
+                "not-base64",
+                "not-base64"
+        );
+        AppleJwks jwks = new AppleJwks(List.of(malformedKey, jwks(keyPair).keys().getFirst()));
+        AppleIdTokenVerifier verifier = verifier(jwks);
+        String token = token(KEY_ID, keyPair, WEB_CLIENT_ID).compact();
+
+        AppleIdentity identity = verifier.verifyWebToken(token);
+
+        assertSoftly(softly -> softly.assertThat(identity.subject()).isEqualTo(SUBJECT));
     }
 
     @Test

--- a/src/test/java/checkmo/authentication/internal/security/apple/AppleIdentityTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/apple/AppleIdentityTest.java
@@ -1,0 +1,51 @@
+package checkmo.authentication.internal.security.apple;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AppleIdentityTest {
+
+    @Test
+    void convertsToOAuth2Attributes() {
+        AppleIdentity identity = new AppleIdentity(
+                "apple-sub",
+                "APPLE_apple-sub",
+                "user@example.com",
+                true,
+                false,
+                "kr.co.checkmo.web"
+        );
+
+        Map<String, Object> attributes = identity.toOAuth2Attributes();
+
+        assertSoftly(softly -> {
+            softly.assertThat(attributes.get("sub")).isEqualTo("apple-sub");
+            softly.assertThat(attributes.get("email")).isEqualTo("user@example.com");
+            softly.assertThat(attributes.get("email_verified")).isEqualTo(true);
+            softly.assertThat(attributes.get("is_private_email")).isEqualTo(false);
+        });
+    }
+
+    @Test
+    void omitsEmailWhenEmailIsBlank() {
+        AppleIdentity identity = new AppleIdentity(
+                "apple-sub",
+                "APPLE_apple-sub",
+                "   ",
+                false,
+                true,
+                "kr.co.checkmo.web"
+        );
+
+        Map<String, Object> attributes = identity.toOAuth2Attributes();
+
+        assertSoftly(softly -> {
+            softly.assertThat(attributes).doesNotContainKey("email");
+            softly.assertThat(attributes.get("sub")).isEqualTo("apple-sub");
+            softly.assertThat(attributes.get("email_verified")).isEqualTo(false);
+            softly.assertThat(attributes.get("is_private_email")).isEqualTo(true);
+        });
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/apple/AppleIdentityTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/apple/AppleIdentityTest.java
@@ -48,4 +48,25 @@ class AppleIdentityTest {
             softly.assertThat(attributes.get("is_private_email")).isEqualTo(true);
         });
     }
+
+    @Test
+    void omitsEmailWhenEmailIsNull() {
+        AppleIdentity identity = new AppleIdentity(
+                "apple-sub",
+                "APPLE_apple-sub",
+                null,
+                false,
+                true,
+                "kr.co.checkmo.web"
+        );
+
+        Map<String, Object> attributes = identity.toOAuth2Attributes();
+
+        assertSoftly(softly -> {
+            softly.assertThat(attributes).doesNotContainKey("email");
+            softly.assertThat(attributes.get("sub")).isEqualTo("apple-sub");
+            softly.assertThat(attributes.get("email_verified")).isEqualTo(false);
+            softly.assertThat(attributes.get("is_private_email")).isEqualTo(true);
+        });
+    }
 }

--- a/src/test/java/checkmo/authentication/internal/security/jwt/TokenCacheServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/jwt/TokenCacheServiceTest.java
@@ -1,6 +1,7 @@
 package checkmo.authentication.internal.security.jwt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -232,6 +233,107 @@ class TokenCacheServiceTest {
         });
 
         tokenCacheService.saveRefreshToken("member-1", "refresh-token");
+    }
+
+    @Test
+    void saveOAuthExchangeCodeUsesRawStringValueWithTwoMinuteTtl() {
+        tokenCacheService = tokenCacheServiceWithRefreshTtl(5_678L);
+
+        when(redisTemplate.execute(any(RedisCallback.class))).thenAnswer(invocation -> {
+            RedisCallback<?> callback = invocation.getArgument(0);
+            RedisConnection connection = mock(RedisConnection.class);
+            RedisStringCommands stringCommands = mock(RedisStringCommands.class, setInvocation -> {
+                if ("set".equals(setInvocation.getMethod().getName())) {
+                    return true;
+                }
+                return org.mockito.Mockito.RETURNS_DEFAULTS.answer(setInvocation);
+            });
+            when(connection.stringCommands()).thenReturn(stringCommands);
+
+            Object result = callback.doInRedis(connection);
+
+            ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);
+            ArgumentCaptor<byte[]> valueCaptor = ArgumentCaptor.forClass(byte[].class);
+            ArgumentCaptor<Expiration> expirationCaptor = ArgumentCaptor.forClass(Expiration.class);
+            verify(stringCommands).set(
+                    keyCaptor.capture(),
+                    valueCaptor.capture(),
+                    expirationCaptor.capture(),
+                    org.mockito.ArgumentMatchers.eq(RedisStringCommands.SetOption.upsert())
+            );
+            assertSoftly(softly -> {
+                softly.assertThat(new String(keyCaptor.getValue(), StandardCharsets.UTF_8))
+                        .isEqualTo("oauthCode::exchange-code");
+                softly.assertThat(new String(valueCaptor.getValue(), StandardCharsets.UTF_8))
+                        .isEqualTo("true|refresh-token");
+                softly.assertThat(expirationCaptor.getValue().getExpirationTimeInMilliseconds())
+                        .isEqualTo(120_000L);
+            });
+            return result;
+        });
+
+        tokenCacheService.saveOAuthExchangeCode("exchange-code", "true|refresh-token");
+    }
+
+    @Test
+    void consumeOAuthExchangeCodeUsesLuaAndReturnsRawValue() {
+        tokenCacheService = tokenCacheServiceWithRefreshTtl(5_678L);
+
+        when(redisTemplate.execute(any(RedisCallback.class))).thenAnswer(invocation -> {
+            RedisCallback<?> callback = invocation.getArgument(0);
+            RedisConnection connection = mock(RedisConnection.class);
+            RedisScriptingCommands scriptingCommands = mock(RedisScriptingCommands.class, evalInvocation -> {
+                if ("eval".equals(evalInvocation.getMethod().getName())) {
+                    return "true|refresh-token".getBytes(StandardCharsets.UTF_8);
+                }
+                return org.mockito.Mockito.RETURNS_DEFAULTS.answer(evalInvocation);
+            });
+            when(connection.scriptingCommands()).thenReturn(scriptingCommands);
+
+            Object result = callback.doInRedis(connection);
+
+            ArgumentCaptor<byte[][]> keysAndArgsCaptor = ArgumentCaptor.forClass(byte[][].class);
+            verify(scriptingCommands).eval(
+                    any(byte[].class),
+                    org.mockito.ArgumentMatchers.eq(ReturnType.VALUE),
+                    org.mockito.ArgumentMatchers.eq(1),
+                    keysAndArgsCaptor.capture()
+            );
+            assertSoftly(softly -> {
+                softly.assertThat(new String(keysAndArgsCaptor.getValue()[0], StandardCharsets.UTF_8))
+                        .isEqualTo("oauthCode::exchange-code");
+                softly.assertThat(new String((byte[]) result, StandardCharsets.UTF_8))
+                        .isEqualTo("true|refresh-token");
+            });
+            return result;
+        });
+
+        String value = tokenCacheService.consumeOAuthExchangeCode("exchange-code");
+
+        assertThat(value).isEqualTo("true|refresh-token");
+    }
+
+    @Test
+    void consumeOAuthExchangeCodeReturnsNullWhenCodeDoesNotExist() {
+        tokenCacheService = tokenCacheServiceWithRefreshTtl(5_678L);
+
+        when(redisTemplate.execute(any(RedisCallback.class))).thenAnswer(invocation -> {
+            RedisCallback<?> callback = invocation.getArgument(0);
+            RedisConnection connection = mock(RedisConnection.class);
+            RedisScriptingCommands scriptingCommands = mock(RedisScriptingCommands.class, evalInvocation -> {
+                if ("eval".equals(evalInvocation.getMethod().getName())) {
+                    return null;
+                }
+                return org.mockito.Mockito.RETURNS_DEFAULTS.answer(evalInvocation);
+            });
+            when(connection.scriptingCommands()).thenReturn(scriptingCommands);
+
+            return callback.doInRedis(connection);
+        });
+
+        String value = tokenCacheService.consumeOAuthExchangeCode("missing-code");
+
+        assertThat(value).isNull();
     }
 
     private TokenCacheService tokenCacheServiceWithRefreshTtl(long refreshTtlMs) {

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/AppleClientSecretTokenRequestParametersConverterTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/AppleClientSecretTokenRequestParametersConverterTest.java
@@ -32,8 +32,8 @@ class AppleClientSecretTokenRequestParametersConverterTest {
 
         assertSoftly(softly -> {
             softly.assertThat(parameters.getFirst(OAuth2ParameterNames.CLIENT_ID)).isEqualTo("kr.co.checkmo.web");
-            softly.assertThat(parameters.getFirst(OAuth2ParameterNames.CLIENT_SECRET))
-                    .isEqualTo("generated-apple-client-secret");
+            softly.assertThat(parameters.get(OAuth2ParameterNames.CLIENT_SECRET))
+                    .containsExactly("generated-apple-client-secret");
             softly.assertThat(parameters.getFirst(OAuth2ParameterNames.CODE)).isEqualTo("authorization-code");
         });
         verify(generator).generateClientSecret();

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/AppleClientSecretTokenRequestParametersConverterTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/AppleClientSecretTokenRequestParametersConverterTest.java
@@ -1,0 +1,103 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import checkmo.authentication.internal.security.apple.AppleClientSecretGenerator;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.util.MultiValueMap;
+
+class AppleClientSecretTokenRequestParametersConverterTest {
+
+    @Test
+    void replacesAppleClientSecretWithGeneratedValue() {
+        AppleClientSecretGenerator generator = mock(AppleClientSecretGenerator.class);
+        AppleClientSecretTokenRequestParametersConverter converter =
+                new AppleClientSecretTokenRequestParametersConverter(generator);
+        when(generator.generateClientSecret()).thenReturn("generated-apple-client-secret");
+
+        MultiValueMap<String, String> parameters = converter.convert(grantRequest(appleRegistration()));
+
+        assertSoftly(softly -> {
+            softly.assertThat(parameters.getFirst(OAuth2ParameterNames.CLIENT_ID)).isEqualTo("kr.co.checkmo.web");
+            softly.assertThat(parameters.getFirst(OAuth2ParameterNames.CLIENT_SECRET))
+                    .isEqualTo("generated-apple-client-secret");
+            softly.assertThat(parameters.getFirst(OAuth2ParameterNames.CODE)).isEqualTo("authorization-code");
+        });
+        verify(generator).generateClientSecret();
+    }
+
+    @Test
+    void keepsDefaultClientSecretForNonAppleRegistration() {
+        AppleClientSecretGenerator generator = mock(AppleClientSecretGenerator.class);
+        AppleClientSecretTokenRequestParametersConverter converter =
+                new AppleClientSecretTokenRequestParametersConverter(generator);
+
+        MultiValueMap<String, String> parameters = converter.convert(grantRequest(googleRegistration()));
+
+        assertSoftly(softly -> {
+            softly.assertThat(parameters.getFirst(OAuth2ParameterNames.CLIENT_ID)).isEqualTo("google-client-id");
+            softly.assertThat(parameters.getFirst(OAuth2ParameterNames.CLIENT_SECRET))
+                    .isEqualTo("google-client-secret");
+        });
+        verify(generator, never()).generateClientSecret();
+    }
+
+    private OAuth2AuthorizationCodeGrantRequest grantRequest(ClientRegistration clientRegistration) {
+        OAuth2AuthorizationRequest authorizationRequest = OAuth2AuthorizationRequest.authorizationCode()
+                .authorizationUri(clientRegistration.getProviderDetails().getAuthorizationUri())
+                .clientId(clientRegistration.getClientId())
+                .redirectUri(clientRegistration.getRedirectUri())
+                .state("state")
+                .attributes(Map.of(OAuth2ParameterNames.REGISTRATION_ID, clientRegistration.getRegistrationId()))
+                .build();
+        OAuth2AuthorizationResponse authorizationResponse = OAuth2AuthorizationResponse.success("authorization-code")
+                .redirectUri(clientRegistration.getRedirectUri())
+                .state("state")
+                .build();
+        return new OAuth2AuthorizationCodeGrantRequest(
+                clientRegistration,
+                new OAuth2AuthorizationExchange(authorizationRequest, authorizationResponse)
+        );
+    }
+
+    private ClientRegistration appleRegistration() {
+        return ClientRegistration.withRegistrationId("apple")
+                .clientId("kr.co.checkmo.web")
+                .clientSecret("placeholder")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("https://api.checkmo.co.kr/login/oauth2/code/apple")
+                .authorizationUri("https://appleid.apple.com/auth/authorize")
+                .tokenUri("https://appleid.apple.com/auth/token")
+                .scope("openid", "email", "name")
+                .clientName("Apple")
+                .build();
+    }
+
+    private ClientRegistration googleRegistration() {
+        return ClientRegistration.withRegistrationId("google")
+                .clientId("google-client-id")
+                .clientSecret("google-client-secret")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("https://api.checkmo.co.kr/login/oauth2/code/google")
+                .authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
+                .tokenUri("https://oauth2.googleapis.com/token")
+                .scope("email", "profile")
+                .clientName("Google")
+                .build();
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolverTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolverTest.java
@@ -1,0 +1,80 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+class AppleOAuth2AuthorizationRequestResolverTest {
+
+    @Test
+    void addsFormPostResponseModeForAppleAuthorizationRequest() {
+        AppleOAuth2AuthorizationRequestResolver resolver = new AppleOAuth2AuthorizationRequestResolver(
+                new InMemoryClientRegistrationRepository(appleRegistration())
+        );
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/apple");
+        request.setServerName("api.checkmo.co.kr");
+        request.setScheme("https");
+        request.setServerPort(443);
+
+        OAuth2AuthorizationRequest authorizationRequest = resolver.resolve(request);
+
+        assertSoftly(softly -> {
+            softly.assertThat(authorizationRequest.getAdditionalParameters())
+                    .containsEntry("response_mode", "form_post");
+            softly.assertThat(authorizationRequest.getAuthorizationRequestUri())
+                    .contains("response_mode=form_post")
+                    .contains("client_id=kr.co.checkmo.web");
+        });
+    }
+
+    @Test
+    void keepsDefaultParametersForNonAppleAuthorizationRequest() {
+        AppleOAuth2AuthorizationRequestResolver resolver = new AppleOAuth2AuthorizationRequestResolver(
+                new InMemoryClientRegistrationRepository(googleRegistration())
+        );
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/google");
+
+        OAuth2AuthorizationRequest authorizationRequest = resolver.resolve(request);
+
+        assertSoftly(softly -> {
+            softly.assertThat(authorizationRequest.getAdditionalParameters()).doesNotContainKey("response_mode");
+            softly.assertThat(authorizationRequest.getAuthorizationRequestUri()).doesNotContain("response_mode");
+        });
+    }
+
+    private ClientRegistration appleRegistration() {
+        return ClientRegistration.withRegistrationId("apple")
+                .clientId("kr.co.checkmo.web")
+                .clientSecret("placeholder")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("https://api.checkmo.co.kr/login/oauth2/code/apple")
+                .authorizationUri("https://appleid.apple.com/auth/authorize")
+                .tokenUri("https://appleid.apple.com/auth/token")
+                .scope("openid", "email", "name")
+                .clientName("Apple")
+                .build();
+    }
+
+    private ClientRegistration googleRegistration() {
+        return ClientRegistration.withRegistrationId("google")
+                .clientId("google-client-id")
+                .clientSecret("google-client-secret")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("https://api.checkmo.co.kr/login/oauth2/code/google")
+                .authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
+                .tokenUri("https://oauth2.googleapis.com/token")
+                .userInfoUri("https://www.googleapis.com/oauth2/v3/userinfo")
+                .userNameAttributeName("sub")
+                .scope("email", "profile")
+                .clientName("Google")
+                .build();
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolverTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolverTest.java
@@ -53,7 +53,8 @@ class AppleOAuth2AuthorizationRequestResolverTest {
                     .contains("response_mode=form_post")
                     .contains("client_id=kr.co.checkmo.web");
             softly.assertThat(request.getSession().getAttribute(
-                            AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE))
+                            AppleOAuth2AuthorizationRequestResolver.sessionClientTypeKey(
+                                    authorizationRequest.getState())))
                     .isEqualTo(AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP);
         });
     }
@@ -72,19 +73,20 @@ class AppleOAuth2AuthorizationRequestResolverTest {
             softly.assertThat(authorizationRequest.getAdditionalParameters()).doesNotContainKey("response_mode");
             softly.assertThat(authorizationRequest.getAuthorizationRequestUri()).doesNotContain("response_mode");
             softly.assertThat(request.getSession().getAttribute(
-                            AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE))
+                            AppleOAuth2AuthorizationRequestResolver.sessionClientTypeKey(
+                                    authorizationRequest.getState())))
                     .isEqualTo(AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP);
         });
     }
 
     @Test
-    void clearsStaleAppClientTypeForWebAuthorizationRequest() {
+    void doesNotClearOtherStateAppClientTypeForWebAuthorizationRequest() {
         AppleOAuth2AuthorizationRequestResolver resolver = new AppleOAuth2AuthorizationRequestResolver(
                 new InMemoryClientRegistrationRepository(googleRegistration())
         );
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/google");
         request.getSession().setAttribute(
-                AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE,
+                AppleOAuth2AuthorizationRequestResolver.sessionClientTypeKey("other-state"),
                 AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP
         );
 
@@ -93,7 +95,11 @@ class AppleOAuth2AuthorizationRequestResolverTest {
         assertSoftly(softly -> {
             softly.assertThat(authorizationRequest.getAuthorizationRequestUri()).doesNotContain("response_mode");
             softly.assertThat(request.getSession().getAttribute(
-                    AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE)).isNull();
+                            AppleOAuth2AuthorizationRequestResolver.sessionClientTypeKey("other-state")))
+                    .isEqualTo(AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP);
+            softly.assertThat(request.getSession().getAttribute(
+                    AppleOAuth2AuthorizationRequestResolver.sessionClientTypeKey(
+                            authorizationRequest.getState()))).isNull();
         });
     }
 

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolverTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2AuthorizationRequestResolverTest.java
@@ -34,6 +34,70 @@ class AppleOAuth2AuthorizationRequestResolverTest {
     }
 
     @Test
+    void storesAppClientTypeAndKeepsFormPostForAppleAppAuthorizationRequest() {
+        AppleOAuth2AuthorizationRequestResolver resolver = new AppleOAuth2AuthorizationRequestResolver(
+                new InMemoryClientRegistrationRepository(appleRegistration())
+        );
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/apple");
+        request.setParameter("client", "app");
+        request.setServerName("api.checkmo.co.kr");
+        request.setScheme("https");
+        request.setServerPort(443);
+
+        OAuth2AuthorizationRequest authorizationRequest = resolver.resolve(request);
+
+        assertSoftly(softly -> {
+            softly.assertThat(authorizationRequest.getAdditionalParameters())
+                    .containsEntry("response_mode", "form_post");
+            softly.assertThat(authorizationRequest.getAuthorizationRequestUri())
+                    .contains("response_mode=form_post")
+                    .contains("client_id=kr.co.checkmo.web");
+            softly.assertThat(request.getSession().getAttribute(
+                            AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE))
+                    .isEqualTo(AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP);
+        });
+    }
+
+    @Test
+    void storesAppClientTypeWithoutFormPostForNonAppleAppAuthorizationRequest() {
+        AppleOAuth2AuthorizationRequestResolver resolver = new AppleOAuth2AuthorizationRequestResolver(
+                new InMemoryClientRegistrationRepository(googleRegistration())
+        );
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/google");
+        request.setParameter("client", "app");
+
+        OAuth2AuthorizationRequest authorizationRequest = resolver.resolve(request);
+
+        assertSoftly(softly -> {
+            softly.assertThat(authorizationRequest.getAdditionalParameters()).doesNotContainKey("response_mode");
+            softly.assertThat(authorizationRequest.getAuthorizationRequestUri()).doesNotContain("response_mode");
+            softly.assertThat(request.getSession().getAttribute(
+                            AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE))
+                    .isEqualTo(AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP);
+        });
+    }
+
+    @Test
+    void clearsStaleAppClientTypeForWebAuthorizationRequest() {
+        AppleOAuth2AuthorizationRequestResolver resolver = new AppleOAuth2AuthorizationRequestResolver(
+                new InMemoryClientRegistrationRepository(googleRegistration())
+        );
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/oauth2/authorization/google");
+        request.getSession().setAttribute(
+                AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE,
+                AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP
+        );
+
+        OAuth2AuthorizationRequest authorizationRequest = resolver.resolve(request);
+
+        assertSoftly(softly -> {
+            softly.assertThat(authorizationRequest.getAuthorizationRequestUri()).doesNotContain("response_mode");
+            softly.assertThat(request.getSession().getAttribute(
+                    AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE)).isNull();
+        });
+    }
+
+    @Test
     void keepsDefaultParametersForNonAppleAuthorizationRequest() {
         AppleOAuth2AuthorizationRequestResolver resolver = new AppleOAuth2AuthorizationRequestResolver(
                 new InMemoryClientRegistrationRepository(googleRegistration())

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2UserServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2UserServiceTest.java
@@ -1,0 +1,121 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import checkmo.authentication.internal.entity.AuthUser;
+import checkmo.authentication.internal.entity.Role;
+import checkmo.authentication.internal.security.apple.AppleIdTokenVerifier;
+import checkmo.authentication.internal.security.apple.AppleIdentity;
+import checkmo.authentication.internal.security.auth.PrincipalDetails;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+class AppleOAuth2UserServiceTest {
+
+    @Test
+    void loadsAppleUserFromIdTokenAndResolvesSocialAccount() {
+        AppleIdTokenVerifier verifier = mock(AppleIdTokenVerifier.class);
+        SocialAccountResolver socialAccountResolver = mock(SocialAccountResolver.class);
+        AppleOAuth2UserService service = new AppleOAuth2UserService(verifier, socialAccountResolver);
+        AppleIdentity identity = new AppleIdentity(
+                "apple-sub",
+                "APPLE_apple-sub",
+                "apple-user@example.com",
+                true,
+                false,
+                "kr.co.checkmo.web"
+        );
+        AuthUser user = user("APPLE_apple-sub", "apple-user@example.com");
+        when(verifier.verifyWebToken("apple.identity.token")).thenReturn(identity);
+        when(socialAccountResolver.resolve(any(OAuth2Attributes.class), eq("apple")))
+                .thenReturn(new SocialAccountResolution(user, true));
+
+        OAuth2User oauth2User = service.loadUser(appleUserRequest("apple.identity.token"));
+
+        ArgumentCaptor<OAuth2Attributes> attributesCaptor = ArgumentCaptor.forClass(OAuth2Attributes.class);
+        verify(socialAccountResolver).resolve(attributesCaptor.capture(), eq("apple"));
+        OAuth2Attributes attributes = attributesCaptor.getValue();
+        PrincipalDetails principalDetails = (PrincipalDetails) oauth2User;
+        assertSoftly(softly -> {
+            softly.assertThat(attributes.getProviderId()).isEqualTo("apple-sub");
+            softly.assertThat(attributes.getEmail()).isEqualTo("apple-user@example.com");
+            softly.assertThat(principalDetails.getUsername()).isEqualTo("APPLE_apple-sub");
+            softly.assertThat(principalDetails.isNewSocialSignUp()).isTrue();
+            softly.assertThat(principalDetails.getAttributes())
+                    .containsEntry("sub", "apple-sub")
+                    .containsEntry("email", "apple-user@example.com")
+                    .containsEntry("email_verified", true)
+                    .containsEntry("is_private_email", false);
+        });
+    }
+
+    @Test
+    void rejectsAppleUserRequestWithoutIdToken() {
+        AppleIdTokenVerifier verifier = mock(AppleIdTokenVerifier.class);
+        SocialAccountResolver socialAccountResolver = mock(SocialAccountResolver.class);
+        AppleOAuth2UserService service = new AppleOAuth2UserService(verifier, socialAccountResolver);
+
+        Throwable thrown = catchThrowable(() -> service.loadUser(appleUserRequest(null)));
+
+        assertSoftly(softly -> {
+            softly.assertThat(thrown).isInstanceOf(OAuth2AuthenticationException.class);
+            OAuth2AuthenticationException exception = (OAuth2AuthenticationException) thrown;
+            softly.assertThat(exception.getError().getErrorCode()).isEqualTo("invalid_apple_id_token");
+        });
+        verify(verifier, never()).verifyWebToken(any());
+        verify(socialAccountResolver, never()).resolve(any(), eq("apple"));
+    }
+
+    private OAuth2UserRequest appleUserRequest(String idToken) {
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER,
+                "access-token",
+                Instant.parse("2026-06-28T00:00:00Z"),
+                Instant.parse("2026-06-28T00:05:00Z")
+        );
+        Map<String, Object> additionalParameters = idToken == null
+                ? Map.of()
+                : Map.of("id_token", idToken);
+        return new OAuth2UserRequest(appleRegistration(), accessToken, additionalParameters);
+    }
+
+    private ClientRegistration appleRegistration() {
+        return ClientRegistration.withRegistrationId("apple")
+                .clientId("kr.co.checkmo.web")
+                .clientSecret("placeholder")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("https://api.checkmo.co.kr/login/oauth2/code/apple")
+                .authorizationUri("https://appleid.apple.com/auth/authorize")
+                .tokenUri("https://appleid.apple.com/auth/token")
+                .scope("openid", "email", "name")
+                .clientName("Apple")
+                .build();
+    }
+
+    private AuthUser user(String id, String email) {
+        return AuthUser.builder()
+                .id(id)
+                .email(email)
+                .password("")
+                .role(Role.USER)
+                .profileCompleted(false)
+                .build();
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,36 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import checkmo.authentication.internal.exception.AuthErrorStatus;
+import checkmo.authentication.internal.exception.AuthException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+class CustomOAuth2UserServiceTest {
+
+    @Test
+    void translatesAuthExceptionToOAuth2AuthenticationException() {
+        SocialAccountResolver socialAccountResolver = mock(SocialAccountResolver.class);
+        CustomOAuth2UserService service = new CustomOAuth2UserService(socialAccountResolver);
+        OAuth2Attributes attributes = OAuth2Attributes.of("google", Map.of(
+                "email", "social-user@example.com",
+                "sub", "google-sub"
+        ));
+        when(socialAccountResolver.resolve(attributes, "google"))
+                .thenThrow(new AuthException(AuthErrorStatus.SOCIAL_ACCOUNT_EMAIL_CONFLICT));
+
+        Throwable thrown = catchThrowable(() -> service.resolveSocialAccount(attributes, "google"));
+
+        assertSoftly(softly -> {
+            softly.assertThat(thrown).isInstanceOf(OAuth2AuthenticationException.class);
+            OAuth2AuthenticationException exception = (OAuth2AuthenticationException) thrown;
+            softly.assertThat(exception.getError().getErrorCode()).isEqualTo("AUTH_414");
+            softly.assertThat(exception).hasCauseInstanceOf(AuthException.class);
+        });
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AttributesTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AttributesTest.java
@@ -1,9 +1,11 @@
 package checkmo.authentication.internal.security.oauth2;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 
 class OAuth2AttributesTest {
 
@@ -34,5 +36,24 @@ class OAuth2AttributesTest {
             softly.assertThat(naver.getEmail()).isEqualTo("naver-user@example.com");
             softly.assertThat(naver.getProviderId()).isEqualTo("naver-id");
         });
+    }
+
+    @Test
+    void mapsApple() {
+        OAuth2Attributes apple = OAuth2Attributes.of("apple", Map.of(
+                "email", "apple-user@example.com",
+                "sub", "apple-sub"
+        ));
+
+        assertSoftly(softly -> {
+            softly.assertThat(apple.getEmail()).isEqualTo("apple-user@example.com");
+            softly.assertThat(apple.getProviderId()).isEqualTo("apple-sub");
+        });
+    }
+
+    @Test
+    void rejectsAppleWithoutSubject() {
+        assertThatThrownBy(() -> OAuth2Attributes.of("apple", Map.of("email", "apple-user@example.com")))
+                .isInstanceOf(OAuth2AuthenticationException.class);
     }
 }

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AttributesTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AttributesTest.java
@@ -1,0 +1,38 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OAuth2AttributesTest {
+
+    @Test
+    void mapsGoogleKakaoNaver() {
+        OAuth2Attributes google = OAuth2Attributes.of("google", Map.of(
+                "email", "google-user@example.com",
+                "sub", "google-sub"
+        ));
+
+        OAuth2Attributes kakao = OAuth2Attributes.of("kakao", Map.of(
+                "id", 12345L,
+                "kakao_account", Map.of("email", "kakao-user@example.com")
+        ));
+
+        OAuth2Attributes naver = OAuth2Attributes.of("naver", Map.of(
+                "response", Map.of(
+                        "email", "naver-user@example.com",
+                        "id", "naver-id"
+                )
+        ));
+
+        assertSoftly(softly -> {
+            softly.assertThat(google.getEmail()).isEqualTo("google-user@example.com");
+            softly.assertThat(google.getProviderId()).isEqualTo("google-sub");
+            softly.assertThat(kakao.getEmail()).isEqualTo("kakao-user@example.com");
+            softly.assertThat(kakao.getProviderId()).isEqualTo("12345");
+            softly.assertThat(naver.getEmail()).isEqualTo("naver-user@example.com");
+            softly.assertThat(naver.getProviderId()).isEqualTo("naver-id");
+        });
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandlerTest.java
@@ -1,0 +1,29 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+class OAuth2AuthenticationFailureHandlerTest {
+
+    @Test
+    void redirectsWithoutSecretQuery() throws Exception {
+        OAuth2AuthenticationFailureHandler handler = new OAuth2AuthenticationFailureHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        OAuth2AuthenticationException exception = new OAuth2AuthenticationException(
+                "provider failed with token=secret-value"
+        );
+
+        handler.onAuthenticationFailure(request, response, exception);
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.getRedirectedUrl()).isEqualTo("/login?error=true");
+            softly.assertThat(response.getRedirectedUrl()).doesNotContain("secret-value");
+            softly.assertThat(response.getRedirectedUrl()).doesNotContain("token=");
+        });
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandlerTest.java
@@ -33,8 +33,9 @@ class OAuth2AuthenticationFailureHandlerTest {
         OAuth2AuthenticationFailureHandler handler = new OAuth2AuthenticationFailureHandler();
         ReflectionTestUtils.setField(handler, "appUri", "checkmo://oauth-callback");
         MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("state", "app-state");
         request.getSession().setAttribute(
-                AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE,
+                AppleOAuth2AuthorizationRequestResolver.sessionClientTypeKey("app-state"),
                 AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP
         );
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -50,7 +51,7 @@ class OAuth2AuthenticationFailureHandlerTest {
             softly.assertThat(response.getRedirectedUrl()).doesNotContain("secret-value");
             softly.assertThat(response.getRedirectedUrl()).doesNotContain("token=");
             softly.assertThat(request.getSession().getAttribute(
-                    AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE)).isNull();
+                    AppleOAuth2AuthorizationRequestResolver.sessionClientTypeKey("app-state"))).isNull();
         });
     }
 }

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandlerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class OAuth2AuthenticationFailureHandlerTest {
 
@@ -24,6 +25,32 @@ class OAuth2AuthenticationFailureHandlerTest {
             softly.assertThat(response.getRedirectedUrl()).isEqualTo("/login?error=true");
             softly.assertThat(response.getRedirectedUrl()).doesNotContain("secret-value");
             softly.assertThat(response.getRedirectedUrl()).doesNotContain("token=");
+        });
+    }
+
+    @Test
+    void appAuthorizationFailureRedirectsDeepLinkErrorWithoutSecretQuery() throws Exception {
+        OAuth2AuthenticationFailureHandler handler = new OAuth2AuthenticationFailureHandler();
+        ReflectionTestUtils.setField(handler, "appUri", "checkmo://oauth-callback");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute(
+                AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE,
+                AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP
+        );
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        OAuth2AuthenticationException exception = new OAuth2AuthenticationException(
+                "provider failed with token=secret-value"
+        );
+
+        handler.onAuthenticationFailure(request, response, exception);
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.getRedirectedUrl())
+                    .isEqualTo("checkmo://oauth-callback?error=login_failed");
+            softly.assertThat(response.getRedirectedUrl()).doesNotContain("secret-value");
+            softly.assertThat(response.getRedirectedUrl()).doesNotContain("token=");
+            softly.assertThat(request.getSession().getAttribute(
+                    AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE)).isNull();
         });
     }
 }

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
@@ -77,9 +77,11 @@ class OAuth2AuthenticationSuccessHandlerTest {
             softly.assertThat(response.getHeaders("Set-Cookie"))
                     .anyMatch(header -> header.startsWith("accessToken=access-token")
                             && header.contains("HttpOnly")
+                            && header.contains("Secure")
                             && header.contains("SameSite=None"))
                     .anyMatch(header -> header.startsWith("refreshToken=refresh-token")
                             && header.contains("HttpOnly")
+                            && header.contains("Secure")
                             && header.contains("SameSite=None"));
         });
         verify(authReactivationCommandService).reactivateIfDeactivated("GOOGLE_google-sub");
@@ -104,8 +106,9 @@ class OAuth2AuthenticationSuccessHandlerTest {
         PrincipalDetails principal = new PrincipalDetails(user, Map.of("sub", "apple-sub"), true);
         TestingAuthenticationToken authentication = new TestingAuthenticationToken(principal, null);
         MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter("state", "app-state");
         request.getSession().setAttribute(
-                AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE,
+                AppleOAuth2AuthorizationRequestResolver.sessionClientTypeKey("app-state"),
                 AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP
         );
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -128,7 +131,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
                     .doesNotContain("access-token");
             softly.assertThat(response.getHeaders("Set-Cookie")).isEmpty();
             softly.assertThat(request.getSession().getAttribute(
-                    AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE)).isNull();
+                    AppleOAuth2AuthorizationRequestResolver.sessionClientTypeKey("app-state"))).isNull();
             softly.assertThat(codeCaptor.getValue()).isNotBlank();
         });
         verify(authReactivationCommandService).reactivateIfDeactivated("APPLE_apple-sub");

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,6 +1,7 @@
 package checkmo.authentication.internal.security.oauth2;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,7 +16,9 @@ import checkmo.authentication.internal.security.jwt.JwtTokenProvider;
 import checkmo.authentication.internal.security.jwt.TokenCacheService;
 import checkmo.authentication.internal.service.command.AuthReactivationCommandService;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.TestingAuthenticationToken;
@@ -23,18 +26,30 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 class OAuth2AuthenticationSuccessHandlerTest {
 
-    @Test
-    void completedProfileRedirectsHomeAndSetsJwtCookies() throws Exception {
-        JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
-        TokenCacheService tokenCacheService = mock(TokenCacheService.class);
-        AuthReactivationCommandService authReactivationCommandService = mock(AuthReactivationCommandService.class);
-        JwtLoginProcessor jwtLoginProcessor = new JwtLoginProcessor(
+    private JwtTokenProvider jwtTokenProvider;
+    private TokenCacheService tokenCacheService;
+    private AuthReactivationCommandService authReactivationCommandService;
+    private JwtLoginProcessor jwtLoginProcessor;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = mock(JwtTokenProvider.class);
+        tokenCacheService = mock(TokenCacheService.class);
+        authReactivationCommandService = mock(AuthReactivationCommandService.class);
+        jwtLoginProcessor = new JwtLoginProcessor(
                 jwtTokenProvider,
                 new JwtCookieUtil(),
                 tokenCacheService,
                 authReactivationCommandService
         );
-        OAuth2AuthenticationSuccessHandler handler = new OAuth2AuthenticationSuccessHandler(jwtLoginProcessor);
+    }
+
+    @Test
+    void completedProfileRedirectsHomeAndSetsJwtCookies() throws Exception {
+        OAuth2AuthenticationSuccessHandler handler = new OAuth2AuthenticationSuccessHandler(
+                jwtLoginProcessor,
+                tokenCacheService
+        );
         ReflectionTestUtils.setField(handler, "baseUri", "https://web.checkmo.test");
         AuthUser user = AuthUser.builder()
                 .id("GOOGLE_google-sub")
@@ -69,5 +84,54 @@ class OAuth2AuthenticationSuccessHandlerTest {
         });
         verify(authReactivationCommandService).reactivateIfDeactivated("GOOGLE_google-sub");
         verify(tokenCacheService).saveRefreshToken("GOOGLE_google-sub", "refresh-token");
+    }
+
+    @Test
+    void appAuthorizationRedirectsOneTimeCodeWithoutJwtCookies() throws Exception {
+        OAuth2AuthenticationSuccessHandler handler = new OAuth2AuthenticationSuccessHandler(
+                jwtLoginProcessor,
+                tokenCacheService
+        );
+        ReflectionTestUtils.setField(handler, "baseUri", "https://web.checkmo.test");
+        ReflectionTestUtils.setField(handler, "appUri", "checkmo://oauth-callback");
+        AuthUser user = AuthUser.builder()
+                .id("APPLE_apple-sub")
+                .email("apple-user@example.com")
+                .password("")
+                .role(Role.USER)
+                .profileCompleted(false)
+                .build();
+        PrincipalDetails principal = new PrincipalDetails(user, Map.of("sub", "apple-sub"), true);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(principal, null);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute(
+                AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE,
+                AppleOAuth2AuthorizationRequestResolver.CLIENT_TYPE_APP
+        );
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtTokenProvider.generateToken(authentication)).thenReturn(JwtToken.builder()
+                .accessToken("access-token")
+                .refreshToken("refresh-token")
+                .build());
+
+        handler.onAuthenticationSuccess(request, response, authentication);
+
+        ArgumentCaptor<String> codeCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tokenCacheService).saveOAuthExchangeCode(codeCaptor.capture(), eq("false|refresh-token"));
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.getRedirectedUrl())
+                    .startsWith("checkmo://oauth-callback?code=")
+                    .contains(codeCaptor.getValue())
+                    .doesNotContain("refresh-token")
+                    .doesNotContain("access-token");
+            softly.assertThat(response.getHeaders("Set-Cookie")).isEmpty();
+            softly.assertThat(request.getSession().getAttribute(
+                    AppleOAuth2AuthorizationRequestResolver.SESSION_CLIENT_TYPE)).isNull();
+            softly.assertThat(codeCaptor.getValue()).isNotBlank();
+        });
+        verify(authReactivationCommandService).reactivateIfDeactivated("APPLE_apple-sub");
+        verify(tokenCacheService).saveRefreshToken("APPLE_apple-sub", "refresh-token");
     }
 }

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,0 +1,73 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import checkmo.authentication.internal.entity.AuthUser;
+import checkmo.authentication.internal.entity.Role;
+import checkmo.authentication.internal.security.auth.PrincipalDetails;
+import checkmo.authentication.internal.security.jwt.JwtCookieUtil;
+import checkmo.authentication.internal.security.jwt.JwtLoginProcessor;
+import checkmo.authentication.internal.security.jwt.JwtToken;
+import checkmo.authentication.internal.security.jwt.JwtTokenProvider;
+import checkmo.authentication.internal.security.jwt.TokenCacheService;
+import checkmo.authentication.internal.service.command.AuthReactivationCommandService;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class OAuth2AuthenticationSuccessHandlerTest {
+
+    @Test
+    void completedProfileRedirectsHomeAndSetsJwtCookies() throws Exception {
+        JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
+        TokenCacheService tokenCacheService = mock(TokenCacheService.class);
+        AuthReactivationCommandService authReactivationCommandService = mock(AuthReactivationCommandService.class);
+        JwtLoginProcessor jwtLoginProcessor = new JwtLoginProcessor(
+                jwtTokenProvider,
+                new JwtCookieUtil(),
+                tokenCacheService,
+                authReactivationCommandService
+        );
+        OAuth2AuthenticationSuccessHandler handler = new OAuth2AuthenticationSuccessHandler(jwtLoginProcessor);
+        ReflectionTestUtils.setField(handler, "baseUri", "https://web.checkmo.test");
+        AuthUser user = AuthUser.builder()
+                .id("GOOGLE_google-sub")
+                .email("social-user@example.com")
+                .password("")
+                .role(Role.USER)
+                .profileCompleted(true)
+                .build();
+        PrincipalDetails principal = new PrincipalDetails(user, Map.of("sub", "google-sub"), false);
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(principal, null);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        when(jwtTokenProvider.generateToken(authentication)).thenReturn(JwtToken.builder()
+                .accessToken("access-token")
+                .refreshToken("refresh-token")
+                .build());
+        when(jwtTokenProvider.getAccessTokenExpirationTime()).thenReturn(3_600_000L);
+        when(jwtTokenProvider.getRefreshTokenExpirationTime()).thenReturn(86_400_000L);
+
+        handler.onAuthenticationSuccess(request, response, authentication);
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.getRedirectedUrl()).isEqualTo("https://web.checkmo.test/");
+            softly.assertThat(response.getHeaders("Set-Cookie"))
+                    .anyMatch(header -> header.startsWith("accessToken=access-token")
+                            && header.contains("HttpOnly")
+                            && header.contains("SameSite=None"))
+                    .anyMatch(header -> header.startsWith("refreshToken=refresh-token")
+                            && header.contains("HttpOnly")
+                            && header.contains("SameSite=None"));
+        });
+        verify(authReactivationCommandService).reactivateIfDeactivated("GOOGLE_google-sub");
+        verify(tokenCacheService).saveRefreshToken("GOOGLE_google-sub", "refresh-token");
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreatorIntegrationTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreatorIntegrationTest.java
@@ -1,0 +1,64 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import checkmo.authentication.internal.entity.AuthUser;
+import checkmo.authentication.internal.entity.Role;
+import checkmo.support.ApiTestSupport;
+import jakarta.persistence.PersistenceException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SocialAccountCreatorIntegrationTest extends ApiTestSupport {
+
+    @Autowired
+    private SocialAccountCreator socialAccountCreator;
+
+    @Test
+    void persistsNewSocialUserWithAssignedProviderId() {
+        OAuth2Attributes attributes = OAuth2Attributes.of("apple", Map.of(
+                "sub", "apple-sub",
+                "email", "apple-user@example.com"
+        ));
+
+        AuthUser createdUser = socialAccountCreator.create(attributes, "apple");
+        AuthUser savedUser = authRepository.findById("APPLE_apple-sub").orElseThrow();
+
+        assertSoftly(softly -> {
+            softly.assertThat(createdUser.getId()).isEqualTo("APPLE_apple-sub");
+            softly.assertThat(savedUser.getId()).isEqualTo("APPLE_apple-sub");
+            softly.assertThat(savedUser.getEmail()).isEqualTo("apple-user@example.com");
+            softly.assertThat(savedUser.isProfileCompleted()).isFalse();
+        });
+    }
+
+    @Test
+    void duplicateProviderIdFailsInsteadOfMergingExistingUser() {
+        authRepository.saveAndFlush(user("APPLE_apple-sub", "existing@example.com"));
+        OAuth2Attributes attributes = OAuth2Attributes.of("apple", Map.of(
+                "sub", "apple-sub",
+                "email", "new@example.com"
+        ));
+
+        assertThatThrownBy(() -> socialAccountCreator.create(attributes, "apple"))
+                .isInstanceOf(PersistenceException.class);
+
+        AuthUser savedUser = authRepository.findById("APPLE_apple-sub").orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(savedUser.getEmail()).isEqualTo("existing@example.com");
+            softly.assertThat(authRepository.findByEmail("new@example.com")).isEmpty();
+        });
+    }
+
+    private AuthUser user(String id, String email) {
+        return AuthUser.builder()
+                .id(id)
+                .email(email)
+                .password("")
+                .role(Role.USER)
+                .profileCompleted(false)
+                .build();
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreatorIntegrationTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreatorIntegrationTest.java
@@ -5,16 +5,57 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import checkmo.authentication.internal.entity.AuthUser;
 import checkmo.authentication.internal.entity.Role;
-import checkmo.support.ApiTestSupport;
+import checkmo.authentication.internal.repository.AuthRepository;
+import checkmo.book.internal.scheduler.BookRecommendationScheduler;
+import checkmo.bookStory.internal.scheduler.BookStoryViewScheduler;
+import checkmo.member.internal.scheduler.MemberCleanupScheduler;
+import checkmo.support.SpringTest;
 import jakarta.persistence.PersistenceException;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-class SocialAccountCreatorIntegrationTest extends ApiTestSupport {
+@SpringTest
+@TestPropertySource(properties = "aladin.api.recommendation.refresh.background.fixed-delay=60000")
+class SocialAccountCreatorIntegrationTest {
 
     @Autowired
     private SocialAccountCreator socialAccountCreator;
+
+    @Autowired
+    private AuthRepository authRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockitoBean
+    private BookRecommendationScheduler bookRecommendationScheduler;
+
+    @MockitoBean
+    private BookStoryViewScheduler bookStoryViewScheduler;
+
+    @MockitoBean
+    private MemberCleanupScheduler memberCleanupScheduler;
+
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY FALSE");
+        jdbcTemplate.queryForList(
+                        """
+                                select table_name
+                                from information_schema.tables
+                                where lower(table_schema) = 'public'
+                                  and table_type in ('BASE TABLE', 'TABLE')
+                                """,
+                        String.class
+                )
+                .forEach(tableName -> jdbcTemplate.execute("delete from " + quoteIdentifier(tableName)));
+        jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY TRUE");
+    }
 
     @Test
     void persistsNewSocialUserWithAssignedProviderId() {
@@ -60,5 +101,9 @@ class SocialAccountCreatorIntegrationTest extends ApiTestSupport {
                 .role(Role.USER)
                 .profileCompleted(false)
                 .build();
+    }
+
+    private String quoteIdentifier(String identifier) {
+        return "\"" + identifier.replace("\"", "\"\"") + "\"";
     }
 }

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolverTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolverTest.java
@@ -1,0 +1,184 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import checkmo.authentication.internal.entity.AuthUser;
+import checkmo.authentication.internal.entity.Role;
+import checkmo.authentication.internal.exception.AuthErrorStatus;
+import checkmo.authentication.internal.exception.AuthException;
+import checkmo.authentication.internal.repository.AuthRepository;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SocialAccountResolverTest {
+
+    private final AuthRepository authRepository = mock(AuthRepository.class);
+    private final SocialAccountCreator socialAccountCreator = mock(SocialAccountCreator.class);
+    private final SocialAccountResolver resolver = new SocialAccountResolver(authRepository, socialAccountCreator);
+
+    @Test
+    void createsIncompleteAppleUserWhenFirstLoginHasEmail() {
+        OAuth2Attributes attributes = appleAttributes("apple-sub", "apple-user@example.com");
+
+        when(authRepository.findById("APPLE_apple-sub")).thenReturn(Optional.empty());
+        when(authRepository.findByEmail("apple-user@example.com")).thenReturn(Optional.empty());
+        when(socialAccountCreator.create(attributes, "apple"))
+                .thenReturn(user("APPLE_apple-sub", "apple-user@example.com"));
+
+        SocialAccountResolution result = resolver.resolve(attributes, "apple");
+
+        assertSoftly(softly -> {
+            softly.assertThat(result.newSocialSignUp()).isTrue();
+            softly.assertThat(result.user().getId()).isEqualTo("APPLE_apple-sub");
+            softly.assertThat(result.user().getEmail()).isEqualTo("apple-user@example.com");
+            softly.assertThat(result.user().isProfileCompleted()).isFalse();
+        });
+        verify(socialAccountCreator).create(attributes, "apple");
+    }
+
+    @Test
+    void resolvesRepeatAppleLoginByProviderIdWithoutEmail() {
+        AuthUser existingUser = user("APPLE_apple-sub", "apple-user@example.com");
+        OAuth2Attributes attributes = appleAttributesWithoutEmail("apple-sub");
+
+        when(authRepository.findById("APPLE_apple-sub")).thenReturn(Optional.of(existingUser));
+
+        SocialAccountResolution result = resolver.resolve(attributes, "apple");
+
+        assertSoftly(softly -> {
+            softly.assertThat(result.user()).isSameAs(existingUser);
+            softly.assertThat(result.newSocialSignUp()).isFalse();
+        });
+        verify(authRepository, never()).findByEmail(any());
+        verify(socialAccountCreator, never()).create(attributes, "apple");
+    }
+
+    @Test
+    void rejectsAppleEmailCollisionWithControlledConflict() {
+        OAuth2Attributes attributes = appleAttributes("apple-sub", "shared@example.com");
+
+        when(authRepository.findById("APPLE_apple-sub")).thenReturn(Optional.empty());
+        when(authRepository.findByEmail("shared@example.com"))
+                .thenReturn(Optional.of(user("LOCAL_local-user", "shared@example.com")));
+
+        Throwable thrown = catchThrowable(() -> resolver.resolve(attributes, "apple"));
+
+        assertAuthException(thrown, AuthErrorStatus.SOCIAL_ACCOUNT_EMAIL_CONFLICT, HttpStatus.CONFLICT);
+        verify(socialAccountCreator, never()).create(attributes, "apple");
+    }
+
+    @Test
+    void rejectsNewAppleLoginWithoutEmail() {
+        OAuth2Attributes attributes = appleAttributesWithoutEmail("apple-sub");
+
+        when(authRepository.findById("APPLE_apple-sub")).thenReturn(Optional.empty());
+
+        Throwable thrown = catchThrowable(() -> resolver.resolve(attributes, "apple"));
+
+        assertAuthException(thrown, AuthErrorStatus.APPLE_EMAIL_REQUIRED, HttpStatus.BAD_REQUEST);
+        verify(socialAccountCreator, never()).create(attributes, "apple");
+    }
+
+    @Test
+    void resolvesConcurrentAppleFirstLoginWhenDuplicateSaveCanRefetchById() {
+        AuthUser existingUser = user("APPLE_apple-sub", "apple-user@example.com");
+        OAuth2Attributes attributes = appleAttributes("apple-sub", "apple-user@example.com");
+
+        when(authRepository.findById("APPLE_apple-sub"))
+                .thenReturn(Optional.empty(), Optional.of(existingUser));
+        when(authRepository.findByEmail("apple-user@example.com")).thenReturn(Optional.empty());
+        when(socialAccountCreator.create(attributes, "apple"))
+                .thenThrow(new DataIntegrityViolationException("duplicate auth_user"));
+
+        SocialAccountResolution result = resolver.resolve(attributes, "apple");
+
+        assertSoftly(softly -> {
+            softly.assertThat(result.user()).isSameAs(existingUser);
+            softly.assertThat(result.newSocialSignUp()).isFalse();
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("emailBasedSocialAttributes")
+    void resolvesEmailBasedSocialLoginByEmailEvenWhenProviderIdDiffers(
+            String registrationId,
+            String newProviderMemberId,
+            OAuth2Attributes attributes
+    ) {
+        AuthUser existingUser = user(registrationId.toUpperCase() + "_old-provider-id", "social-user@example.com");
+
+        when(authRepository.findByEmail("social-user@example.com")).thenReturn(Optional.of(existingUser));
+
+        SocialAccountResolution result = resolver.resolve(attributes, registrationId);
+
+        assertSoftly(softly -> {
+            softly.assertThat(result.user()).isSameAs(existingUser);
+            softly.assertThat(result.newSocialSignUp()).isFalse();
+        });
+        verify(authRepository, never()).findById(newProviderMemberId);
+        verify(socialAccountCreator, never()).create(attributes, registrationId);
+    }
+
+    private OAuth2Attributes appleAttributes(String subject, String email) {
+        return OAuth2Attributes.of("apple", Map.of(
+                "sub", subject,
+                "email", email
+        ));
+    }
+
+    private OAuth2Attributes appleAttributesWithoutEmail(String subject) {
+        return OAuth2Attributes.of("apple", Map.of("sub", subject));
+    }
+
+    private AuthUser user(String id, String email) {
+        return AuthUser.builder()
+                .id(id)
+                .email(email)
+                .password("")
+                .role(Role.USER)
+                .profileCompleted(false)
+                .build();
+    }
+
+    private static Stream<Arguments> emailBasedSocialAttributes() {
+        return Stream.of(
+                Arguments.of("google", "GOOGLE_new-provider-id", OAuth2Attributes.of("google", Map.of(
+                        "email", "social-user@example.com",
+                        "sub", "new-provider-id"
+                ))),
+                Arguments.of("kakao", "KAKAO_12345", OAuth2Attributes.of("kakao", Map.of(
+                        "id", 12345L,
+                        "kakao_account", Map.of("email", "social-user@example.com")
+                ))),
+                Arguments.of("naver", "NAVER_naver-new-id", OAuth2Attributes.of("naver", Map.of(
+                        "response", Map.of(
+                                "email", "social-user@example.com",
+                                "id", "naver-new-id"
+                        )
+                )))
+        );
+    }
+
+    private void assertAuthException(Throwable thrown, AuthErrorStatus status, HttpStatus httpStatus) {
+        assertThat(thrown).isInstanceOf(AuthException.class);
+        AuthException authException = (AuthException) thrown;
+        assertSoftly(softly -> {
+            softly.assertThat(authException.getErrorCode()).isEqualTo(status);
+            softly.assertThat(authException.getErrorReasonHttpStatus().getHttpStatus()).isEqualTo(httpStatus);
+        });
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/SocialOAuth2UserServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/SocialOAuth2UserServiceTest.java
@@ -1,0 +1,71 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+class SocialOAuth2UserServiceTest {
+
+    @Test
+    void delegatesAppleRegistrationToAppleUserService() {
+        CustomOAuth2UserService defaultOAuth2UserService = mock(CustomOAuth2UserService.class);
+        AppleOAuth2UserService appleOAuth2UserService = mock(AppleOAuth2UserService.class);
+        SocialOAuth2UserService service =
+                new SocialOAuth2UserService(defaultOAuth2UserService, appleOAuth2UserService);
+        OAuth2UserRequest userRequest = userRequest("apple");
+        OAuth2User oauth2User = mock(OAuth2User.class);
+        when(appleOAuth2UserService.loadUser(userRequest)).thenReturn(oauth2User);
+
+        service.loadUser(userRequest);
+
+        verify(appleOAuth2UserService).loadUser(userRequest);
+    }
+
+    @Test
+    void delegatesNonAppleRegistrationToDefaultUserService() {
+        CustomOAuth2UserService defaultOAuth2UserService = mock(CustomOAuth2UserService.class);
+        AppleOAuth2UserService appleOAuth2UserService = mock(AppleOAuth2UserService.class);
+        SocialOAuth2UserService service =
+                new SocialOAuth2UserService(defaultOAuth2UserService, appleOAuth2UserService);
+        OAuth2UserRequest userRequest = userRequest("google");
+        OAuth2User oauth2User = mock(OAuth2User.class);
+        when(defaultOAuth2UserService.loadUser(userRequest)).thenReturn(oauth2User);
+
+        service.loadUser(userRequest);
+
+        verify(defaultOAuth2UserService).loadUser(userRequest);
+    }
+
+    private OAuth2UserRequest userRequest(String registrationId) {
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER,
+                "access-token",
+                Instant.parse("2026-06-28T00:00:00Z"),
+                Instant.parse("2026-06-28T00:05:00Z")
+        );
+        return new OAuth2UserRequest(clientRegistration(registrationId), accessToken, Map.of());
+    }
+
+    private ClientRegistration clientRegistration(String registrationId) {
+        return ClientRegistration.withRegistrationId(registrationId)
+                .clientId(registrationId + "-client-id")
+                .clientSecret(registrationId + "-client-secret")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("https://api.checkmo.co.kr/login/oauth2/code/" + registrationId)
+                .authorizationUri("https://example.com/oauth2/authorize")
+                .tokenUri("https://example.com/oauth2/token")
+                .clientName(registrationId)
+                .build();
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/SocialOAuth2UserServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/SocialOAuth2UserServiceTest.java
@@ -1,6 +1,8 @@
 package checkmo.authentication.internal.security.oauth2;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,9 +28,11 @@ class SocialOAuth2UserServiceTest {
         OAuth2User oauth2User = mock(OAuth2User.class);
         when(appleOAuth2UserService.loadUser(userRequest)).thenReturn(oauth2User);
 
-        service.loadUser(userRequest);
+        OAuth2User result = service.loadUser(userRequest);
 
+        assertThat(result).isSameAs(oauth2User);
         verify(appleOAuth2UserService).loadUser(userRequest);
+        verify(defaultOAuth2UserService, never()).loadUser(userRequest);
     }
 
     @Test
@@ -41,9 +45,11 @@ class SocialOAuth2UserServiceTest {
         OAuth2User oauth2User = mock(OAuth2User.class);
         when(defaultOAuth2UserService.loadUser(userRequest)).thenReturn(oauth2User);
 
-        service.loadUser(userRequest);
+        OAuth2User result = service.loadUser(userRequest);
 
+        assertThat(result).isSameAs(oauth2User);
         verify(defaultOAuth2UserService).loadUser(userRequest);
+        verify(appleOAuth2UserService, never()).loadUser(userRequest);
     }
 
     private OAuth2UserRequest userRequest(String registrationId) {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -63,6 +63,7 @@ app:
   oauth2:
     redirect:
       base-uri: http://localhost:3000
+      app-uri: checkmo://oauth-callback
 
 jwt:
   secret: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=


### PR DESCRIPTION
## 요약
- 웹 Apple OAuth 로그인 흐름을 추가했습니다.
- 앱 OAuth 딥링크 코드 교환 흐름과 Apple 네이티브 로그인 API를 추가했습니다.
- Apple ID token 검증, JWKS 서명 키 필터링, 앱/웹 social account resolution 흐름을 정리했습니다.

## 최종 점검
- Apple 로그인 전용 클래스 과분리 여부를 점검하고 필요한 정리만 반영했습니다.
- JWKS는 RSA 서명용 키만 신뢰하도록 보강했습니다.
- Verifier 내부 전용 값 객체를 private record로 내부화했습니다.
- 웹/앱 Apple identity attributes 변환 중복을 제거했습니다.

## Tested
- ./gradlew test --tests checkmo.authentication.internal.security.apple.AppleIdTokenVerifierTest
- ./gradlew test --tests checkmo.authentication.internal.security.apple.AppleIdentityTest --tests checkmo.authentication.internal.security.oauth2.AppleOAuth2UserServiceTest --tests checkmo.authentication.AppleAppLoginApiTest
- ./gradlew test --tests checkmo.authentication.AuthApiTest --tests checkmo.authentication.AppleAppLoginApiTest --tests 'checkmo.authentication.internal.security.apple.*' --tests 'checkmo.authentication.internal.security.oauth2.*' --tests checkmo.CheckmoApplicationTests
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple sign-in support for the mobile app, including login with Apple credentials and one-time code exchange for app redirects.
  * Introduced smoother social login handling for app and web flows, with deep-link support for app users.

* **Bug Fixes**
  * Improved validation and error handling for Apple login failures, missing required fields, invalid codes, and account conflicts.
  * Updated login behavior to better preserve session state and return the correct token/cookie experience based on the client type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->