### PR TITLE
fix(auth): Apple JWKS URI 설정 추가

### DIFF
--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -73,3 +73,4 @@ spring:
           apple:
             authorization-uri: https://appleid.apple.com/auth/authorize
             token-uri: https://appleid.apple.com/auth/token
+            jwk-set-uri: https://appleid.apple.com/auth/keys

--- a/src/test/java/checkmo/authentication/internal/config/properties/AppleOAuthPropertiesTest.java
+++ b/src/test/java/checkmo/authentication/internal/config/properties/AppleOAuthPropertiesTest.java
@@ -75,6 +75,9 @@ class AppleOAuthPropertiesTest {
                 softly.assertThat(environment.getProperty(
                         "spring.security.oauth2.client.provider.apple.token-uri"
                 )).isEqualTo("https://appleid.apple.com/auth/token");
+                softly.assertThat(environment.getProperty(
+                        "spring.security.oauth2.client.provider.apple.jwk-set-uri"
+                )).isEqualTo("https://appleid.apple.com/auth/keys");
             });
         });
     }


### PR DESCRIPTION
## 작업 내용

- Apple OAuth provider 설정에 `jwk-set-uri`를 추가했습니다.
- Spring Security가 Apple `id_token` 서명 검증에 사용할 JWKS endpoint를 찾을 수 있도록 했습니다.
- Apple OAuth 설정 테스트에 `jwk-set-uri` 검증을 추가했습니다.

## 원인

운영 로그에서 다음 오류가 확인되었습니다.

```text
missing_signature_verifier: Failed to find a Signature Verifier for Client Registration: 'apple'. Check to ensure you have configured the JwkSet URI.
```

Apple token 교환 후 Spring Security의 OIDC `id_token` 검증 단계에서 provider의 JWK Set URI가 필요하지만, 기존 `application-oauth2.yml`의 Apple provider 설정에는 `authorization-uri`, `token-uri`만 있었습니다.

## 검증

```bash
./gradlew test --tests checkmo.authentication.internal.config.properties.AppleOAuthPropertiesTest --tests checkmo.authentication.internal.security.oauth2.AppleOAuth2UserServiceTest --tests checkmo.authentication.internal.security.oauth2.AppleClientSecretTokenRequestParametersConverterTest --tests checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationFailureHandlerTest
```

Refs #269