### PR TITLE
feat(member): 프로필 응답에 소셜 여부 추가

### DIFF
--- a/src/main/java/checkmo/member/internal/converter/MemberConverter.java
+++ b/src/main/java/checkmo/member/internal/converter/MemberConverter.java
@@ -17,7 +17,12 @@ public class MemberConverter {
                 .profileImageUrl(member.getImgUrl())
                 .phoneNumber(member.getPhoneNumber())
                 .categories(member.getInterestCategories())
+                .social(isSocialMember(member))
                 .build();
+    }
+
+    private static boolean isSocialMember(Member member) {
+        return !member.getId().startsWith("LOCAL_");
     }
 
     public static othersDetailInfo toOtherProfile(

--- a/src/main/java/checkmo/member/internal/converter/MemberConverter.java
+++ b/src/main/java/checkmo/member/internal/converter/MemberConverter.java
@@ -17,12 +17,8 @@ public class MemberConverter {
                 .profileImageUrl(member.getImgUrl())
                 .phoneNumber(member.getPhoneNumber())
                 .categories(member.getInterestCategories())
-                .social(isSocialMember(member))
+                .social(member.isSocial())
                 .build();
-    }
-
-    private static boolean isSocialMember(Member member) {
-        return !member.getId().startsWith("LOCAL_");
     }
 
     public static othersDetailInfo toOtherProfile(

--- a/src/main/java/checkmo/member/internal/entity/Member.java
+++ b/src/main/java/checkmo/member/internal/entity/Member.java
@@ -148,4 +148,8 @@ public class Member extends BaseEntity {
     public boolean isActive() {
         return deactivatedAt == null;
     }
+
+    public boolean isSocial() {
+        return !id.startsWith("LOCAL_");
+    }
 }

--- a/src/main/java/checkmo/member/web/dto/MemberResponseDTO.java
+++ b/src/main/java/checkmo/member/web/dto/MemberResponseDTO.java
@@ -1,13 +1,13 @@
 package checkmo.member.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import checkmo.member.internal.entity.MemberInterestCategory;
+import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
-import java.util.Set;
 
 public class MemberResponseDTO {
 
@@ -61,6 +61,8 @@ public class MemberResponseDTO {
         private String profileImageUrl;
         private String phoneNumber;
         private Set<MemberInterestCategory> categories;
+        @JsonProperty("isSocial")
+        private boolean social;
     }
 
     @Getter

--- a/src/main/java/checkmo/member/web/dto/MemberResponseDTO.java
+++ b/src/main/java/checkmo/member/web/dto/MemberResponseDTO.java
@@ -1,6 +1,5 @@
 package checkmo.member.web.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import checkmo.member.internal.entity.MemberInterestCategory;
 import java.util.List;
 import java.util.Set;
@@ -61,7 +60,6 @@ public class MemberResponseDTO {
         private String profileImageUrl;
         private String phoneNumber;
         private Set<MemberInterestCategory> categories;
-        @JsonProperty("isSocial")
         private boolean social;
     }
 

--- a/src/test/java/checkmo/member/MemberApiTest.java
+++ b/src/test/java/checkmo/member/MemberApiTest.java
@@ -343,7 +343,8 @@ class MemberApiTest extends ApiTestSupport {
                 .get("/api/v1/members/me")
                 .then()
                 .statusCode(200)
-                .body("isSuccess", equalTo(true));
+                .body("isSuccess", equalTo(true))
+                .body("result.isSocial", equalTo(false));
 
         given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -419,6 +420,20 @@ class MemberApiTest extends ApiTestSupport {
                 .statusCode(200)
                 .body("isSuccess", equalTo(true))
                 .body("result.nickname", equalTo(user.nickName()));
+    }
+
+    @Test
+    void 소셜_회원_프로필_조회는_소셜_로그인_여부를_반환한다() {
+        TestUser user = createSocialUser();
+
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .get("/api/v1/members/me")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true))
+                .body("result.isSocial", equalTo(true));
     }
 
     @Test

--- a/src/test/java/checkmo/member/MemberApiTest.java
+++ b/src/test/java/checkmo/member/MemberApiTest.java
@@ -344,7 +344,7 @@ class MemberApiTest extends ApiTestSupport {
                 .then()
                 .statusCode(200)
                 .body("isSuccess", equalTo(true))
-                .body("result.isSocial", equalTo(false));
+                .body("result.social", equalTo(false));
 
         given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -433,7 +433,7 @@ class MemberApiTest extends ApiTestSupport {
                 .then()
                 .statusCode(200)
                 .body("isSuccess", equalTo(true))
-                .body("result.isSocial", equalTo(true));
+                .body("result.social", equalTo(true));
     }
 
     @Test

--- a/src/test/java/checkmo/support/ApiTestSupport.java
+++ b/src/test/java/checkmo/support/ApiTestSupport.java
@@ -237,6 +237,10 @@ public abstract class ApiTestSupport {
         return createUser(Role.USER, false);
     }
 
+    protected TestUser createSocialUser() {
+        return createUser(Role.USER, true, "Pass123!", "KAKAO_");
+    }
+
     protected TestUser createAdmin() {
         return createUser(Role.ADMIN, true);
     }
@@ -252,8 +256,17 @@ public abstract class ApiTestSupport {
     private TestUser createUser(Role role, boolean profileCompleted, String rawPassword) {
         String suffix = UUID.randomUUID().toString().substring(0, 8);
         String id = role == Role.USER ? "LOCAL_" + suffix : role.name().toLowerCase() + "-" + suffix;
+        return createUserWithId(role, profileCompleted, rawPassword, id);
+    }
+
+    private TestUser createUser(Role role, boolean profileCompleted, String rawPassword, String idPrefix) {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        return createUserWithId(role, profileCompleted, rawPassword, idPrefix + suffix);
+    }
+
+    private TestUser createUserWithId(Role role, boolean profileCompleted, String rawPassword, String id) {
         String email = id + "@example.com";
-        String nickName = role.name().toLowerCase() + suffix;
+        String nickName = role.name().toLowerCase() + id.substring(Math.max(0, id.length() - 8));
 
         AuthUser authUser = AuthUser.builder()
                 .id(id)


### PR DESCRIPTION
## 요약
- `GET /api/v1/members/me` 응답 `result`에 `isSocial` 필드를 추가했습니다.
- 기존 계정 id 정책에 맞춰 `LOCAL_`로 시작하지 않는 회원을 소셜 회원으로 판단합니다.
- 로컬 회원은 `false`, 소셜 형태 회원은 `true`를 반환하도록 API 테스트를 추가했습니다.

Closes #276

## 검증
- [x] `./gradlew test --tests checkmo.member.MemberApiTest`
- [x] `./gradlew test --tests checkmo.CheckmoApplicationTests`
- [x] `./gradlew test`

## 비고
- standalone `bootRun` + `curl` QA는 수행하지 않았습니다. H2가 `testRuntimeOnly`라 test profile 서버를 일반 bootRun으로 띄우는 경로가 런타임 의존성과 맞지 않아, 기존 표준인 random-port Spring Boot + RestAssured API 테스트로 HTTP surface를 검증했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Member profile responses now include an `isSocial` flag to indicate whether an account is social or local.

* **Bug Fixes**
  * Social membership is now identified more consistently in profile data.
  * Profile API responses now serialize the social-status field with the expected `isSocial` name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->