### PR TITLE
fix(auth): Apple 웹 로그인 세션 쿠키 설정

### DIFF
--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtCookieUtil.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtCookieUtil.java
@@ -10,16 +10,6 @@ import org.springframework.stereotype.Component;
 public class JwtCookieUtil {
 
     public void addTokenToCookie(HttpServletResponse response, String cookieName, String token, int maxAge) {
-    /*
-        Cookie cookie = new Cookie(cookieName, token);
-        cookie.setHttpOnly(true); // 클라이언트 스크립트에서 접근 불가
-        cookie.setAttribute("SameSite", "None"); // 프론트 배포 성공 시 사용, TODO : 프론트 배포 성공 시 주석해제
-        //cookie.setAttribute("SameSite", "Lax"); // 프론트가 개발중일 때 사용, TODO : 프론트 배포 성공 시 삭제
-        cookie.setPath("/"); // 모든 경로에서 접근 가능
-        cookie.setMaxAge(maxAge);
-        cookie.setSecure(true); // HTTPS에서만 전송하도록 추가
-        response.addCookie(cookie);
-    */
         ResponseCookie cookie = ResponseCookie.from(cookieName, token)
                 .httpOnly(true)
                 .secure(true)
@@ -44,16 +34,6 @@ public class JwtCookieUtil {
     }
 
     public void deleteTokenFromCookie(HttpServletResponse response, String cookieName) {
-    /*
-        // 쿠키에서 토큰을 삭제
-        Cookie cookie = new Cookie(cookieName, null);
-        cookie.setMaxAge(0);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setAttribute("SameSite", "None"); // 프론트 배포 성공 시 사용, TODO : 프론트 배포 성공 시 주석해제
-        cookie.setSecure(true); // 프론트가 개발중일 때 사용, TODO : 프론트 배포 성공 시 true로 변경
-        response.addCookie(cookie);
-    */
         ResponseCookie cookie = ResponseCookie.from(cookieName, null)
                 .httpOnly(true)
                 .secure(true)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,6 +27,13 @@ logging:
     org.hibernate.SQL: WARN
     checkmo: INFO
 
+server:
+  servlet:
+    session:
+      cookie:
+        same-site: none
+        secure: true
+
 events:
   retry:
     enabled: true

--- a/src/test/java/checkmo/authentication/internal/config/OAuthSessionCookiePropertiesTest.java
+++ b/src/test/java/checkmo/authentication/internal/config/OAuthSessionCookiePropertiesTest.java
@@ -1,0 +1,45 @@
+package checkmo.authentication.internal.config;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ClassPathResource;
+
+class OAuthSessionCookiePropertiesTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withInitializer(loadProdYaml());
+
+    @Test
+    void configuresSecureCrossSiteSessionCookieForAppleFormPostCallback() {
+        contextRunner.run(context -> assertSoftly(softly -> {
+            softly.assertThat(context.getEnvironment().getProperty("server.servlet.session.cookie.same-site"))
+                    .isEqualTo("none");
+            softly.assertThat(context.getEnvironment().getProperty("server.servlet.session.cookie.secure"))
+                    .isEqualTo("true");
+        }));
+    }
+
+    private ApplicationContextInitializer<ConfigurableApplicationContext> loadProdYaml() {
+        return context -> {
+            try {
+                YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
+                List<PropertySource<?>> propertySources = loader.load(
+                        "application-prod",
+                        new ClassPathResource("application-prod.yml")
+                );
+                propertySources.forEach(propertySource ->
+                        context.getEnvironment().getPropertySources().addLast(propertySource));
+            } catch (IOException e) {
+                throw new IllegalStateException("application-prod.yml could not be loaded", e);
+            }
+        };
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/config/OAuthSessionCookiePropertiesTest.java
+++ b/src/test/java/checkmo/authentication/internal/config/OAuthSessionCookiePropertiesTest.java
@@ -2,44 +2,39 @@ package checkmo.authentication.internal.config;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import java.io.IOException;
-import java.util.List;
+import checkmo.book.internal.scheduler.BookRecommendationScheduler;
+import checkmo.bookStory.internal.scheduler.BookStoryViewScheduler;
+import checkmo.member.internal.scheduler.MemberCleanupScheduler;
+import checkmo.support.SpringTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.boot.env.YamlPropertySourceLoader;
-import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.core.env.PropertySource;
-import org.springframework.core.io.ClassPathResource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+@SpringTest
+@ActiveProfiles({"prod", "test"})
 class OAuthSessionCookiePropertiesTest {
 
-    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withInitializer(loadProdYaml());
+    @Autowired
+    private Environment environment;
+
+    @MockitoBean
+    private BookRecommendationScheduler bookRecommendationScheduler;
+
+    @MockitoBean
+    private BookStoryViewScheduler bookStoryViewScheduler;
+
+    @MockitoBean
+    private MemberCleanupScheduler memberCleanupScheduler;
 
     @Test
     void configuresSecureCrossSiteSessionCookieForAppleFormPostCallback() {
-        contextRunner.run(context -> assertSoftly(softly -> {
-            softly.assertThat(context.getEnvironment().getProperty("server.servlet.session.cookie.same-site"))
+        assertSoftly(softly -> {
+            softly.assertThat(environment.getProperty("server.servlet.session.cookie.same-site"))
                     .isEqualTo("none");
-            softly.assertThat(context.getEnvironment().getProperty("server.servlet.session.cookie.secure"))
+            softly.assertThat(environment.getProperty("server.servlet.session.cookie.secure"))
                     .isEqualTo("true");
-        }));
-    }
-
-    private ApplicationContextInitializer<ConfigurableApplicationContext> loadProdYaml() {
-        return context -> {
-            try {
-                YamlPropertySourceLoader loader = new YamlPropertySourceLoader();
-                List<PropertySource<?>> propertySources = loader.load(
-                        "application-prod",
-                        new ClassPathResource("application-prod.yml")
-                );
-                propertySources.forEach(propertySource ->
-                        context.getEnvironment().getPropertySources().addLast(propertySource));
-            } catch (IOException e) {
-                throw new IllegalStateException("application-prod.yml could not be loaded", e);
-            }
-        };
+        });
     }
 }


### PR DESCRIPTION
## 작업 내용

- 운영 환경의 Spring Security 세션 쿠키에 `SameSite=None`, `Secure=true` 설정을 추가했습니다.
- Apple 웹 OAuth의 `form_post` 콜백에서 `JSESSIONID`가 누락되지 않도록 설정을 회귀 테스트로 고정했습니다.
- `JwtCookieUtil`에 남아 있던 과거 쿠키 생성 방식 주석을 제거했습니다.

## 원인

Apple 웹 로그인은 인증 후 `response_mode=form_post`로 cross-site POST 콜백을 사용합니다. 기존 운영 세션 쿠키는 `SameSite=None; Secure`가 없어 브라우저가 Apple 콜백 요청에 `JSESSIONID`를 포함하지 않았고, Spring Security OAuth state 검증이 실패해 `/login?error=true`로 이동했습니다.

## 검증

```bash
./gradlew test --tests checkmo.authentication.internal.config.OAuthSessionCookiePropertiesTest --tests checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationSuccessHandlerTest --tests checkmo.authentication.AuthApiTest --tests checkmo.CheckmoApplicationTests
```

Closes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication cookie handling so JWT and session cookies are consistently sent with secure browser settings.
  * Updated production cookie settings to support cross-site usage more reliably while keeping cookies protected.
  * Added automated coverage to verify the production session cookie configuration stays correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->