### PR TITLE
fix(auth): 미완성 회원 로그인 상태 조회 허용

### DIFF
--- a/src/main/java/checkmo/authentication/internal/security/auth/ProfileCompletionAuthorizationFilter.java
+++ b/src/main/java/checkmo/authentication/internal/security/auth/ProfileCompletionAuthorizationFilter.java
@@ -27,6 +27,7 @@ public class ProfileCompletionAuthorizationFilter extends OncePerRequestFilter {
             "/api/v1/auth/logout",
             "/api/v1/terms",
             "/api/v1/members/me/terms",
+            "/api/v1/members/me/login-status",
             "/api/v1/members/additional-info",
             "/api/v1/auth/redirect/oauth2",
             "/api/v1/members/check-nickname",

--- a/src/test/java/checkmo/member/MemberApiTest.java
+++ b/src/test/java/checkmo/member/MemberApiTest.java
@@ -454,6 +454,19 @@ class MemberApiTest extends ApiTestSupport {
     }
 
     @Test
+    void incompleteProfileCanReadLoginStatus() {
+        TestUser user = createIncompleteUser();
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/v1/members/me/login-status")
+                .then()
+                .statusCode(200)
+                .body("result.provider", equalTo("LOCAL"));
+    }
+
+    @Test
     void followListAndUnfollowFlowSucceeds() {
         TestUser me = createUser();
         TestUser target = createUser();


### PR DESCRIPTION
## 요약
- 프로필 미완성 회원도 /api/v1/members/me/login-status를 조회할 수 있도록 프로필 완료 필터 예외에 추가했습니다.
- 약관 온보딩 진입 후 프론트가 로그인 상태를 확인하지 못하던 403 흐름을 막는 회귀 테스트를 추가했습니다.

## 검증
- ./gradlew test --tests checkmo.member.MemberApiTest