### PR TITLE
fix(auth): Apple OIDC principal 변환 연결

### DIFF
--- a/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
+++ b/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import checkmo.authentication.internal.security.auth.ProfileCompletionAuthorizat
 import checkmo.authentication.internal.security.jwt.JwtAuthenticationFilter;
 import checkmo.authentication.internal.security.apple.AppleClientSecretGenerator;
 import checkmo.authentication.internal.security.oauth2.AppleClientSecretTokenRequestParametersConverter;
+import checkmo.authentication.internal.security.oauth2.AppleOidcUserService;
 import checkmo.authentication.internal.security.oauth2.AppleOAuth2AuthorizationRequestResolver;
 import checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationFailureHandler;
 import checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationSuccessHandler;
@@ -37,6 +38,7 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final ProfileCompletionAuthorizationFilter profileCompletionAuthorizationFilter;
     private final SocialOAuth2UserService socialOAuth2UserService;
+    private final AppleOidcUserService appleOidcUserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
 
@@ -96,7 +98,9 @@ public class SecurityConfig {
                         .tokenEndpoint(token -> token
                                 .accessTokenResponseClient(accessTokenResponseClient)
                         )
-                        .userInfoEndpoint(userInfo -> userInfo.userService(socialOAuth2UserService)
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(socialOAuth2UserService)
+                                .oidcUserService(appleOidcUserService)
                         )
                         .successHandler(oAuth2AuthenticationSuccessHandler) // 로그인 성공 핸들러 설정
                         .failureHandler(oAuth2AuthenticationFailureHandler) // 로그인 실패 핸들러 설정

--- a/src/main/java/checkmo/authentication/internal/security/auth/PrincipalOidcDetails.java
+++ b/src/main/java/checkmo/authentication/internal/security/auth/PrincipalOidcDetails.java
@@ -1,0 +1,40 @@
+package checkmo.authentication.internal.security.auth;
+
+import checkmo.authentication.internal.entity.AuthUser;
+import java.util.Map;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+public class PrincipalOidcDetails extends PrincipalDetails implements OidcUser {
+
+    private final OidcIdToken idToken;
+    private final OidcUserInfo userInfo;
+
+    public PrincipalOidcDetails(
+            AuthUser user,
+            Map<String, Object> attributes,
+            boolean newSocialSignUp,
+            OidcIdToken idToken,
+            OidcUserInfo userInfo
+    ) {
+        super(user, attributes, newSocialSignUp);
+        this.idToken = idToken;
+        this.userInfo = userInfo;
+    }
+
+    @Override
+    public Map<String, Object> getClaims() {
+        return getAttributes();
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo() {
+        return userInfo;
+    }
+
+    @Override
+    public OidcIdToken getIdToken() {
+        return idToken;
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2UserService.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2UserService.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
@@ -44,11 +45,19 @@ public class AppleOAuth2UserService implements OAuth2UserService<OAuth2UserReque
     }
 
     private AppleIdentity verifyIdentity(OAuth2UserRequest userRequest) {
+        if (userRequest instanceof OidcUserRequest oidcUserRequest) {
+            return verifyIdToken(oidcUserRequest.getIdToken().getTokenValue());
+        }
+
         Object idToken = userRequest.getAdditionalParameters().get(OidcParameterNames.ID_TOKEN);
         if (!(idToken instanceof String value) || !StringUtils.hasText(value)) {
             throw invalidAppleIdToken(null);
         }
 
+        return verifyIdToken(value);
+    }
+
+    private AppleIdentity verifyIdToken(String value) {
         try {
             return appleIdTokenVerifier.verifyWebToken(value);
         } catch (InvalidAppleIdentityTokenException e) {

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOidcUserService.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleOidcUserService.java
@@ -1,0 +1,29 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import checkmo.authentication.internal.security.auth.PrincipalDetails;
+import checkmo.authentication.internal.security.auth.PrincipalOidcDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AppleOidcUserService implements OAuth2UserService<OidcUserRequest, OidcUser> {
+
+    private final AppleOAuth2UserService appleOAuth2UserService;
+
+    @Override
+    public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+        PrincipalDetails principalDetails = (PrincipalDetails) appleOAuth2UserService.loadUser(userRequest);
+        return new PrincipalOidcDetails(
+                principalDetails.getUser(),
+                principalDetails.getAttributes(),
+                principalDetails.isNewSocialSignUp(),
+                userRequest.getIdToken(),
+                null
+        );
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOidcUserServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOidcUserServiceTest.java
@@ -1,0 +1,95 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import checkmo.authentication.internal.entity.AuthUser;
+import checkmo.authentication.internal.entity.Role;
+import checkmo.authentication.internal.security.auth.PrincipalDetails;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+class AppleOidcUserServiceTest {
+
+    @Test
+    void adaptsApplePrincipalDetailsToOidcUser() {
+        AppleOAuth2UserService appleOAuth2UserService = mock(AppleOAuth2UserService.class);
+        AppleOidcUserService appleOidcUserService = new AppleOidcUserService(appleOAuth2UserService);
+        OidcUserRequest userRequest = userRequest();
+        PrincipalDetails principalDetails = new PrincipalDetails(
+                user(),
+                Map.of("sub", "apple-sub", "email", "apple-user@example.com"),
+                true
+        );
+        when(appleOAuth2UserService.loadUser(userRequest)).thenReturn(principalDetails);
+
+        OidcUser oidcUser = appleOidcUserService.loadUser(userRequest);
+
+        assertSoftly(softly -> {
+            softly.assertThat(oidcUser).isInstanceOf(PrincipalDetails.class);
+            softly.assertThat(((PrincipalDetails) oidcUser).getUser().getId()).isEqualTo("APPLE_apple-sub");
+            softly.assertThat(((PrincipalDetails) oidcUser).isNewSocialSignUp()).isTrue();
+            softly.assertThat(oidcUser.getIdToken()).isSameAs(userRequest.getIdToken());
+            softly.assertThat(oidcUser.getClaims()).containsEntry("sub", "apple-sub");
+        });
+        verify(appleOAuth2UserService).loadUser(userRequest);
+    }
+
+    private OidcUserRequest userRequest() {
+        Instant issuedAt = Instant.parse("2026-07-01T00:00:00Z");
+        Instant expiresAt = Instant.parse("2026-07-01T00:05:00Z");
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER,
+                "access-token",
+                issuedAt,
+                expiresAt
+        );
+        OidcIdToken idToken = new OidcIdToken(
+                "id-token",
+                issuedAt,
+                expiresAt,
+                Map.of(
+                        IdTokenClaimNames.ISS, "https://appleid.apple.com",
+                        IdTokenClaimNames.SUB, "apple-sub",
+                        IdTokenClaimNames.AUD, "kr.co.checkmo.web"
+                )
+        );
+        return new OidcUserRequest(appleRegistration(), accessToken, idToken, Map.of());
+    }
+
+    private ClientRegistration appleRegistration() {
+        return ClientRegistration.withRegistrationId("apple")
+                .clientId("kr.co.checkmo.web")
+                .clientSecret("client-secret")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("https://api.checkmo.co.kr/login/oauth2/code/apple")
+                .authorizationUri("https://appleid.apple.com/auth/authorize")
+                .tokenUri("https://appleid.apple.com/auth/token")
+                .jwkSetUri("https://appleid.apple.com/auth/keys")
+                .scope("openid", "email", "name")
+                .clientName("Apple")
+                .build();
+    }
+
+    private AuthUser user() {
+        return AuthUser.builder()
+                .id("APPLE_apple-sub")
+                .email("apple-user@example.com")
+                .password("")
+                .role(Role.USER)
+                .profileCompleted(false)
+                .build();
+    }
+}


### PR DESCRIPTION
## 작업 내용

- Apple OIDC 로그인 경로에 전용 `oidcUserService`를 연결했습니다.
- Spring 기본 `DefaultOidcUser` 대신 기존 성공 핸들러가 기대하는 `PrincipalDetails` 계열 principal을 반환하도록 했습니다.
- `OidcUser` 계약을 만족하는 `PrincipalOidcDetails`를 추가했습니다.
- Apple OIDC 경로에서 기존 Apple 소셜 계정 생성/조회 로직을 그대로 재사용하도록 했습니다.

## 원인

운영 로그에서 다음 예외가 확인되었습니다.

```text
ClassCastException: DefaultOidcUser cannot be cast to PrincipalDetails
at OAuth2AuthenticationSuccessHandler.onAuthenticationSuccess(OAuth2AuthenticationSuccessHandler.java:42)
```

Apple은 `openid` scope 때문에 Spring Security의 OIDC 경로를 타고, 이 경우 기존 `userService(...)`가 아니라 OIDC user service가 사용됩니다. 기존 설정에는 OIDC user service 연결이 없어 Spring 기본 `DefaultOidcUser`가 success handler로 들어왔습니다.

## 검증

```bash
./gradlew test --tests checkmo.authentication.internal.security.oauth2.AppleOidcUserServiceTest --tests checkmo.authentication.internal.security.oauth2.AppleOAuth2UserServiceTest --tests checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationSuccessHandlerTest --tests checkmo.authentication.internal.config.properties.AppleOAuthPropertiesTest
./gradlew test --tests checkmo.CheckmoApplicationTests
```

Refs #269