### PR TITLE
feat(notification): Expo 기반 푸시 알림 기능 추가

### DIFF
--- a/src/main/java/checkmo/infra/PushAPI.java
+++ b/src/main/java/checkmo/infra/PushAPI.java
@@ -1,0 +1,11 @@
+package checkmo.infra;
+
+import java.util.List;
+import java.util.Map;
+
+public interface PushAPI {
+
+    List<PushSendResult> sendBatch(List<PushSendRequest> requests);
+
+    Map<String, PushReceiptResult> getReceipts(List<String> ticketIds);
+}

--- a/src/main/java/checkmo/infra/PushReceiptResult.java
+++ b/src/main/java/checkmo/infra/PushReceiptResult.java
@@ -1,0 +1,31 @@
+package checkmo.infra;
+
+public record PushReceiptResult(
+        String status,
+        String errorCode,
+        String errorMessage
+) {
+    public boolean isOk() {
+        return "ok".equals(status);
+    }
+
+    public boolean isPending() {
+        return status == null || "pending".equals(status);
+    }
+
+    public boolean isDeviceNotRegistered() {
+        return "error".equals(status) && "DeviceNotRegistered".equals(errorCode);
+    }
+
+    public boolean isMessageRateExceeded() {
+        return "error".equals(status) && "MessageRateExceeded".equals(errorCode);
+    }
+
+    public boolean isPermanentError() {
+        return "error".equals(status) && (
+                "MessageTooBig".equals(errorCode)
+                        || "InvalidCredentials".equals(errorCode)
+                        || "MismatchSenderId".equals(errorCode)
+        );
+    }
+}

--- a/src/main/java/checkmo/infra/PushSendRequest.java
+++ b/src/main/java/checkmo/infra/PushSendRequest.java
@@ -1,0 +1,13 @@
+package checkmo.infra;
+
+import java.util.Map;
+
+public record PushSendRequest(
+        String token,
+        String title,
+        String body,
+        Map<String, Object> data,
+        String sound,
+        String priority,
+        String channelId
+) {}

--- a/src/main/java/checkmo/infra/PushSendResult.java
+++ b/src/main/java/checkmo/infra/PushSendResult.java
@@ -1,0 +1,20 @@
+package checkmo.infra;
+
+public record PushSendResult(
+        boolean ok,
+        String ticketId,
+        String errorCode,
+        String errorMessage
+) {
+    public boolean isDeviceNotRegistered() {
+        return !ok && "DeviceNotRegistered".equals(errorCode);
+    }
+
+    public static PushSendResult ok(String ticketId) {
+        return new PushSendResult(true, ticketId, null, null);
+    }
+
+    public static PushSendResult failed(String errorCode, String errorMessage) {
+        return new PushSendResult(false, null, errorCode, errorMessage);
+    }
+}

--- a/src/main/java/checkmo/infra/push/ExpoMessage.java
+++ b/src/main/java/checkmo/infra/push/ExpoMessage.java
@@ -1,0 +1,13 @@
+package checkmo.infra.push;
+
+import java.util.Map;
+
+public record ExpoMessage(
+        String to,
+        String title,
+        String body,
+        Map<String, Object> data,
+        String sound,
+        String priority,
+        String channelId
+) {}

--- a/src/main/java/checkmo/infra/push/ExpoPushApiImpl.java
+++ b/src/main/java/checkmo/infra/push/ExpoPushApiImpl.java
@@ -1,0 +1,62 @@
+package checkmo.infra.push;
+
+import checkmo.infra.PushAPI;
+import checkmo.infra.PushReceiptResult;
+import checkmo.infra.PushSendRequest;
+import checkmo.infra.PushSendResult;
+import checkmo.infra.push.internal.dto.ExpoMessage;
+import checkmo.infra.push.internal.dto.ExpoReceipt;
+import checkmo.infra.push.internal.dto.ExpoTicket;
+import checkmo.infra.push.internal.service.ExpoPushClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Service
+@RequiredArgsConstructor
+public class ExpoPushApiImpl implements PushAPI {
+
+    private final ExpoPushClient expoPushClient;
+
+    @Override
+    public List<PushSendResult> sendBatch(List<PushSendRequest> requests) {
+        List<ExpoMessage> messages = requests.stream()
+                .map(r -> r == null ? null
+                        : new ExpoMessage(r.token(), r.title(), r.body(), r.data(), r.sound(), r.priority(), r.channelId()))
+                .toList();
+
+        List<ExpoTicket> tickets = expoPushClient.sendBatch(messages);
+
+        return IntStream.range(0, requests.size())
+                .mapToObj(i -> toSendResult(i < tickets.size() ? tickets.get(i) : null))
+                .toList();
+    }
+
+    @Override
+    public Map<String, PushReceiptResult> getReceipts(List<String> ticketIds) {
+        return expoPushClient.getReceipts(ticketIds).entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> toReceiptResult(e.getValue())
+                ));
+    }
+
+    private PushSendResult toSendResult(ExpoTicket ticket) {
+        if (ticket == null) {
+            return PushSendResult.failed("SEND_FAILED", "No ticket returned from Expo");
+        }
+        if ("ok".equals(ticket.status())) {
+            return PushSendResult.ok(ticket.id());
+        }
+        String errorCode = ticket.details() != null ? ticket.details().error() : "UNKNOWN";
+        return PushSendResult.failed(errorCode, ticket.message());
+    }
+
+    private PushReceiptResult toReceiptResult(ExpoReceipt receipt) {
+        return new PushReceiptResult(receipt.status(), receipt.errorCode(), receipt.message());
+    }
+}

--- a/src/main/java/checkmo/infra/push/ExpoPushClient.java
+++ b/src/main/java/checkmo/infra/push/ExpoPushClient.java
@@ -1,0 +1,102 @@
+package checkmo.infra.push;
+
+import checkmo.infra.push.internal.config.properties.ExpoPushProperties;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExpoPushClient {
+
+    private static final int MAX_BATCH_SIZE = 100;
+
+    private final RestClient expoPushRestClient;
+    private final ExpoPushProperties properties;
+
+    /**
+     * 메시지 목록을 Expo Push Service에 발송한다.
+     * 반환 리스트는 입력 messages와 동일한 순서·길이를 보장한다.
+     * HTTP 오류로 청크 전체가 실패한 경우 해당 인덱스는 null로 채워진다.
+     */
+    public List<ExpoTicket> sendBatch(List<ExpoMessage> messages) {
+        if (!properties.isEnabled() || messages.isEmpty()) {
+            return Collections.nCopies(messages.size(), null);
+        }
+
+        List<ExpoTicket> result = new ArrayList<>(messages.size());
+
+        for (List<ExpoMessage> chunk : partition(messages, MAX_BATCH_SIZE)) {
+            try {
+                List<ExpoTicket> tickets = sendChunk(chunk);
+                result.addAll(tickets);
+            } catch (Exception e) {
+                log.error("Expo 푸시 발송 실패: count={}, error={}", chunk.size(), e.getMessage());
+                result.addAll(Collections.nCopies(chunk.size(), null));
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * ticket ID 목록으로 delivery receipt를 조회한다.
+     * enabled=false인 경우 빈 맵을 반환한다 (로컬·테스트 환경 보호).
+     * 반환 맵의 키는 ticketId이며, 응답에 없는 ticketId는 포함되지 않는다.
+     */
+    public Map<String, ExpoReceipt> getReceipts(List<String> ticketIds) {
+        if (!properties.isEnabled() || ticketIds.isEmpty()) {
+            return Map.of();
+        }
+
+        try {
+            ReceiptResponse response = expoPushRestClient.post()
+                    .uri("/push/getReceipts")
+                    .body(new ReceiptRequest(ticketIds))
+                    .retrieve()
+                    .body(ReceiptResponse.class);
+
+            return (response != null && response.data() != null) ? response.data() : Map.of();
+        } catch (Exception e) {
+            log.error("Expo receipt 조회 실패: count={}, error={}", ticketIds.size(), e.getMessage());
+            return Map.of();
+        }
+    }
+
+    private List<ExpoTicket> sendChunk(List<ExpoMessage> chunk) {
+        ExpoSendResponse response = expoPushRestClient.post()
+                .uri("/push/send")
+                .body(chunk)
+                .retrieve()
+                .body(ExpoSendResponse.class);
+
+        if (response == null || response.data() == null) {
+            return Collections.nCopies(chunk.size(), null);
+        }
+        return response.data();
+    }
+
+    private static <T> List<List<T>> partition(List<T> list, int size) {
+        List<List<T>> partitions = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += size) {
+            partitions.add(list.subList(i, Math.min(i + size, list.size())));
+        }
+        return partitions;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ExpoSendResponse(List<ExpoTicket> data) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ReceiptRequest(List<String> ids) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ReceiptResponse(Map<String, ExpoReceipt> data) {}
+}

--- a/src/main/java/checkmo/infra/push/ExpoReceipt.java
+++ b/src/main/java/checkmo/infra/push/ExpoReceipt.java
@@ -1,0 +1,42 @@
+package checkmo.infra.push;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExpoReceipt(
+        String status,
+        String id,
+        String message,
+        ExpoDetails details
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ExpoDetails(String error) {}
+
+    public boolean isOk() {
+        return "ok".equals(status);
+    }
+
+    public boolean isDeviceNotRegistered() {
+        return "error".equals(status)
+                && details != null
+                && "DeviceNotRegistered".equals(details.error());
+    }
+
+    public boolean isMessageRateExceeded() {
+        return "error".equals(status)
+                && details != null
+                && "MessageRateExceeded".equals(details.error());
+    }
+
+    public boolean isPermanentError() {
+        if (!"error".equals(status) || details == null) return false;
+        String error = details.error();
+        return "MessageTooBig".equals(error)
+                || "InvalidCredentials".equals(error)
+                || "MismatchSenderId".equals(error);
+    }
+
+    public String errorCode() {
+        return details != null ? details.error() : null;
+    }
+}

--- a/src/main/java/checkmo/infra/push/internal/config/ExpoPushConfig.java
+++ b/src/main/java/checkmo/infra/push/internal/config/ExpoPushConfig.java
@@ -1,0 +1,36 @@
+package checkmo.infra.push.internal.config;
+
+import checkmo.infra.push.internal.config.properties.ExpoPushProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@RequiredArgsConstructor
+public class ExpoPushConfig {
+
+    private final ExpoPushProperties properties;
+
+    @Bean
+    public RestClient expoPushRestClient() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(properties.getConnectTimeout());
+        factory.setReadTimeout(properties.getReadTimeout());
+
+        RestClient.Builder builder = RestClient.builder()
+                .requestFactory(factory)
+                .baseUrl(properties.getBaseUrl())
+                .defaultHeader("Content-Type", "application/json")
+                .defaultHeader("Accept", "application/json")
+                .defaultHeader("Accept-Encoding", "gzip, deflate");
+
+        if (StringUtils.hasText(properties.getAccessToken())) {
+            builder.defaultHeader("Authorization", "Bearer " + properties.getAccessToken());
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/checkmo/infra/push/internal/config/properties/ExpoPushProperties.java
+++ b/src/main/java/checkmo/infra/push/internal/config/properties/ExpoPushProperties.java
@@ -1,0 +1,28 @@
+package checkmo.infra.push.internal.config.properties;
+
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Component
+@Validated
+@ConfigurationProperties(prefix = "expo.push")
+public class ExpoPushProperties {
+
+    private String baseUrl = "https://exp.host/--/api/v2";
+
+    private String accessToken;
+
+    private boolean enabled;
+
+    @Positive
+    private int connectTimeout = 5000;
+
+    @Positive
+    private int readTimeout = 10000;
+}

--- a/src/main/java/checkmo/infra/push/internal/dto/ExpoMessage.java
+++ b/src/main/java/checkmo/infra/push/internal/dto/ExpoMessage.java
@@ -1,4 +1,4 @@
-package checkmo.infra.push;
+package checkmo.infra.push.internal.dto;
 
 import java.util.Map;
 
@@ -10,4 +10,5 @@ public record ExpoMessage(
         String sound,
         String priority,
         String channelId
-) {}
+) {
+}

--- a/src/main/java/checkmo/infra/push/internal/dto/ExpoReceipt.java
+++ b/src/main/java/checkmo/infra/push/internal/dto/ExpoReceipt.java
@@ -1,4 +1,4 @@
-package checkmo.infra.push;
+package checkmo.infra.push.internal.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -9,9 +9,6 @@ public record ExpoReceipt(
         String message,
         ExpoDetails details
 ) {
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public record ExpoDetails(String error) {}
-
     public boolean isOk() {
         return "ok".equals(status);
     }
@@ -38,5 +35,9 @@ public record ExpoReceipt(
 
     public String errorCode() {
         return details != null ? details.error() : null;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ExpoDetails(String error) {
     }
 }

--- a/src/main/java/checkmo/infra/push/internal/dto/ExpoTicket.java
+++ b/src/main/java/checkmo/infra/push/internal/dto/ExpoTicket.java
@@ -1,0 +1,21 @@
+package checkmo.infra.push.internal.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExpoTicket(
+        String status,
+        String id,
+        String message,
+        ExpoDetails details
+) {
+    public boolean isDeviceNotRegistered() {
+        return "error".equals(status)
+                && details != null
+                && "DeviceNotRegistered".equals(details.error());
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ExpoDetails(String error) {
+    }
+}

--- a/src/main/java/checkmo/infra/push/internal/service/ExpoPushClient.java
+++ b/src/main/java/checkmo/infra/push/internal/service/ExpoPushClient.java
@@ -1,15 +1,19 @@
-package checkmo.infra.push;
+package checkmo.infra.push.internal.service;
 
 import checkmo.infra.push.internal.config.properties.ExpoPushProperties;
+import checkmo.infra.push.internal.dto.ExpoMessage;
+import checkmo.infra.push.internal.dto.ExpoReceipt;
+import checkmo.infra.push.internal.dto.ExpoTicket;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -20,6 +24,14 @@ public class ExpoPushClient {
 
     private final RestClient expoPushRestClient;
     private final ExpoPushProperties properties;
+
+    private static <T> List<List<T>> partition(List<T> list, int size) {
+        List<List<T>> partitions = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += size) {
+            partitions.add(list.subList(i, Math.min(i + size, list.size())));
+        }
+        return partitions;
+    }
 
     /**
      * 메시지 목록을 Expo Push Service에 발송한다.
@@ -83,20 +95,15 @@ public class ExpoPushClient {
         return response.data();
     }
 
-    private static <T> List<List<T>> partition(List<T> list, int size) {
-        List<List<T>> partitions = new ArrayList<>();
-        for (int i = 0; i < list.size(); i += size) {
-            partitions.add(list.subList(i, Math.min(i + size, list.size())));
-        }
-        return partitions;
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record ExpoSendResponse(List<ExpoTicket> data) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record ExpoSendResponse(List<ExpoTicket> data) {}
+    private record ReceiptRequest(List<String> ids) {
+    }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record ReceiptRequest(List<String> ids) {}
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private record ReceiptResponse(Map<String, ExpoReceipt> data) {}
+    private record ReceiptResponse(Map<String, ExpoReceipt> data) {
+    }
 }

--- a/src/main/java/checkmo/notification/internal/PushMessageFactory.java
+++ b/src/main/java/checkmo/notification/internal/PushMessageFactory.java
@@ -1,0 +1,93 @@
+package checkmo.notification.internal;
+
+import checkmo.clubManagement.ClubManagementAPI;
+import checkmo.infra.push.ExpoMessage;
+import checkmo.member.MemberAPI;
+import checkmo.notification.internal.entity.Notification;
+import checkmo.notification.internal.entity.Notification.NotificationType;
+import checkmo.notification.internal.entity.PushDelivery;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PushMessageFactory {
+
+    private static final String APP_TITLE = "책모";
+    private static final String SOUND = "default";
+    private static final String PRIORITY = "high";
+    private static final String CHANNEL_ID = "checkmo-default";
+
+    private final MemberAPI memberAPI;
+    private final ClubManagementAPI clubManagementAPI;
+
+    public ExpoMessage build(PushDelivery delivery, Notification notification) {
+        String displayName = resolveDisplayName(notification);
+        return new ExpoMessage(
+                delivery.getPushDevice().getExpoPushToken(),
+                APP_TITLE,
+                buildBody(notification.getNotificationType(), displayName),
+                buildData(notification, displayName),
+                SOUND,
+                PRIORITY,
+                CHANNEL_ID
+        );
+    }
+
+    private String resolveDisplayName(Notification notification) {
+        return switch (notification.getNotificationType()) {
+            case LIKE, COMMENT, FOLLOW -> fetchNickname(notification.getSenderId());
+            case JOIN_CLUB, CLUB_MEETING_CREATED, CLUB_NOTICE_CREATED -> fetchClubName(notification.getDomainId());
+        };
+    }
+
+    private String buildBody(NotificationType type, String displayName) {
+        return switch (type) {
+            case LIKE -> displayName + "님이 회원님의 책이야기를 좋아합니다.";
+            case COMMENT -> displayName + "님이 회원님의 책이야기에 댓글을 달았습니다.";
+            case FOLLOW -> displayName + "님이 회원님을 팔로우했습니다.";
+            case JOIN_CLUB -> displayName + " 모임 가입이 승인되었습니다.";
+            case CLUB_MEETING_CREATED -> displayName + " 모임에 새로운 정기 모임이 생성되었습니다.";
+            case CLUB_NOTICE_CREATED -> displayName + " 모임에 새로운 공지사항이 등록되었습니다.";
+        };
+    }
+
+    private Map<String, Object> buildData(Notification notification, String displayName) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("schemaVersion", 1);
+        data.put("notificationId", notification.getId());
+        data.put("notificationType", notification.getNotificationType().name());
+        data.put("domainId", notification.getDomainId());
+        data.put("displayName", displayName);
+
+        // CLUB_MEETING_CREATED, CLUB_NOTICE_CREATED만 sourceId 포함
+        if (notification.getNotificationType().needsSourceId()) {
+            data.put("sourceId", notification.getSourceId());
+        }
+
+        return data;
+    }
+
+    private String fetchNickname(String memberId) {
+        try {
+            return memberAPI.fetchNickname(memberId);
+        } catch (Exception e) {
+            log.debug("닉네임 조회 실패 (탈퇴한 회원): memberId={}", memberId);
+            return "탈퇴한 회원";
+        }
+    }
+
+    private String fetchClubName(Long clubId) {
+        try {
+            return clubManagementAPI.fetchClubName(clubId);
+        } catch (Exception e) {
+            log.debug("모임명 조회 실패 (삭제된 모임): clubId={}", clubId);
+            return "삭제된 모임";
+        }
+    }
+}

--- a/src/main/java/checkmo/notification/internal/PushMessageFactory.java
+++ b/src/main/java/checkmo/notification/internal/PushMessageFactory.java
@@ -1,7 +1,7 @@
 package checkmo.notification.internal;
 
 import checkmo.clubManagement.ClubManagementAPI;
-import checkmo.infra.push.ExpoMessage;
+import checkmo.infra.PushSendRequest;
 import checkmo.member.MemberAPI;
 import checkmo.notification.internal.entity.Notification;
 import checkmo.notification.internal.entity.Notification.NotificationType;
@@ -26,9 +26,9 @@ public class PushMessageFactory {
     private final MemberAPI memberAPI;
     private final ClubManagementAPI clubManagementAPI;
 
-    public ExpoMessage build(PushDelivery delivery, Notification notification) {
+    public PushSendRequest build(PushDelivery delivery, Notification notification) {
         String displayName = resolveDisplayName(notification);
-        return new ExpoMessage(
+        return new PushSendRequest(
                 delivery.getPushDevice().getExpoPushToken(),
                 APP_TITLE,
                 buildBody(notification.getNotificationType(), displayName),

--- a/src/main/java/checkmo/notification/internal/converter/PushDeviceConverter.java
+++ b/src/main/java/checkmo/notification/internal/converter/PushDeviceConverter.java
@@ -1,0 +1,19 @@
+package checkmo.notification.internal.converter;
+
+import checkmo.notification.internal.entity.PushDevice;
+import checkmo.notification.web.dto.PushDeviceResponseDTO;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PushDeviceConverter {
+
+    public static PushDeviceResponseDTO toResponse(PushDevice device) {
+        return PushDeviceResponseDTO.builder()
+                .deviceId(device.getId())
+                .installationId(device.getInstallationId())
+                .active(device.isActive())
+                .registeredAt(device.getLastRegisteredAt())
+                .build();
+    }
+}

--- a/src/main/java/checkmo/notification/internal/entity/DeliveryStatus.java
+++ b/src/main/java/checkmo/notification/internal/entity/DeliveryStatus.java
@@ -1,0 +1,11 @@
+package checkmo.notification.internal.entity;
+
+public enum DeliveryStatus {
+    PENDING,
+    PROCESSING,
+    TICKET_ACCEPTED,
+    DELIVERED,
+    RETRY_WAIT,
+    PERMANENT_FAILED,
+    CANCELLED
+}

--- a/src/main/java/checkmo/notification/internal/entity/PushDelivery.java
+++ b/src/main/java/checkmo/notification/internal/entity/PushDelivery.java
@@ -1,0 +1,109 @@
+package checkmo.notification.internal.entity;
+
+import checkmo.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_push_delivery_notification_device",
+                        columnNames = {"notification_id", "push_device_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_push_delivery_expo_ticket_id", columnList = "expo_ticket_id"),
+                @Index(name = "idx_push_delivery_next_attempt_at", columnList = "next_attempt_at")
+        }
+)
+public class PushDelivery extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notification_id", nullable = false)
+    private Notification notification;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "push_device_id", nullable = false)
+    private PushDevice pushDevice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private DeliveryStatus status;
+
+    @Column(name = "expo_ticket_id", length = 100)
+    private String expoTicketId;
+
+    @Builder.Default
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount = 0;
+
+    @Column(name = "next_attempt_at")
+    private LocalDateTime nextAttemptAt;
+
+    @Column(name = "processing_started_at")
+    private LocalDateTime processingStartedAt;
+
+    @Column(name = "last_error_code", length = 100)
+    private String lastErrorCode;
+
+    @Column(name = "last_error_message", length = 500)
+    private String lastErrorMessage;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @Column(name = "receipt_checked_at")
+    private LocalDateTime receiptCheckedAt;
+
+    @Column(name = "delivered_at")
+    private LocalDateTime deliveredAt;
+
+    public void markProcessing() {
+        this.status = DeliveryStatus.PROCESSING;
+        this.processingStartedAt = LocalDateTime.now();
+    }
+
+    public void markTicketAccepted(String ticketId) {
+        this.status = DeliveryStatus.TICKET_ACCEPTED;
+        this.expoTicketId = ticketId;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    public void markDelivered() {
+        this.status = DeliveryStatus.DELIVERED;
+        this.deliveredAt = LocalDateTime.now();
+    }
+
+    public void markRetryWait(LocalDateTime nextAt, String errorCode, String errorMessage) {
+        this.status = DeliveryStatus.RETRY_WAIT;
+        this.nextAttemptAt = nextAt;
+        this.lastErrorCode = errorCode;
+        this.lastErrorMessage = errorMessage;
+        this.attemptCount++;
+    }
+
+    public void markPermanentFailed(String errorCode, String errorMessage) {
+        this.status = DeliveryStatus.PERMANENT_FAILED;
+        this.lastErrorCode = errorCode;
+        this.lastErrorMessage = errorMessage;
+    }
+
+    public void markCancelled() {
+        this.status = DeliveryStatus.CANCELLED;
+    }
+
+    public void updateReceiptCheckedAt(LocalDateTime checkedAt) {
+        this.receiptCheckedAt = checkedAt;
+    }
+}

--- a/src/main/java/checkmo/notification/internal/entity/PushDevice.java
+++ b/src/main/java/checkmo/notification/internal/entity/PushDevice.java
@@ -27,7 +27,8 @@ public class PushDevice extends BaseEntity {
     @Column(name = "installation_id", nullable = false, length = 36)
     private String installationId;
 
-    @Column(name = "expo_push_token", nullable = false, length = 255)
+    // 비활성화 시 null로 해제하여 동일 token의 재등록을 허용한다
+    @Column(name = "expo_push_token", length = 255)
     private String expoPushToken;
 
     @Enumerated(EnumType.STRING)
@@ -63,6 +64,7 @@ public class PushDevice extends BaseEntity {
 
     public void deactivate() {
         this.active = false;
+        this.expoPushToken = null;
         this.deactivatedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/checkmo/notification/internal/entity/PushDevice.java
+++ b/src/main/java/checkmo/notification/internal/entity/PushDevice.java
@@ -1,0 +1,72 @@
+package checkmo.notification.internal.entity;
+
+import checkmo.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(name = "uk_push_device_installation_id", columnNames = {"installation_id"}),
+        @UniqueConstraint(name = "uk_push_device_expo_push_token", columnNames = {"expo_push_token"})
+})
+public class PushDevice extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private String memberId;
+
+    @Column(name = "installation_id", nullable = false, length = 36)
+    private String installationId;
+
+    @Column(name = "expo_push_token", nullable = false, length = 255)
+    private String expoPushToken;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PushPlatform platform;
+
+    @Column(name = "app_version", nullable = false, length = 32)
+    private String appVersion;
+
+    @Column(name = "build_number", nullable = false, length = 32)
+    private String buildNumber;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean active = true;
+
+    @Column(name = "last_registered_at")
+    private LocalDateTime lastRegisteredAt;
+
+    @Column(name = "deactivated_at")
+    private LocalDateTime deactivatedAt;
+
+    public void update(String expoPushToken, String memberId, PushPlatform platform, String appVersion, String buildNumber) {
+        this.expoPushToken = expoPushToken;
+        this.memberId = memberId;
+        this.platform = platform;
+        this.appVersion = appVersion;
+        this.buildNumber = buildNumber;
+        this.active = true;
+        this.lastRegisteredAt = LocalDateTime.now();
+        this.deactivatedAt = null;
+    }
+
+    public void deactivate() {
+        this.active = false;
+        this.deactivatedAt = LocalDateTime.now();
+    }
+
+    public enum PushPlatform {
+        IOS, ANDROID
+    }
+}

--- a/src/main/java/checkmo/notification/internal/listener/PushDeliveryEventListener.java
+++ b/src/main/java/checkmo/notification/internal/listener/PushDeliveryEventListener.java
@@ -1,0 +1,49 @@
+package checkmo.notification.internal.listener;
+
+import checkmo.notification.internal.entity.DeliveryStatus;
+import checkmo.notification.internal.entity.PushDelivery;
+import checkmo.notification.internal.entity.PushDevice;
+import checkmo.notification.internal.listener.event.NotificationCreatedForPush;
+import checkmo.notification.internal.repository.NotificationRepository;
+import checkmo.notification.internal.repository.PushDeliveryRepository;
+import checkmo.notification.internal.repository.PushDeviceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class PushDeliveryEventListener {
+
+    private final NotificationRepository notificationRepository;
+    private final PushDeviceRepository pushDeviceRepository;
+    private final PushDeliveryRepository pushDeliveryRepository;
+
+    @ApplicationModuleListener
+    public void handleNotificationCreated(NotificationCreatedForPush event) {
+        List<PushDevice> devices = pushDeviceRepository.findAllByMemberIdAndActiveTrue(event.receiverId());
+        if (devices.isEmpty()) {
+            return;
+        }
+
+        notificationRepository.findById(event.notificationId()).ifPresent(notification -> {
+            for (PushDevice device : devices) {
+                PushDelivery delivery = PushDelivery.builder()
+                        .notification(notification)
+                        .pushDevice(device)
+                        .status(DeliveryStatus.PENDING)
+                        .build();
+                try {
+                    pushDeliveryRepository.save(delivery);
+                } catch (DataIntegrityViolationException e) {
+                    log.debug("push_delivery 이미 존재: notificationId={}, deviceId={}", event.notificationId(), device.getId());
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/checkmo/notification/internal/listener/event/NotificationCreatedForPush.java
+++ b/src/main/java/checkmo/notification/internal/listener/event/NotificationCreatedForPush.java
@@ -1,0 +1,4 @@
+package checkmo.notification.internal.listener.event;
+
+public record NotificationCreatedForPush(Long notificationId, String receiverId) {
+}

--- a/src/main/java/checkmo/notification/internal/repository/PushDeliveryRepository.java
+++ b/src/main/java/checkmo/notification/internal/repository/PushDeliveryRepository.java
@@ -1,0 +1,50 @@
+package checkmo.notification.internal.repository;
+
+import checkmo.notification.internal.entity.DeliveryStatus;
+import checkmo.notification.internal.entity.PushDelivery;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PushDeliveryRepository extends JpaRepository<PushDelivery, Long>, PushDeliveryRepositoryCustom {
+
+    Optional<PushDelivery> findByNotificationIdAndPushDeviceId(Long notificationId, Long pushDeviceId);
+
+    // sentAt 기준으로 조회해 receipt 확인 시점을 Expo 권장 15분 지연에 맞춘다
+    @Query("""
+            SELECT pd FROM PushDelivery pd
+            JOIN FETCH pd.pushDevice
+            WHERE pd.status = checkmo.notification.internal.entity.DeliveryStatus.TICKET_ACCEPTED
+              AND pd.expoTicketId IS NOT NULL
+              AND pd.sentAt <= :threshold
+            ORDER BY pd.sentAt ASC
+            """)
+    List<PushDelivery> findTicketAcceptedOlderThan(@Param("threshold") LocalDateTime threshold, Pageable pageable);
+
+    // processingStartedAt 기준으로 lease 만료된 PROCESSING을 찾아 RETRY_WAIT으로 복구한다
+    @Query("""
+            SELECT pd FROM PushDelivery pd
+            WHERE pd.status = checkmo.notification.internal.entity.DeliveryStatus.PROCESSING
+              AND pd.processingStartedAt <= :leaseExpiry
+            """)
+    List<PushDelivery> findStaleProcessing(@Param("leaseExpiry") LocalDateTime leaseExpiry);
+
+    @Query("""
+            SELECT pd FROM PushDelivery pd
+            WHERE pd.pushDevice.id = :pushDeviceId
+              AND pd.status NOT IN :terminalStatuses
+            """)
+    List<PushDelivery> findActiveDeliveriesByPushDeviceId(
+            @Param("pushDeviceId") Long pushDeviceId,
+            @Param("terminalStatuses") List<DeliveryStatus> terminalStatuses
+    );
+
+    void deleteAllByNotificationIdIn(List<Long> notificationIds);
+
+    void deleteAllByPushDeviceIdIn(List<Long> pushDeviceIds);
+}

--- a/src/main/java/checkmo/notification/internal/repository/PushDeliveryRepository.java
+++ b/src/main/java/checkmo/notification/internal/repository/PushDeliveryRepository.java
@@ -44,6 +44,18 @@ public interface PushDeliveryRepository extends JpaRepository<PushDelivery, Long
             @Param("terminalStatuses") List<DeliveryStatus> terminalStatuses
     );
 
+    @Query("""
+            SELECT pd FROM PushDelivery pd
+            WHERE pd.status IN :statuses
+              AND pd.updatedAt <= :threshold
+            ORDER BY pd.updatedAt ASC
+            """)
+    List<PushDelivery> findTerminalDeliveriesOlderThan(
+            @Param("statuses") List<DeliveryStatus> statuses,
+            @Param("threshold") LocalDateTime threshold,
+            Pageable pageable
+    );
+
     void deleteAllByNotificationIdIn(List<Long> notificationIds);
 
     void deleteAllByPushDeviceIdIn(List<Long> pushDeviceIds);

--- a/src/main/java/checkmo/notification/internal/repository/PushDeliveryRepositoryCustom.java
+++ b/src/main/java/checkmo/notification/internal/repository/PushDeliveryRepositoryCustom.java
@@ -1,0 +1,11 @@
+package checkmo.notification.internal.repository;
+
+import checkmo.notification.internal.entity.PushDelivery;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PushDeliveryRepositoryCustom {
+
+    List<PushDelivery> claimPendingBatch(int limit, LocalDateTime now);
+}

--- a/src/main/java/checkmo/notification/internal/repository/PushDeliveryRepositoryCustomImpl.java
+++ b/src/main/java/checkmo/notification/internal/repository/PushDeliveryRepositoryCustomImpl.java
@@ -1,0 +1,68 @@
+package checkmo.notification.internal.repository;
+
+import static checkmo.notification.internal.entity.QPushDelivery.pushDelivery;
+
+import checkmo.notification.internal.entity.DeliveryStatus;
+import checkmo.notification.internal.entity.PushDelivery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Repository
+public class PushDeliveryRepositoryCustomImpl implements PushDeliveryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
+
+    /**
+     * PENDING 또는 재시도 기한이 지난 RETRY_WAIT 레코드를 PROCESSING으로 원자 전환한다.
+     * FOR UPDATE SKIP LOCKED는 QueryDSL이 미지원이므로 native query로 ID만 선점하고,
+     * 이후 상태 변경과 엔티티 조회는 QueryDSL로 처리한다.
+     */
+    @Override
+    @Transactional
+    public List<PushDelivery> claimPendingBatch(int limit, LocalDateTime now) {
+        List<Long> ids = lockClaimableIds(limit, now);
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+
+        markAsProcessing(ids, now);
+        return fetchWithAssociations(ids);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Long> lockClaimableIds(int limit, LocalDateTime now) {
+        return em.createNativeQuery(
+                        "SELECT id FROM push_delivery " +
+                        "WHERE status = 'PENDING' " +
+                        "   OR (status = 'RETRY_WAIT' AND next_attempt_at <= :now) " +
+                        "LIMIT :limit " +
+                        "FOR UPDATE SKIP LOCKED"
+                )
+                .setParameter("now", now)
+                .setParameter("limit", limit)
+                .getResultList();
+    }
+
+    private void markAsProcessing(List<Long> ids, LocalDateTime now) {
+        queryFactory.update(pushDelivery)
+                .set(pushDelivery.status, DeliveryStatus.PROCESSING)
+                .set(pushDelivery.processingStartedAt, now)
+                .where(pushDelivery.id.in(ids))
+                .execute();
+    }
+
+    private List<PushDelivery> fetchWithAssociations(List<Long> ids) {
+        return queryFactory.selectFrom(pushDelivery)
+                .join(pushDelivery.notification).fetchJoin()
+                .join(pushDelivery.pushDevice).fetchJoin()
+                .where(pushDelivery.id.in(ids))
+                .fetch();
+    }
+}

--- a/src/main/java/checkmo/notification/internal/repository/PushDeviceRepository.java
+++ b/src/main/java/checkmo/notification/internal/repository/PushDeviceRepository.java
@@ -1,0 +1,17 @@
+package checkmo.notification.internal.repository;
+
+import checkmo.notification.internal.entity.PushDevice;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
+
+    Optional<PushDevice> findByInstallationId(String installationId);
+
+    Optional<PushDevice> findByInstallationIdAndMemberId(String installationId, String memberId);
+
+    Optional<PushDevice> findByExpoPushToken(String expoPushToken);
+
+    List<PushDevice> findAllByMemberIdAndActiveTrue(String memberId);
+}

--- a/src/main/java/checkmo/notification/internal/repository/PushDeviceRepository.java
+++ b/src/main/java/checkmo/notification/internal/repository/PushDeviceRepository.java
@@ -1,8 +1,10 @@
 package checkmo.notification.internal.repository;
 
 import checkmo.notification.internal.entity.PushDevice;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
@@ -14,4 +16,6 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
     Optional<PushDevice> findByExpoPushToken(String expoPushToken);
 
     List<PushDevice> findAllByMemberIdAndActiveTrue(String memberId);
+
+    List<PushDevice> findAllByActiveFalseAndDeactivatedAtBefore(LocalDateTime threshold, Pageable pageable);
 }

--- a/src/main/java/checkmo/notification/internal/scheduler/PushCleanupScheduler.java
+++ b/src/main/java/checkmo/notification/internal/scheduler/PushCleanupScheduler.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -43,7 +42,6 @@ public class PushCleanupScheduler {
     }
 
     // FK 순서: delivery 먼저 삭제 후 device 삭제
-    @Transactional
     public void deleteExpiredDevices(LocalDateTime threshold) {
         int totalDeleted = 0;
         List<PushDevice> page;
@@ -65,7 +63,6 @@ public class PushCleanupScheduler {
         }
     }
 
-    @Transactional
     public void deleteTerminalDeliveries(LocalDateTime threshold) {
         int totalDeleted = 0;
         List<PushDelivery> page;

--- a/src/main/java/checkmo/notification/internal/scheduler/PushCleanupScheduler.java
+++ b/src/main/java/checkmo/notification/internal/scheduler/PushCleanupScheduler.java
@@ -1,0 +1,88 @@
+package checkmo.notification.internal.scheduler;
+
+import checkmo.notification.internal.entity.DeliveryStatus;
+import checkmo.notification.internal.entity.PushDelivery;
+import checkmo.notification.internal.entity.PushDevice;
+import checkmo.notification.internal.repository.PushDeliveryRepository;
+import checkmo.notification.internal.repository.PushDeviceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PushCleanupScheduler {
+
+    private static final int PAGE_SIZE = 500;
+    private static final int RETENTION_DAYS = 90;
+    private static final List<DeliveryStatus> TERMINAL_STATUSES = List.of(
+            DeliveryStatus.DELIVERED,
+            DeliveryStatus.CANCELLED,
+            DeliveryStatus.PERMANENT_FAILED
+    );
+
+    private final PushDeliveryRepository pushDeliveryRepository;
+    private final PushDeviceRepository pushDeviceRepository;
+
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
+    public void cleanup() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(RETENTION_DAYS);
+        log.info("push 정리 시작: threshold={}", threshold);
+
+        deleteExpiredDevices(threshold);
+        deleteTerminalDeliveries(threshold);
+
+        log.info("push 정리 완료");
+    }
+
+    // FK 순서: delivery 먼저 삭제 후 device 삭제
+    @Transactional
+    public void deleteExpiredDevices(LocalDateTime threshold) {
+        int totalDeleted = 0;
+        List<PushDevice> page;
+
+        do {
+            page = pushDeviceRepository.findAllByActiveFalseAndDeactivatedAtBefore(
+                    threshold, PageRequest.of(0, PAGE_SIZE)
+            );
+            if (page.isEmpty()) break;
+
+            List<Long> deviceIds = page.stream().map(PushDevice::getId).toList();
+            pushDeliveryRepository.deleteAllByPushDeviceIdIn(deviceIds);
+            pushDeviceRepository.deleteAllByIdInBatch(deviceIds);
+            totalDeleted += deviceIds.size();
+        } while (page.size() == PAGE_SIZE);
+
+        if (totalDeleted > 0) {
+            log.info("비활성 device 삭제: {}건", totalDeleted);
+        }
+    }
+
+    @Transactional
+    public void deleteTerminalDeliveries(LocalDateTime threshold) {
+        int totalDeleted = 0;
+        List<PushDelivery> page;
+
+        do {
+            page = pushDeliveryRepository.findTerminalDeliveriesOlderThan(
+                    TERMINAL_STATUSES, threshold, PageRequest.of(0, PAGE_SIZE)
+            );
+            if (page.isEmpty()) break;
+
+            List<Long> ids = page.stream().map(PushDelivery::getId).toList();
+            pushDeliveryRepository.deleteAllByIdInBatch(ids);
+            totalDeleted += ids.size();
+        } while (page.size() == PAGE_SIZE);
+
+        if (totalDeleted > 0) {
+            log.info("만료 delivery 삭제: {}건", totalDeleted);
+        }
+    }
+}

--- a/src/main/java/checkmo/notification/internal/scheduler/PushReceiptScheduler.java
+++ b/src/main/java/checkmo/notification/internal/scheduler/PushReceiptScheduler.java
@@ -1,7 +1,7 @@
 package checkmo.notification.internal.scheduler;
 
-import checkmo.infra.push.ExpoReceipt;
-import checkmo.infra.push.ExpoPushClient;
+import checkmo.infra.PushAPI;
+import checkmo.infra.PushReceiptResult;
 import checkmo.notification.internal.entity.PushDelivery;
 import checkmo.notification.internal.repository.PushDeliveryRepository;
 import checkmo.notification.internal.repository.PushDeviceRepository;
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -23,18 +24,16 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PushReceiptScheduler {
 
-    // Expo receipt API 단일 요청 최대 ticket 수
     private static final int RECEIPT_BATCH_SIZE = 300;
     private static final int PAGE_SIZE = 1000;
     private static final int MAX_ATTEMPTS = 5;
 
     private final PushDeliveryRepository pushDeliveryRepository;
     private final PushDeviceRepository pushDeviceRepository;
-    private final ExpoPushClient expoPushClient;
+    private final PushAPI pushAPI;
 
     @Scheduled(fixedDelay = 900_000)
     public void checkReceipts() {
-        // sentAt 기준 15분 이상 지난 TICKET_ACCEPTED 조회
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime threshold = now.minusMinutes(15);
 
@@ -48,7 +47,7 @@ public class PushReceiptScheduler {
         Map<String, PushDelivery> byTicketId = deliveries.stream()
                 .collect(Collectors.toMap(PushDelivery::getExpoTicketId, d -> d));
 
-        Map<String, ExpoReceipt> receipts = fetchAllReceipts(new ArrayList<>(byTicketId.keySet()));
+        Map<String, PushReceiptResult> receipts = fetchAllReceipts(new ArrayList<>(byTicketId.keySet()));
 
         for (PushDelivery delivery : deliveries) {
             try {
@@ -60,19 +59,17 @@ public class PushReceiptScheduler {
         }
     }
 
-    // Expo 300건 제한에 맞춰 분할 요청 후 결과를 합친다
-    private Map<String, ExpoReceipt> fetchAllReceipts(List<String> ticketIds) {
-        Map<String, ExpoReceipt> result = new java.util.HashMap<>();
+    private Map<String, PushReceiptResult> fetchAllReceipts(List<String> ticketIds) {
+        Map<String, PushReceiptResult> result = new HashMap<>();
         for (int i = 0; i < ticketIds.size(); i += RECEIPT_BATCH_SIZE) {
             List<String> chunk = ticketIds.subList(i, Math.min(i + RECEIPT_BATCH_SIZE, ticketIds.size()));
-            result.putAll(expoPushClient.getReceipts(chunk));
+            result.putAll(pushAPI.getReceipts(chunk));
         }
         return result;
     }
 
-    private void applyReceiptResult(PushDelivery delivery, ExpoReceipt receipt, LocalDateTime now) {
-        if (receipt == null || "pending".equals(receipt.status())) {
-            // receipt 미도착: 24시간 초과 시 만료 처리
+    private void applyReceiptResult(PushDelivery delivery, PushReceiptResult receipt, LocalDateTime now) {
+        if (receipt == null || receipt.isPending()) {
             if (delivery.getSentAt() != null
                     && delivery.getSentAt().plus(Duration.ofHours(24)).isBefore(now)) {
                 delivery.markPermanentFailed("RECEIPT_EXPIRED", "Receipt not arrived within 24 hours");
@@ -86,12 +83,11 @@ public class PushReceiptScheduler {
             pushDeviceRepository.save(delivery.getPushDevice());
             delivery.markCancelled();
         } else if (receipt.isMessageRateExceeded()) {
-            handleRetryOrFail(delivery, receipt.errorCode(), receipt.message());
+            handleRetryOrFail(delivery, receipt.errorCode(), receipt.errorMessage());
         } else if (receipt.isPermanentError()) {
-            delivery.markPermanentFailed(receipt.errorCode(), receipt.message());
+            delivery.markPermanentFailed(receipt.errorCode(), receipt.errorMessage());
         } else {
-            // 알 수 없는 오류 → 재시도
-            handleRetryOrFail(delivery, receipt.errorCode(), receipt.message());
+            handleRetryOrFail(delivery, receipt.errorCode(), receipt.errorMessage());
         }
 
         pushDeliveryRepository.save(delivery);

--- a/src/main/java/checkmo/notification/internal/scheduler/PushReceiptScheduler.java
+++ b/src/main/java/checkmo/notification/internal/scheduler/PushReceiptScheduler.java
@@ -1,0 +1,117 @@
+package checkmo.notification.internal.scheduler;
+
+import checkmo.infra.push.ExpoReceipt;
+import checkmo.infra.push.ExpoPushClient;
+import checkmo.notification.internal.entity.PushDelivery;
+import checkmo.notification.internal.repository.PushDeliveryRepository;
+import checkmo.notification.internal.repository.PushDeviceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PushReceiptScheduler {
+
+    // Expo receipt API 단일 요청 최대 ticket 수
+    private static final int RECEIPT_BATCH_SIZE = 300;
+    private static final int PAGE_SIZE = 1000;
+    private static final int MAX_ATTEMPTS = 5;
+
+    private final PushDeliveryRepository pushDeliveryRepository;
+    private final PushDeviceRepository pushDeviceRepository;
+    private final ExpoPushClient expoPushClient;
+
+    @Scheduled(fixedDelay = 900_000)
+    public void checkReceipts() {
+        // sentAt 기준 15분 이상 지난 TICKET_ACCEPTED 조회
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime threshold = now.minusMinutes(15);
+
+        List<PushDelivery> deliveries = pushDeliveryRepository.findTicketAcceptedOlderThan(
+                threshold, PageRequest.of(0, PAGE_SIZE)
+        );
+        if (deliveries.isEmpty()) {
+            return;
+        }
+
+        Map<String, PushDelivery> byTicketId = deliveries.stream()
+                .collect(Collectors.toMap(PushDelivery::getExpoTicketId, d -> d));
+
+        Map<String, ExpoReceipt> receipts = fetchAllReceipts(new ArrayList<>(byTicketId.keySet()));
+
+        for (PushDelivery delivery : deliveries) {
+            try {
+                applyReceiptResult(delivery, receipts.get(delivery.getExpoTicketId()), now);
+            } catch (Exception e) {
+                log.error("receipt 처리 실패: deliveryId={}, ticketId={}",
+                        delivery.getId(), delivery.getExpoTicketId(), e);
+            }
+        }
+    }
+
+    // Expo 300건 제한에 맞춰 분할 요청 후 결과를 합친다
+    private Map<String, ExpoReceipt> fetchAllReceipts(List<String> ticketIds) {
+        Map<String, ExpoReceipt> result = new java.util.HashMap<>();
+        for (int i = 0; i < ticketIds.size(); i += RECEIPT_BATCH_SIZE) {
+            List<String> chunk = ticketIds.subList(i, Math.min(i + RECEIPT_BATCH_SIZE, ticketIds.size()));
+            result.putAll(expoPushClient.getReceipts(chunk));
+        }
+        return result;
+    }
+
+    private void applyReceiptResult(PushDelivery delivery, ExpoReceipt receipt, LocalDateTime now) {
+        if (receipt == null || "pending".equals(receipt.status())) {
+            // receipt 미도착: 24시간 초과 시 만료 처리
+            if (delivery.getSentAt() != null
+                    && delivery.getSentAt().plus(Duration.ofHours(24)).isBefore(now)) {
+                delivery.markPermanentFailed("RECEIPT_EXPIRED", "Receipt not arrived within 24 hours");
+            } else {
+                delivery.updateReceiptCheckedAt(now);
+            }
+        } else if (receipt.isOk()) {
+            delivery.markDelivered();
+        } else if (receipt.isDeviceNotRegistered()) {
+            delivery.getPushDevice().deactivate();
+            pushDeviceRepository.save(delivery.getPushDevice());
+            delivery.markCancelled();
+        } else if (receipt.isMessageRateExceeded()) {
+            handleRetryOrFail(delivery, receipt.errorCode(), receipt.message());
+        } else if (receipt.isPermanentError()) {
+            delivery.markPermanentFailed(receipt.errorCode(), receipt.message());
+        } else {
+            // 알 수 없는 오류 → 재시도
+            handleRetryOrFail(delivery, receipt.errorCode(), receipt.message());
+        }
+
+        pushDeliveryRepository.save(delivery);
+    }
+
+    private void handleRetryOrFail(PushDelivery delivery, String errorCode, String errorMessage) {
+        if (delivery.getAttemptCount() >= MAX_ATTEMPTS - 1) {
+            delivery.markPermanentFailed(errorCode, errorMessage);
+        } else {
+            delivery.markRetryWait(nextAttemptAt(delivery.getAttemptCount()), errorCode, errorMessage);
+        }
+    }
+
+    private LocalDateTime nextAttemptAt(int attemptCount) {
+        Duration delay = switch (attemptCount) {
+            case 0 -> Duration.ofMinutes(1);
+            case 1 -> Duration.ofMinutes(5);
+            case 2 -> Duration.ofMinutes(15);
+            default -> Duration.ofMinutes(60);
+        };
+        return LocalDateTime.now().plus(delay);
+    }
+}

--- a/src/main/java/checkmo/notification/internal/scheduler/PushSendScheduler.java
+++ b/src/main/java/checkmo/notification/internal/scheduler/PushSendScheduler.java
@@ -1,0 +1,121 @@
+package checkmo.notification.internal.scheduler;
+
+import checkmo.infra.push.ExpoMessage;
+import checkmo.infra.push.ExpoPushClient;
+import checkmo.infra.push.ExpoTicket;
+import checkmo.notification.internal.PushMessageFactory;
+import checkmo.notification.internal.entity.PushDelivery;
+import checkmo.notification.internal.repository.PushDeliveryRepository;
+import checkmo.notification.internal.repository.PushDeviceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PushSendScheduler {
+
+    private static final int BATCH_SIZE = 100;
+    // 5회 시도 후 영구 실패: attemptCount가 이 값에 도달하면 PERMANENT_FAILED
+    private static final int MAX_ATTEMPTS = 5;
+
+    private final PushDeliveryRepository pushDeliveryRepository;
+    private final PushDeviceRepository pushDeviceRepository;
+    private final PushMessageFactory pushMessageFactory;
+    private final ExpoPushClient expoPushClient;
+
+    @Scheduled(fixedDelay = 5_000)
+    public void sendPendingDeliveries() {
+        LocalDateTime now = LocalDateTime.now();
+        List<PushDelivery> batch = pushDeliveryRepository.claimPendingBatch(BATCH_SIZE, now);
+        if (batch.isEmpty()) {
+            return;
+        }
+
+        List<ExpoMessage> messages = buildMessages(batch);
+        List<ExpoTicket> tickets = expoPushClient.sendBatch(messages);
+
+        for (int i = 0; i < batch.size(); i++) {
+            ExpoTicket ticket = (i < tickets.size()) ? tickets.get(i) : null;
+            try {
+                applyTicketResult(batch.get(i), ticket);
+            } catch (Exception e) {
+                log.error("push_delivery 상태 저장 실패: deliveryId={}", batch.get(i).getId(), e);
+            }
+        }
+    }
+
+    // lease 10분 초과 PROCESSING을 RETRY_WAIT으로 복구
+    @Scheduled(fixedDelay = 60_000)
+    public void recoverStaleProcessing() {
+        LocalDateTime leaseExpiry = LocalDateTime.now().minusMinutes(10);
+        List<PushDelivery> stale = pushDeliveryRepository.findStaleProcessing(leaseExpiry);
+
+        for (PushDelivery delivery : stale) {
+            try {
+                handleRetryOrFail(delivery, "STALE_PROCESSING", "Processing lease expired");
+                pushDeliveryRepository.save(delivery);
+            } catch (Exception e) {
+                log.error("stale PROCESSING 복구 실패: deliveryId={}", delivery.getId(), e);
+            }
+        }
+    }
+
+    private List<ExpoMessage> buildMessages(List<PushDelivery> batch) {
+        List<ExpoMessage> messages = new ArrayList<>(batch.size());
+        for (PushDelivery delivery : batch) {
+            try {
+                messages.add(pushMessageFactory.build(delivery, delivery.getNotification()));
+            } catch (Exception e) {
+                log.error("push 메시지 조립 실패: deliveryId={}", delivery.getId(), e);
+                messages.add(null);
+            }
+        }
+        return messages;
+    }
+
+    private void applyTicketResult(PushDelivery delivery, ExpoTicket ticket) {
+        if (ticket == null) {
+            // 메시지 조립 실패 또는 HTTP 오류 → RETRY_WAIT
+            handleRetryOrFail(delivery, "SEND_FAILED", "Expo API request failed or message build error");
+        } else if ("ok".equals(ticket.status())) {
+            delivery.markTicketAccepted(ticket.id());
+        } else if (ticket.isDeviceNotRegistered()) {
+            // device를 비활성화하고 delivery는 CANCELLED
+            delivery.getPushDevice().deactivate();
+            pushDeviceRepository.save(delivery.getPushDevice());
+            delivery.markCancelled();
+        } else {
+            String errorCode = ticket.details() != null ? ticket.details().error() : "UNKNOWN";
+            handleRetryOrFail(delivery, errorCode, ticket.message());
+        }
+
+        pushDeliveryRepository.save(delivery);
+    }
+
+    private void handleRetryOrFail(PushDelivery delivery, String errorCode, String errorMessage) {
+        if (delivery.getAttemptCount() >= MAX_ATTEMPTS - 1) {
+            delivery.markPermanentFailed(errorCode, errorMessage);
+        } else {
+            delivery.markRetryWait(nextAttemptAt(delivery.getAttemptCount()), errorCode, errorMessage);
+        }
+    }
+
+    // attemptCount는 markRetryWait 호출 전 값 (0-based)
+    private LocalDateTime nextAttemptAt(int attemptCount) {
+        Duration delay = switch (attemptCount) {
+            case 0 -> Duration.ofMinutes(1);
+            case 1 -> Duration.ofMinutes(5);
+            case 2 -> Duration.ofMinutes(15);
+            default -> Duration.ofMinutes(60);
+        };
+        return LocalDateTime.now().plus(delay);
+    }
+}

--- a/src/main/java/checkmo/notification/internal/scheduler/PushSendScheduler.java
+++ b/src/main/java/checkmo/notification/internal/scheduler/PushSendScheduler.java
@@ -1,8 +1,8 @@
 package checkmo.notification.internal.scheduler;
 
-import checkmo.infra.push.ExpoMessage;
-import checkmo.infra.push.ExpoPushClient;
-import checkmo.infra.push.ExpoTicket;
+import checkmo.infra.PushAPI;
+import checkmo.infra.PushSendRequest;
+import checkmo.infra.PushSendResult;
 import checkmo.notification.internal.PushMessageFactory;
 import checkmo.notification.internal.entity.PushDelivery;
 import checkmo.notification.internal.repository.PushDeliveryRepository;
@@ -23,13 +23,12 @@ import java.util.List;
 public class PushSendScheduler {
 
     private static final int BATCH_SIZE = 100;
-    // 5회 시도 후 영구 실패: attemptCount가 이 값에 도달하면 PERMANENT_FAILED
     private static final int MAX_ATTEMPTS = 5;
 
     private final PushDeliveryRepository pushDeliveryRepository;
     private final PushDeviceRepository pushDeviceRepository;
     private final PushMessageFactory pushMessageFactory;
-    private final ExpoPushClient expoPushClient;
+    private final PushAPI pushAPI;
 
     @Scheduled(fixedDelay = 5_000)
     public void sendPendingDeliveries() {
@@ -39,20 +38,19 @@ public class PushSendScheduler {
             return;
         }
 
-        List<ExpoMessage> messages = buildMessages(batch);
-        List<ExpoTicket> tickets = expoPushClient.sendBatch(messages);
+        List<PushSendRequest> requests = buildRequests(batch);
+        List<PushSendResult> results = pushAPI.sendBatch(requests);
 
         for (int i = 0; i < batch.size(); i++) {
-            ExpoTicket ticket = (i < tickets.size()) ? tickets.get(i) : null;
+            PushSendResult result = (i < results.size()) ? results.get(i) : null;
             try {
-                applyTicketResult(batch.get(i), ticket);
+                applySendResult(batch.get(i), result);
             } catch (Exception e) {
                 log.error("push_delivery 상태 저장 실패: deliveryId={}", batch.get(i).getId(), e);
             }
         }
     }
 
-    // lease 10분 초과 PROCESSING을 RETRY_WAIT으로 복구
     @Scheduled(fixedDelay = 60_000)
     public void recoverStaleProcessing() {
         LocalDateTime leaseExpiry = LocalDateTime.now().minusMinutes(10);
@@ -68,33 +66,31 @@ public class PushSendScheduler {
         }
     }
 
-    private List<ExpoMessage> buildMessages(List<PushDelivery> batch) {
-        List<ExpoMessage> messages = new ArrayList<>(batch.size());
+    private List<PushSendRequest> buildRequests(List<PushDelivery> batch) {
+        List<PushSendRequest> requests = new ArrayList<>(batch.size());
         for (PushDelivery delivery : batch) {
             try {
-                messages.add(pushMessageFactory.build(delivery, delivery.getNotification()));
+                requests.add(pushMessageFactory.build(delivery, delivery.getNotification()));
             } catch (Exception e) {
                 log.error("push 메시지 조립 실패: deliveryId={}", delivery.getId(), e);
-                messages.add(null);
+                requests.add(null);
             }
         }
-        return messages;
+        return requests;
     }
 
-    private void applyTicketResult(PushDelivery delivery, ExpoTicket ticket) {
-        if (ticket == null) {
-            // 메시지 조립 실패 또는 HTTP 오류 → RETRY_WAIT
+    private void applySendResult(PushDelivery delivery, PushSendResult result) {
+        if (result == null) {
             handleRetryOrFail(delivery, "SEND_FAILED", "Expo API request failed or message build error");
-        } else if ("ok".equals(ticket.status())) {
-            delivery.markTicketAccepted(ticket.id());
-        } else if (ticket.isDeviceNotRegistered()) {
-            // device를 비활성화하고 delivery는 CANCELLED
+        } else if (result.ok()) {
+            delivery.markTicketAccepted(result.ticketId());
+        } else if (result.isDeviceNotRegistered()) {
             delivery.getPushDevice().deactivate();
             pushDeviceRepository.save(delivery.getPushDevice());
             delivery.markCancelled();
         } else {
-            String errorCode = ticket.details() != null ? ticket.details().error() : "UNKNOWN";
-            handleRetryOrFail(delivery, errorCode, ticket.message());
+            String errorCode = result.errorCode() != null ? result.errorCode() : "UNKNOWN";
+            handleRetryOrFail(delivery, errorCode, result.errorMessage());
         }
 
         pushDeliveryRepository.save(delivery);
@@ -108,7 +104,6 @@ public class PushSendScheduler {
         }
     }
 
-    // attemptCount는 markRetryWait 호출 전 값 (0-based)
     private LocalDateTime nextAttemptAt(int attemptCount) {
         Duration delay = switch (attemptCount) {
             case 0 -> Duration.ofMinutes(1);

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
@@ -6,20 +6,23 @@ import checkmo.clubManagement.ClubManagementEvent.JoinClubEvent;
 import checkmo.clubMeeting.ClubMeetingEvent.ClubMeetingCreated;
 import checkmo.clubNotice.ClubNoticeEvent.ClubNoticeCreated;
 import checkmo.member.MemberEvent;
-import java.util.List;
 import checkmo.notification.internal.entity.Notification;
 import checkmo.notification.internal.entity.Notification.NotificationType;
 import checkmo.notification.internal.exception.NotificationErrorStatus;
 import checkmo.notification.internal.exception.NotificationException;
+import checkmo.notification.internal.listener.event.NotificationCreatedForPush;
 import checkmo.notification.internal.repository.NotificationRepository;
 import checkmo.notification.internal.repository.NotificationSettingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +35,7 @@ public class NotificationCommandService {
     private final NotificationSettingRepository notificationSettingRepository;
 
     private final CacheManager cacheManager;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 좋아요 알림 생성
@@ -52,7 +56,8 @@ public class NotificationCommandService {
                 .receiverId(event.receiverId())
                 .build();
         try {
-            notificationRepository.save(notification);
+            Notification saved = notificationRepository.save(notification);
+            eventPublisher.publishEvent(new NotificationCreatedForPush(saved.getId(), event.receiverId()));
             evictNotificationCache(event.receiverId());
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
@@ -78,7 +83,8 @@ public class NotificationCommandService {
                 .receiverId(event.receiverId())
                 .build();
         try {
-            notificationRepository.save(notification);
+            Notification saved = notificationRepository.save(notification);
+            eventPublisher.publishEvent(new NotificationCreatedForPush(saved.getId(), event.receiverId()));
             evictNotificationCache(event.receiverId());
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
@@ -105,7 +111,8 @@ public class NotificationCommandService {
                 .receiverId(event.followingId())
                 .build();
         try {
-            notificationRepository.save(notification);
+            Notification saved = notificationRepository.save(notification);
+            eventPublisher.publishEvent(new NotificationCreatedForPush(saved.getId(), event.followingId()));
             evictNotificationCache(event.followingId());
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
@@ -131,7 +138,8 @@ public class NotificationCommandService {
                 .receiverId(event.memberId())
                 .build();
         try {
-            notificationRepository.save(notification);
+            Notification saved = notificationRepository.save(notification);
+            eventPublisher.publishEvent(new NotificationCreatedForPush(saved.getId(), event.memberId()));
             evictNotificationCache(event.memberId());
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
@@ -182,7 +190,8 @@ public class NotificationCommandService {
                 .receiverId(receiverId)
                 .build();
         try {
-            notificationRepository.save(notification);
+            Notification saved = notificationRepository.save(notification);
+            eventPublisher.publishEvent(new NotificationCreatedForPush(saved.getId(), receiverId));
             evictNotificationCache(receiverId);
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시

--- a/src/main/java/checkmo/notification/internal/service/command/PushDeviceCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/PushDeviceCommandService.java
@@ -67,8 +67,13 @@ public class PushDeviceCommandService {
     }
 
     private void deactivateTokenConflict(String token, String excludeInstallationId) {
+        // saveAndFlush로 즉시 UPDATE를 실행해 token=null을 DB에 반영한 뒤 새 device를 INSERT한다.
+        // 순서를 보장하지 않으면 Hibernate가 INSERT를 먼저 실행하여 UNIQUE 위반이 발생한다.
         pushDeviceRepository.findByExpoPushToken(token)
                 .filter(d -> !d.getInstallationId().equals(excludeInstallationId))
-                .ifPresent(PushDevice::deactivate);
+                .ifPresent(d -> {
+                    d.deactivate();
+                    pushDeviceRepository.saveAndFlush(d);
+                });
     }
 }

--- a/src/main/java/checkmo/notification/internal/service/command/PushDeviceCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/PushDeviceCommandService.java
@@ -1,0 +1,74 @@
+package checkmo.notification.internal.service.command;
+
+import checkmo.notification.internal.entity.PushDevice;
+import checkmo.notification.internal.repository.PushDeviceRepository;
+import checkmo.notification.web.dto.PushDeviceRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PushDeviceCommandService {
+
+    private final PushDeviceRepository pushDeviceRepository;
+
+    public PushDevice upsert(String memberId, PushDeviceRequestDTO request) {
+        String installationId = (request.getInstallationId() != null)
+                ? request.getInstallationId()
+                : UUID.randomUUID().toString();
+        String token = request.getExpoPushToken();
+
+        PushDevice device;
+        var existing = pushDeviceRepository.findByInstallationId(installationId);
+
+        if (existing.isPresent()) {
+            device = existing.get();
+            // token이 바뀐 경우에만 다른 installation에 같은 token이 있는지 확인한다.
+            // token이 동일하면 자기 자신만 존재할 수 있으므로 DB 조회를 생략한다.
+            if (!device.getExpoPushToken().equals(token)) {
+                deactivateTokenConflict(token, installationId);
+            }
+            device.update(token, memberId, request.getPlatform(), request.getAppVersion(), request.getBuildNumber());
+        } else {
+            // 신규 installation이므로 excludeInstallationId를 null로 넘겨 같은 token을 가진 모든 installation을 비활성화한다.
+            deactivateTokenConflict(token, null);
+            device = PushDevice.builder()
+                    .installationId(installationId)
+                    .expoPushToken(token)
+                    .platform(request.getPlatform())
+                    .appVersion(request.getAppVersion())
+                    .buildNumber(request.getBuildNumber())
+                    .memberId(memberId)
+                    .lastRegisteredAt(LocalDateTime.now())
+                    .build();
+            try {
+                pushDeviceRepository.save(device);
+            } catch (DataIntegrityViolationException e) {
+                // 동시 요청으로 같은 installationId가 이미 생성된 경우 재조회 후 갱신
+                device = pushDeviceRepository.findByInstallationId(installationId).orElseThrow();
+                device.update(token, memberId, request.getPlatform(), request.getAppVersion(), request.getBuildNumber());
+            }
+        }
+
+        return device;
+    }
+
+    public void deactivate(String memberId, String installationId) {
+        // 미존재·이미 비활성·타인 소유 모두 성공으로 처리한다
+        pushDeviceRepository.findByInstallationId(installationId)
+                .filter(d -> memberId.equals(d.getMemberId()) && d.isActive())
+                .ifPresent(PushDevice::deactivate);
+    }
+
+    private void deactivateTokenConflict(String token, String excludeInstallationId) {
+        pushDeviceRepository.findByExpoPushToken(token)
+                .filter(d -> !d.getInstallationId().equals(excludeInstallationId))
+                .ifPresent(PushDevice::deactivate);
+    }
+}

--- a/src/main/java/checkmo/notification/package-info.java
+++ b/src/main/java/checkmo/notification/package-info.java
@@ -1,5 +1,4 @@
 @org.springframework.modulith.ApplicationModule(
-        allowedDependencies = {"authentication", "bookStory", "clubManagement", "clubMeeting", "clubNotice", "common",
-                "member"}
+        allowedDependencies = {"authentication", "bookStory", "clubManagement", "clubMeeting", "clubNotice", "common", "member", "infra"}
 )
 package checkmo.notification;

--- a/src/main/java/checkmo/notification/web/controller/NotificationController.java
+++ b/src/main/java/checkmo/notification/web/controller/NotificationController.java
@@ -2,6 +2,8 @@ package checkmo.notification.web.controller;
 
 import checkmo.authentication.CurrentId;
 import checkmo.common.apiPayload.ApiResponse;
+import checkmo.notification.internal.converter.PushDeviceConverter;
+import checkmo.notification.internal.service.command.PushDeviceCommandService;
 import checkmo.notification.web.dto.NotificationSettingType;
 import checkmo.notification.internal.service.NotificationQueryFacade;
 import checkmo.notification.internal.service.command.NotificationCommandService;
@@ -9,14 +11,20 @@ import checkmo.notification.internal.service.command.NotificationSettingCommandS
 import checkmo.notification.web.dto.NotificationResponseDTO.BasicInfoList;
 import checkmo.notification.web.dto.NotificationResponseDTO.BasicInfoPreviewList;
 import checkmo.notification.web.dto.NotificationResponseDTO.SettingInfo;
+import checkmo.notification.web.dto.PushDeviceRequestDTO;
+import checkmo.notification.web.dto.PushDeviceResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,6 +38,38 @@ public class NotificationController {
     private final NotificationQueryFacade notificationQueryFacade;
     private final NotificationCommandService notificationCommandService;
     private final NotificationSettingCommandService notificationSettingCommandService;
+    private final PushDeviceCommandService pushDeviceCommandService;
+
+    @Operation(summary = "푸시 디바이스 등록·갱신",
+            description = "installationId 기준으로 upsert합니다. 같은 token이 다른 설치에 있으면 이전 설치를 비활성화합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "등록 또는 갱신 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @PutMapping("/push-devices")
+    public ApiResponse<PushDeviceResponseDTO> registerPushDevice(
+            @CurrentId String memberId,
+            @RequestBody @Valid PushDeviceRequestDTO request
+    ) {
+        var device = pushDeviceCommandService.upsert(memberId, request);
+        return ApiResponse.onSuccess(PushDeviceConverter.toResponse(device));
+    }
+
+    @Operation(summary = "푸시 디바이스 해제",
+            description = "해당 installationId의 디바이스를 비활성화합니다. 존재하지 않거나 이미 비활성인 경우에도 성공을 반환합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스 입니다.")
+    })
+    @DeleteMapping("/push-devices/{installationId}")
+    public ApiResponse<Void> deregisterPushDevice(
+            @CurrentId String memberId,
+            @PathVariable String installationId
+    ) {
+        pushDeviceCommandService.deactivate(memberId, installationId);
+        return ApiResponse.onSuccess(null);
+    }
 
     @Operation(summary = "알림 전체 조회", description = "특정 회원의 전체 알림을 조회합니다.")
     @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "10")

--- a/src/main/java/checkmo/notification/web/dto/PushDeviceRequestDTO.java
+++ b/src/main/java/checkmo/notification/web/dto/PushDeviceRequestDTO.java
@@ -1,0 +1,43 @@
+package checkmo.notification.web.dto;
+
+import checkmo.notification.internal.entity.PushDevice.PushPlatform;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "푸시 디바이스 등록·갱신 요청")
+public class PushDeviceRequestDTO {
+
+    @Size(max = 36)
+    @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+            message = "UUID 형식이어야 합니다.")
+    @Schema(description = "앱 설치 단위 UUID. null이면 서버가 생성한다.", example = "70cb28d6-1118-4c26-bf14-a73edfde97df", nullable = true)
+    private String installationId;
+
+    @NotBlank
+    @Size(max = 255)
+    @Pattern(regexp = "^(ExponentPushToken|ExpoPushToken)\\[.+\\]$",
+            message = "ExponentPushToken[...] 또는 ExpoPushToken[...] 형식이어야 합니다.")
+    @Schema(description = "Expo Push Token", example = "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]")
+    private String expoPushToken;
+
+    @NotNull
+    @Schema(description = "플랫폼", example = "IOS")
+    private PushPlatform platform;
+
+    @NotBlank
+    @Size(max = 32)
+    @Schema(description = "앱 버전", example = "1.0.1")
+    private String appVersion;
+
+    @NotBlank
+    @Size(max = 32)
+    @Schema(description = "빌드 번호", example = "12")
+    private String buildNumber;
+}

--- a/src/main/java/checkmo/notification/web/dto/PushDeviceResponseDTO.java
+++ b/src/main/java/checkmo/notification/web/dto/PushDeviceResponseDTO.java
@@ -1,0 +1,29 @@
+package checkmo.notification.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "푸시 디바이스 등록·갱신 응답")
+public class PushDeviceResponseDTO {
+
+    @Schema(description = "디바이스 ID", example = "142")
+    private Long deviceId;
+
+    @Schema(description = "설치 UUID (서버 생성 시에도 반환)", example = "70cb28d6-1118-4c26-bf14-a73edfde97df")
+    private String installationId;
+
+    @Schema(description = "활성 여부", example = "true")
+    private boolean active;
+
+    @Schema(description = "등록 일시", example = "2026-06-22T12:00:00")
+    private LocalDateTime registeredAt;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,3 +48,8 @@ realtime:
     allowed-origins:
       - ${FRONTEND_BASE_URL}
       - http://localhost:3000
+
+expo:
+  push:
+    access-token: ${EXPO_ACCESS_TOKEN:}
+    enabled: ${EXPO_PUSH_ENABLED:true}

--- a/src/main/resources/db/migration/V20260702__create_push_device_and_delivery.sql
+++ b/src/main/resources/db/migration/V20260702__create_push_device_and_delivery.sql
@@ -3,7 +3,7 @@ CREATE TABLE push_device
     id                 BIGINT       NOT NULL AUTO_INCREMENT,
     member_id          VARCHAR(255) NOT NULL,
     installation_id    VARCHAR(36)  NOT NULL,
-    expo_push_token    VARCHAR(255) NOT NULL,
+    expo_push_token    VARCHAR(255),
     platform           VARCHAR(20)  NOT NULL,
     app_version        VARCHAR(32)  NOT NULL,
     build_number       VARCHAR(32)  NOT NULL,

--- a/src/main/resources/db/migration/V20260702__create_push_device_and_delivery.sql
+++ b/src/main/resources/db/migration/V20260702__create_push_device_and_delivery.sql
@@ -1,0 +1,46 @@
+CREATE TABLE push_device
+(
+    id                 BIGINT       NOT NULL AUTO_INCREMENT,
+    member_id          VARCHAR(255) NOT NULL,
+    installation_id    VARCHAR(36)  NOT NULL,
+    expo_push_token    VARCHAR(255) NOT NULL,
+    platform           VARCHAR(20)  NOT NULL,
+    app_version        VARCHAR(32)  NOT NULL,
+    build_number       VARCHAR(32)  NOT NULL,
+    active             BIT          NOT NULL DEFAULT 1,
+    last_registered_at DATETIME(6),
+    deactivated_at     DATETIME(6),
+    created_at         DATETIME(6),
+    updated_at         DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_push_device_installation_id UNIQUE (installation_id),
+    CONSTRAINT uk_push_device_expo_push_token UNIQUE (expo_push_token)
+) ENGINE = InnoDB;
+
+CREATE INDEX idx_push_device_member_id ON push_device (member_id);
+
+CREATE TABLE push_delivery
+(
+    id                    BIGINT      NOT NULL AUTO_INCREMENT,
+    notification_id       BIGINT      NOT NULL,
+    push_device_id        BIGINT      NOT NULL,
+    status                VARCHAR(30) NOT NULL,
+    expo_ticket_id        VARCHAR(100),
+    attempt_count         INT         NOT NULL DEFAULT 0,
+    next_attempt_at       DATETIME(6),
+    processing_started_at DATETIME(6),
+    last_error_code       VARCHAR(100),
+    last_error_message    VARCHAR(500),
+    sent_at               DATETIME(6),
+    receipt_checked_at    DATETIME(6),
+    delivered_at          DATETIME(6),
+    created_at            DATETIME(6),
+    updated_at            DATETIME(6),
+    PRIMARY KEY (id),
+    CONSTRAINT uk_push_delivery_notification_device UNIQUE (notification_id, push_device_id),
+    CONSTRAINT fk_push_delivery_notification FOREIGN KEY (notification_id) REFERENCES notification (id),
+    CONSTRAINT fk_push_delivery_push_device FOREIGN KEY (push_device_id) REFERENCES push_device (id)
+) ENGINE = InnoDB;
+
+CREATE INDEX idx_push_delivery_expo_ticket_id ON push_delivery (expo_ticket_id);
+CREATE INDEX idx_push_delivery_next_attempt_at ON push_delivery (next_attempt_at);


### PR DESCRIPTION
## 🚀 변경사항

- 푸시 디바이스 등록/갱신 및 해제 API를 추가했습니다.
  - `PUT /api/v1/notifications/push-devices`
  - `DELETE /api/v1/notifications/push-devices/{installationId}`
- `push_device`, `push_delivery` 테이블과 푸시 발송 상태 모델을 추가했습니다.
- 기존 알림 생성 흐름에서 `NotificationCreatedForPush` 이벤트를 발행하고, 수신자의 활성 디바이스별로 `PushDelivery`를 생성하도록 연결했습니다.
- 알림 타입별 Expo push 메시지 제목/본문/data payload를 조립하는 `PushMessageFactory`를 구현했습니다.
- `PushSendScheduler`를 추가해 대기 중인 푸시를 claim, Expo 발송, ticket 결과 저장, 재시도 상태 전이까지 처리하도록 했습니다.
- `PushReceiptScheduler`를 추가해 Expo receipt 조회 결과를 `DELIVERED`, `CANCELLED`, `RETRY_WAIT`, `PERMANENT_FAILED` 상태로 반영하도록 했습니다.
- `PushCleanupScheduler`를 추가해 90일이 지난 비활성 디바이스와 종료된 delivery 데이터를 정리하도록 했습니다.
- Expo 연동 세부 구현을 `infra.push` 내부로 캡슐화하고, notification 모듈은 `PushAPI` 공개 인터페이스만 의존하도록 정리했습니다.
- Expo 설정을 위한 `EXPO_ACCESS_TOKEN`, `EXPO_PUSH_ENABLED` 환경변수 기반 설정을 추가했습니다.

## 🔗 관련 이슈

- Closes #268

## ✅ 체크리스트

- [ ] 로컬에서 테스트 완료
- [ ] 코드 리뷰 준비 완료

## 📝 특이사항

- 비활성화된 디바이스는 동일 Expo token 재등록 시 UNIQUE 제약에 걸리지 않도록 `expoPushToken`을 `null`로 해제합니다.
- `DeviceNotRegistered` 응답은 디바이스 비활성화 및 delivery 취소로 처리합니다.
- Expo 직접 의존성은 `infra.push.internal`에 숨기고, notification 모듈은 `PushAPI`, `PushSendRequest`, `PushSendResult`, `PushReceiptResult`만 사용합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added push notification delivery support, including sending notifications in batches and checking delivery status.
  * Added push device management so devices can be registered and deregistered from the app.
  * Notification creation now automatically triggers push delivery processing.
* **Bug Fixes**
  * Improved handling for failed or unavailable push deliveries, including retries and device deactivation when a token is no longer valid.
  * Added automatic cleanup of old devices and completed delivery records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->