### PR TITLE
fix(auth): OAuth 실패 로그 상세화

### DIFF
--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -27,7 +29,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
             HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
             throws IOException {
 
-        log.error("소셜 로그인 인증 실패: {}", exception.getClass().getSimpleName());
+        logAuthenticationFailure(request, exception);
 
         if (AppleOAuth2AuthorizationRequestResolver.consumeAppClientType(request)) {
             redirectAppFailure(request, response);
@@ -36,6 +38,40 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
         // 실패 시 리다이렉트 URL 설정
         getRedirectStrategy().sendRedirect(request, response, "/login?error=true");
+    }
+
+    private void logAuthenticationFailure(HttpServletRequest request, AuthenticationException exception) {
+        if (exception instanceof OAuth2AuthenticationException oauth2Exception) {
+            OAuth2Error error = oauth2Exception.getError();
+            log.error(
+                    "소셜 로그인 인증 실패: type={}, uri={}, errorCode={}, description={}, message={}",
+                    oauth2Exception.getClass().getSimpleName(),
+                    request.getRequestURI(),
+                    error.getErrorCode(),
+                    sanitize(error.getDescription()),
+                    sanitize(exception.getMessage()),
+                    exception
+            );
+            return;
+        }
+
+        log.error(
+                "소셜 로그인 인증 실패: type={}, uri={}, message={}",
+                exception.getClass().getSimpleName(),
+                request.getRequestURI(),
+                sanitize(exception.getMessage()),
+                exception
+        );
+    }
+
+    private String sanitize(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.replaceAll(
+                "(?i)(client_secret|code|id_token|access_token|refresh_token|token)=([^\\s&]+)",
+                "$1=***"
+        );
     }
 
     private void redirectAppFailure(HttpServletRequest request, HttpServletResponse response) throws IOException {


### PR DESCRIPTION
## 작업 내용

- OAuth2 로그인 실패 시 예외 클래스명만 남기던 로그를 상세화했습니다.
- `OAuth2AuthenticationException`의 `errorCode`, `description`, `message`, stack trace를 함께 기록합니다.
- `code`, `client_secret`, `id_token`, `access_token`, `refresh_token` 등 민감 파라미터는 로그에서 마스킹합니다.

## 배경

Apple 웹 로그인 콜백은 서버까지 정상 도착하지만 `OAuth2AuthenticationException`으로 실패하고 있습니다. 기존 로그는 클래스명만 남겨 state 검증 실패, token 교환 실패, id_token 검증 실패를 구분할 수 없어 운영 재현 시 원인을 확인하기 어렵습니다.

## 검증

```bash
./gradlew test --tests checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationFailureHandlerTest --tests checkmo.authentication.internal.config.OAuthSessionCookiePropertiesTest
```

Refs #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication failure handling with more detailed logs for OAuth2 errors.
  * Added safer log output by masking sensitive values such as tokens, secrets, and authorization codes.
  * Standardized failure logging so non-OAuth2 authentication errors are still recorded cleanly without exposing private details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->