### PR TITLE
refactor: 회원 인증 식별자 BIGINT 전환

### DIFF
--- a/docs/member_auth_bigint_identity_migration.md
+++ b/docs/member_auth_bigint_identity_migration.md
@@ -2,7 +2,7 @@
 
 ## 목적과 불변조건
 
-이 문서는 기존 provider-shaped 문자열 식별자(`LOCAL_*`, `GOOGLE_*`, `APPLE_*`, `KAKAO_*`)를 내부 숫자 식별자로 전환하기 위한 운영 preflight, rollout, rollback 절차이다.
+이 문서는 기존 provider-shaped 문자열 식별자(`LOCAL_*`, `GOOGLE_*`, `APPLE_*`, `KAKAO_*`, `NAVER_*`)를 내부 숫자 식별자로 전환하기 위한 운영 preflight, rollout, rollback 절차이다.
 
 - `auth_user.id`만 `BIGINT` 생성 원천이다.
 - `member.id`는 `auth_user.id`와 같은 값을 할당받아 공유한다.
@@ -228,6 +228,7 @@ WITH parsed_auth AS (
        OR id LIKE 'GOOGLE\_%'
        OR id LIKE 'APPLE\_%'
        OR id LIKE 'KAKAO\_%'
+       OR id LIKE 'NAVER\_%'
 )
 SELECT
     provider,
@@ -277,6 +278,15 @@ SELECT
 FROM auth_user
 WHERE id LIKE 'KAKAO\_%'
 GROUP BY SUBSTRING(id, LOCATE('_', id) + 1)
+HAVING COUNT(*) > 1
+UNION ALL
+SELECT
+    'NAVER' AS provider,
+    SUBSTRING(id, LOCATE('_', id) + 1) AS provider_user_id,
+    COUNT(*) AS duplicate_count
+FROM auth_user
+WHERE id LIKE 'NAVER\_%'
+GROUP BY SUBSTRING(id, LOCATE('_', id) + 1)
 HAVING COUNT(*) > 1;
 ```
 
@@ -291,7 +301,7 @@ SELECT
     COUNT(*) AS row_count
 FROM auth_user
 WHERE LOCATE('_', id) = 0
-   OR SUBSTRING_INDEX(id, '_', 1) NOT IN ('LOCAL', 'GOOGLE', 'APPLE', 'KAKAO')
+   OR SUBSTRING_INDEX(id, '_', 1) NOT IN ('LOCAL', 'GOOGLE', 'APPLE', 'KAKAO', 'NAVER')
 GROUP BY legacy_prefix
 ORDER BY row_count DESC, legacy_prefix;
 ```
@@ -373,6 +383,15 @@ ORDER BY b.table_name;
 7. post-cutover validation SQL을 실행한다.
 8. refresh token 저장소를 token invalidation checklist에 따라 처리한다.
 9. smoke test가 끝날 때까지 외부 트래픽을 재개하지 않는다.
+
+## Module boundary decision
+
+회원 프로필 응답의 `social` 여부는 `member` 테이블에 중복 저장하지 않고 `authentication` 모듈의 public `AuthenticationAPI.fetchProvider(memberId)`로 조회한다.
+
+- `member` 모듈은 `package-info.java`에서 `authentication` public API 의존을 명시적으로 허용한다.
+- `member` 모듈은 `authentication.internal` 또는 `authentication.web` 패키지를 직접 참조하지 않는다.
+- provider 값은 로그인 식별자 원천인 `auth_user.provider`에만 저장해 이벤트 지연이나 캐시 불일치로 프로필의 `social` 값이 엇갈리는 상황을 피한다.
+- provider 조회 실패는 회원 프로필 조회 실패로 취급한다. `auth_user`와 `member`의 1:1 정합성은 preflight와 post-cutover validation의 중단 조건이다.
 
 ## Token invalidation checklist
 
@@ -559,7 +578,7 @@ rollback은 smoke 실패가 외부 트래픽 재개 전에 발견된 경우 즉�
 - auth/member one-to-one mismatch가 1건 이상이다.
 - member reference orphan이 1건 이상이다.
 - provider/provider_user_id duplicate가 1건 이상이다.
-- `LOCAL`, `GOOGLE`, `APPLE`, `KAKAO` 외 prefix 또는 `_` 없는 legacy id가 존재한다.
+- `LOCAL`, `GOOGLE`, `APPLE`, `KAKAO`, `NAVER` 외 prefix 또는 `_` 없는 legacy id가 존재한다.
 - `auth_user.id`와 `member.id`가 독립 생성될 수 있는 migration 설계가 발견된다.
 - target schema에 `auth_user.member_id` 또는 `member.auth_user_id`가 추가된다.
 - backup/snapshot 생성 여부가 확인되지 않는다.

--- a/docs/member_auth_bigint_identity_migration.md
+++ b/docs/member_auth_bigint_identity_migration.md
@@ -77,7 +77,7 @@ LIMIT 50;
 
 ### orphan member reference checks
 
-모든 member reference column은 cutover 전에 `member.id`에 매칭되어야 한다. nullable column은 `NULL`을 orphan으로 보지 않는다.
+모든 member reference column은 cutover 전에 `member.id`에 매칭되어야 한다. nullable column은 `NULL`을 orphan으로 보지 않는다. `notification.sender_id = 'SYSTEM'`은 시스템 발신자를 뜻하므로 preflight orphan으로 보지 않고, cutover 후 `NULL`로 변환한다.
 
 ```sql
 SELECT 'member_interest_categories.member_id' AS reference_column, COUNT(*) AS orphan_count
@@ -128,7 +128,7 @@ UNION ALL
 SELECT 'notification.sender_id', COUNT(*)
 FROM notification r
 LEFT JOIN member m ON m.id = r.sender_id
-WHERE r.sender_id IS NOT NULL AND m.id IS NULL
+WHERE r.sender_id IS NOT NULL AND r.sender_id <> 'SYSTEM' AND m.id IS NULL
 UNION ALL
 SELECT 'topic.member_id', COUNT(*)
 FROM topic r
@@ -332,7 +332,7 @@ ORDER BY b.table_name;
 6. 새 Flyway migration과 애플리케이션 코드를 같은 배포 단위로 반영한다.
 7. migration은 `member_identity_map`을 생성해 old legacy id와 new bigint id 매핑을 고정해야 한다.
 8. migration은 `auth_user.legacy_id`, `member.legacy_id`, `auth_user.provider`, `auth_user.provider_user_id`를 채우고 `UNIQUE(provider, provider_user_id)`를 생성해야 한다.
-9. 모든 member reference column을 `member_identity_map`으로 `BIGINT`에 backfill한 뒤 FK와 unique index를 다시 검증한다.
+9. 모든 member reference column을 `member_identity_map`으로 `BIGINT`에 backfill한 뒤 FK와 unique index를 다시 검증한다. `notification.sender_id = 'SYSTEM'`은 nullable `BIGINT` 컬럼의 `NULL`로 변환한다.
 10. refresh token 저장소는 기존 문자열 subject 기반 key를 제거하거나 만료되도록 둔다. 재로그인 후 numeric subject 기반 token만 유효해야 한다.
 11. smoke test가 끝날 때까지 외부 트래픽을 재개하지 않는다.
 
@@ -400,6 +400,8 @@ WHERE table_schema = DATABASE()
   )
 ORDER BY table_name, column_name;
 ```
+
+`notification.receiver_id`는 `BIGINT NOT NULL`, `notification.sender_id`는 시스템 발신자를 표현하기 위해 `BIGINT NULL`이어야 한다.
 
 ### post-cutover FK validation
 

--- a/docs/member_auth_bigint_identity_migration.md
+++ b/docs/member_auth_bigint_identity_migration.md
@@ -1,0 +1,488 @@
+# 회원 인증 BIGINT 식별자 마이그레이션 runbook
+
+## 목적과 불변조건
+
+이 문서는 기존 provider-shaped 문자열 식별자(`LOCAL_*`, `GOOGLE_*`, `APPLE_*`, `KAKAO_*`)를 내부 숫자 식별자로 전환하기 위한 운영 preflight, rollout, rollback 절차이다.
+
+- `auth_user.id`만 `BIGINT` 생성 원천이다.
+- `member.id`는 `auth_user.id`와 같은 값을 할당받아 공유한다.
+- target schema에 `auth_user.member_id` 또는 `member.auth_user_id`를 추가하지 않는다.
+- 기존 문자열 ID는 `auth_user.legacy_id`, `member.legacy_id`에 보존한다.
+- `auth_user.provider`, `auth_user.provider_user_id`, `UNIQUE(provider, provider_user_id)`를 추가한다.
+- cutover 시 기존 access token과 refresh token은 무효화한다. 사용자는 재로그인해야 한다.
+- PR #275 push notification 병합분의 `push_device.member_id`도 같은 전환 범위에 포함한다.
+
+## secret handling
+
+운영자가 이 문서로 작업할 때도 secret-bearing 값을 읽거나 기록하지 않는다.
+
+- `.env`, AWS credentials, RDS_PASSWORD, AWS_ACCESS_KEY, AWS_SECRET, JWT_SECRET, OAuth secret, GitHub secret 값을 읽지 않는다.
+- 터미널, 문서, PR, 이슈, 로그, evidence 파일에 credential, endpoint URL, host name, token 값을 붙여 넣지 않는다.
+- DB 접속은 운영자가 이미 승인된 secret manager 또는 사내 접속 절차로 수행하고, 이 runbook에는 접속 문자열을 기록하지 않는다.
+- preflight와 smoke output은 aggregate/count 또는 필요한 진단 컬럼만 남긴다. 인증 secret 컬럼 값은 출력하지 않는다.
+
+## 사전 운영 조건
+
+- maintenance window를 공지하고 쓰기 트래픽을 중지할 수 있는 시간을 확보한다.
+- 마이그레이션과 애플리케이션 코드는 같은 cutover 배포 단위로 준비한다.
+- 운영 반영 전 local MySQL 또는 staging-equivalent DB에서 Flyway dry-run을 완료한다.
+- RDS snapshot 또는 동등한 point-in-time restore 가능한 backup을 생성한다.
+- rollback은 migration 역실행이 아니라 snapshot restore 기준으로 수행한다.
+- preflight query 결과가 모두 0건 또는 기대 count 일치일 때만 진행한다.
+
+## Preflight SQL
+
+아래 SQL은 기존 문자열 식별자 schema에서 실행한다. 결과 count가 0이 아니면 cutover를 중단하고 데이터를 먼저 정리한다.
+
+### auth/member one-to-one mismatch
+
+```sql
+SELECT
+    'auth_without_member' AS check_name,
+    COUNT(*) AS mismatch_count
+FROM auth_user au
+LEFT JOIN member m ON m.id = au.id
+WHERE m.id IS NULL;
+
+SELECT
+    'member_without_auth' AS check_name,
+    COUNT(*) AS mismatch_count
+FROM member m
+LEFT JOIN auth_user au ON au.id = m.id
+WHERE au.id IS NULL;
+```
+
+진단이 필요할 때만 제한된 컬럼으로 샘플을 확인한다.
+
+```sql
+SELECT
+    au.id AS auth_legacy_id,
+    au.email AS auth_email
+FROM auth_user au
+LEFT JOIN member m ON m.id = au.id
+WHERE m.id IS NULL
+ORDER BY au.id
+LIMIT 50;
+
+SELECT
+    m.id AS member_legacy_id,
+    m.email AS member_email,
+    m.nick_name AS member_nickname
+FROM member m
+LEFT JOIN auth_user au ON au.id = m.id
+WHERE au.id IS NULL
+ORDER BY m.id
+LIMIT 50;
+```
+
+### orphan member reference checks
+
+모든 member reference column은 cutover 전에 `member.id`에 매칭되어야 한다. nullable column은 `NULL`을 orphan으로 보지 않는다.
+
+```sql
+SELECT 'member_interest_categories.member_id' AS reference_column, COUNT(*) AS orphan_count
+FROM member_interest_categories r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'book_review.member_id', COUNT(*)
+FROM book_review r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'book_story.member_id', COUNT(*)
+FROM book_story r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'book_story_liked.member_id', COUNT(*)
+FROM book_story_liked r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'club_member.member_id', COUNT(*)
+FROM club_member r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'comment.member_id', COUNT(*)
+FROM comment r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'follow.follower_id', COUNT(*)
+FROM follow r
+LEFT JOIN member m ON m.id = r.follower_id
+WHERE r.follower_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'follow.following_id', COUNT(*)
+FROM follow r
+LEFT JOIN member m ON m.id = r.following_id
+WHERE r.following_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'notification.receiver_id', COUNT(*)
+FROM notification r
+LEFT JOIN member m ON m.id = r.receiver_id
+WHERE r.receiver_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'notification.sender_id', COUNT(*)
+FROM notification r
+LEFT JOIN member m ON m.id = r.sender_id
+WHERE r.sender_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'topic.member_id', COUNT(*)
+FROM topic r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'notification_setting.member_id', COUNT(*)
+FROM notification_setting r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'member_terms.member_id', COUNT(*)
+FROM member_terms r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'book_liked.member_id', COUNT(*)
+FROM book_liked r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'member_block.blocker_id', COUNT(*)
+FROM member_block r
+LEFT JOIN member m ON m.id = r.blocker_id
+WHERE r.blocker_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'member_block.blocked_id', COUNT(*)
+FROM member_block r
+LEFT JOIN member m ON m.id = r.blocked_id
+WHERE r.blocked_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'report.reporter_id', COUNT(*)
+FROM report r
+LEFT JOIN member m ON m.id = r.reporter_id
+WHERE r.reporter_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'team_chat_message.sender_member_id', COUNT(*)
+FROM team_chat_message r
+LEFT JOIN member m ON m.id = r.sender_member_id
+WHERE r.sender_member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'push_device.member_id', COUNT(*)
+FROM push_device r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL;
+```
+
+orphan 샘플이 필요하면 아래 패턴을 column별로 실행한다.
+
+```sql
+SELECT
+    r.id AS row_id,
+    r.member_id AS legacy_member_id
+FROM push_device r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+ORDER BY r.id
+LIMIT 50;
+```
+
+### provider parse checks
+
+`provider_user_id`는 첫 번째 `_` 뒤의 나머지 문자열이다. 같은 provider와 provider user id 조합이 2건 이상이면 `UNIQUE(provider, provider_user_id)` 생성 전에 중단한다.
+
+```sql
+WITH parsed_auth AS (
+    SELECT
+        id AS legacy_id,
+        SUBSTRING_INDEX(id, '_', 1) AS provider,
+        SUBSTRING(id, LOCATE('_', id) + 1) AS provider_user_id
+    FROM auth_user
+    WHERE id LIKE 'LOCAL\_%'
+       OR id LIKE 'GOOGLE\_%'
+       OR id LIKE 'APPLE\_%'
+       OR id LIKE 'KAKAO\_%'
+)
+SELECT
+    provider,
+    provider_user_id,
+    COUNT(*) AS duplicate_count
+FROM parsed_auth
+GROUP BY provider, provider_user_id
+HAVING COUNT(*) > 1
+ORDER BY duplicate_count DESC, provider, provider_user_id
+LIMIT 100;
+```
+
+provider별로 별도 검증이 필요하면 아래 SQL을 provider 값만 바꿔 반복한다.
+
+```sql
+SELECT
+    'LOCAL' AS provider,
+    SUBSTRING(id, LOCATE('_', id) + 1) AS provider_user_id,
+    COUNT(*) AS duplicate_count
+FROM auth_user
+WHERE id LIKE 'LOCAL\_%'
+GROUP BY SUBSTRING(id, LOCATE('_', id) + 1)
+HAVING COUNT(*) > 1
+UNION ALL
+SELECT
+    'GOOGLE' AS provider,
+    SUBSTRING(id, LOCATE('_', id) + 1) AS provider_user_id,
+    COUNT(*) AS duplicate_count
+FROM auth_user
+WHERE id LIKE 'GOOGLE\_%'
+GROUP BY SUBSTRING(id, LOCATE('_', id) + 1)
+HAVING COUNT(*) > 1
+UNION ALL
+SELECT
+    'APPLE' AS provider,
+    SUBSTRING(id, LOCATE('_', id) + 1) AS provider_user_id,
+    COUNT(*) AS duplicate_count
+FROM auth_user
+WHERE id LIKE 'APPLE\_%'
+GROUP BY SUBSTRING(id, LOCATE('_', id) + 1)
+HAVING COUNT(*) > 1
+UNION ALL
+SELECT
+    'KAKAO' AS provider,
+    SUBSTRING(id, LOCATE('_', id) + 1) AS provider_user_id,
+    COUNT(*) AS duplicate_count
+FROM auth_user
+WHERE id LIKE 'KAKAO\_%'
+GROUP BY SUBSTRING(id, LOCATE('_', id) + 1)
+HAVING COUNT(*) > 1;
+```
+
+예상하지 않은 prefix 또는 `_`가 없는 legacy id는 중단 조건이다.
+
+```sql
+SELECT
+    CASE
+        WHEN LOCATE('_', id) = 0 THEN '(missing_separator)'
+        ELSE SUBSTRING_INDEX(id, '_', 1)
+    END AS legacy_prefix,
+    COUNT(*) AS row_count
+FROM auth_user
+WHERE LOCATE('_', id) = 0
+   OR SUBSTRING_INDEX(id, '_', 1) NOT IN ('LOCAL', 'GOOGLE', 'APPLE', 'KAKAO')
+GROUP BY legacy_prefix
+ORDER BY row_count DESC, legacy_prefix;
+```
+
+### row-count baseline
+
+마이그레이션 전후에 같은 table count를 비교한다. 운영에서는 결과를 안전한 작업 로그에 저장하되 credential과 endpoint는 포함하지 않는다.
+
+```sql
+SELECT 'auth_user' AS table_name, COUNT(*) AS row_count FROM auth_user
+UNION ALL SELECT 'member', COUNT(*) FROM member
+UNION ALL SELECT 'member_interest_categories', COUNT(*) FROM member_interest_categories
+UNION ALL SELECT 'book_review', COUNT(*) FROM book_review
+UNION ALL SELECT 'book_story', COUNT(*) FROM book_story
+UNION ALL SELECT 'book_story_liked', COUNT(*) FROM book_story_liked
+UNION ALL SELECT 'club_member', COUNT(*) FROM club_member
+UNION ALL SELECT 'comment', COUNT(*) FROM comment
+UNION ALL SELECT 'follow', COUNT(*) FROM follow
+UNION ALL SELECT 'notification', COUNT(*) FROM notification
+UNION ALL SELECT 'topic', COUNT(*) FROM topic
+UNION ALL SELECT 'notification_setting', COUNT(*) FROM notification_setting
+UNION ALL SELECT 'member_terms', COUNT(*) FROM member_terms
+UNION ALL SELECT 'book_liked', COUNT(*) FROM book_liked
+UNION ALL SELECT 'member_block', COUNT(*) FROM member_block
+UNION ALL SELECT 'report', COUNT(*) FROM report
+UNION ALL SELECT 'team_chat_message', COUNT(*) FROM team_chat_message
+UNION ALL SELECT 'push_device', COUNT(*) FROM push_device;
+```
+
+dry-run에서 같은 DB session으로 비교할 수 있으면 임시 테이블을 사용한다.
+
+```sql
+CREATE TEMPORARY TABLE member_auth_bigint_row_counts_before AS
+SELECT 'auth_user' AS table_name, COUNT(*) AS row_count FROM auth_user
+UNION ALL SELECT 'member', COUNT(*) FROM member
+UNION ALL SELECT 'push_device', COUNT(*) FROM push_device;
+
+-- Flyway migration 실행 후 같은 session에서:
+CREATE TEMPORARY TABLE member_auth_bigint_row_counts_after AS
+SELECT 'auth_user' AS table_name, COUNT(*) AS row_count FROM auth_user
+UNION ALL SELECT 'member', COUNT(*) FROM member
+UNION ALL SELECT 'push_device', COUNT(*) FROM push_device;
+
+SELECT
+    b.table_name,
+    b.row_count AS before_count,
+    a.row_count AS after_count,
+    a.row_count - b.row_count AS delta_count
+FROM member_auth_bigint_row_counts_before b
+JOIN member_auth_bigint_row_counts_after a ON a.table_name = b.table_name
+WHERE a.row_count <> b.row_count
+ORDER BY b.table_name;
+```
+
+## Rollout order
+
+1. maintenance window 시작을 공지하고 신규 쓰기 요청과 batch/scheduler 실행을 중지한다.
+2. RDS snapshot 또는 동등한 backup을 생성하고 snapshot 식별자만 내부 운영 기록에 남긴다.
+3. 기존 token은 cutover 후 무효화된다고 공지한다.
+4. 위 preflight SQL을 실행한다. mismatch, orphan, duplicate provider identity, unknown prefix 결과가 있으면 중단한다.
+5. row-count baseline을 캡처한다.
+6. 새 Flyway migration과 애플리케이션 코드를 같은 배포 단위로 반영한다.
+7. migration은 `member_identity_map`을 생성해 old legacy id와 new bigint id 매핑을 고정해야 한다.
+8. migration은 `auth_user.legacy_id`, `member.legacy_id`, `auth_user.provider`, `auth_user.provider_user_id`를 채우고 `UNIQUE(provider, provider_user_id)`를 생성해야 한다.
+9. 모든 member reference column을 `member_identity_map`으로 `BIGINT`에 backfill한 뒤 FK와 unique index를 다시 검증한다.
+10. refresh token 저장소는 기존 문자열 subject 기반 key를 제거하거나 만료되도록 둔다. 재로그인 후 numeric subject 기반 token만 유효해야 한다.
+11. smoke test가 끝날 때까지 외부 트래픽을 재개하지 않는다.
+
+## Post-cutover validation SQL
+
+아래 SQL은 target schema 적용 후 실행한다.
+
+### core identity and provider validation
+
+```sql
+SELECT
+    'auth_member_shared_bigint_id' AS check_name,
+    COUNT(*) AS mismatch_count
+FROM auth_user au
+LEFT JOIN member m ON m.id = au.id
+WHERE m.id IS NULL;
+
+SELECT
+    'member_without_auth_after_cutover' AS check_name,
+    COUNT(*) AS mismatch_count
+FROM member m
+LEFT JOIN auth_user au ON au.id = m.id
+WHERE au.id IS NULL;
+
+SELECT
+    'provider_identity_duplicate_after_cutover' AS check_name,
+    COUNT(*) AS duplicate_group_count
+FROM (
+    SELECT provider, provider_user_id
+    FROM auth_user
+    GROUP BY provider, provider_user_id
+    HAVING COUNT(*) > 1
+) duplicated_provider_identity;
+```
+
+### column type validation
+
+```sql
+SELECT
+    table_name,
+    column_name,
+    data_type,
+    column_type
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND (
+      (table_name = 'auth_user' AND column_name IN ('id', 'legacy_id', 'provider', 'provider_user_id'))
+      OR (table_name = 'member' AND column_name IN ('id', 'legacy_id'))
+      OR (table_name = 'member_interest_categories' AND column_name = 'member_id')
+      OR (table_name = 'book_review' AND column_name = 'member_id')
+      OR (table_name = 'book_story' AND column_name = 'member_id')
+      OR (table_name = 'book_story_liked' AND column_name = 'member_id')
+      OR (table_name = 'club_member' AND column_name = 'member_id')
+      OR (table_name = 'comment' AND column_name = 'member_id')
+      OR (table_name = 'follow' AND column_name IN ('follower_id', 'following_id'))
+      OR (table_name = 'notification' AND column_name IN ('receiver_id', 'sender_id'))
+      OR (table_name = 'topic' AND column_name = 'member_id')
+      OR (table_name = 'notification_setting' AND column_name = 'member_id')
+      OR (table_name = 'member_terms' AND column_name = 'member_id')
+      OR (table_name = 'book_liked' AND column_name = 'member_id')
+      OR (table_name = 'member_block' AND column_name IN ('blocker_id', 'blocked_id'))
+      OR (table_name = 'report' AND column_name = 'reporter_id')
+      OR (table_name = 'team_chat_message' AND column_name = 'sender_member_id')
+      OR (table_name = 'push_device' AND column_name = 'member_id')
+  )
+ORDER BY table_name, column_name;
+```
+
+### post-cutover FK validation
+
+```sql
+SELECT
+    table_name,
+    column_name,
+    referenced_table_name,
+    referenced_column_name,
+    constraint_name
+FROM information_schema.key_column_usage
+WHERE table_schema = DATABASE()
+  AND referenced_table_name = 'member'
+  AND referenced_column_name = 'id'
+  AND (
+      (table_name = 'member_interest_categories' AND column_name = 'member_id')
+      OR (table_name = 'book_review' AND column_name = 'member_id')
+      OR (table_name = 'book_story' AND column_name = 'member_id')
+      OR (table_name = 'book_story_liked' AND column_name = 'member_id')
+      OR (table_name = 'club_member' AND column_name = 'member_id')
+      OR (table_name = 'comment' AND column_name = 'member_id')
+      OR (table_name = 'follow' AND column_name IN ('follower_id', 'following_id'))
+      OR (table_name = 'notification' AND column_name IN ('receiver_id', 'sender_id'))
+      OR (table_name = 'topic' AND column_name = 'member_id')
+      OR (table_name = 'notification_setting' AND column_name = 'member_id')
+      OR (table_name = 'member_terms' AND column_name = 'member_id')
+      OR (table_name = 'book_liked' AND column_name = 'member_id')
+      OR (table_name = 'member_block' AND column_name IN ('blocker_id', 'blocked_id'))
+      OR (table_name = 'report' AND column_name = 'reporter_id')
+      OR (table_name = 'team_chat_message' AND column_name = 'sender_member_id')
+      OR (table_name = 'push_device' AND column_name = 'member_id')
+  )
+ORDER BY table_name, column_name;
+```
+
+FK가 있어도 변환 누락이 없는지 anti-join으로 한 번 더 확인한다.
+
+```sql
+SELECT 'push_device.member_id' AS reference_column, COUNT(*) AS orphan_count
+FROM push_device r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'report.reporter_id', COUNT(*)
+FROM report r
+LEFT JOIN member m ON m.id = r.reporter_id
+WHERE r.reporter_id IS NOT NULL AND m.id IS NULL
+UNION ALL
+SELECT 'team_chat_message.sender_member_id', COUNT(*)
+FROM team_chat_message r
+LEFT JOIN member m ON m.id = r.sender_member_id
+WHERE r.sender_member_id IS NOT NULL AND m.id IS NULL;
+```
+
+## Smoke checklist
+
+- `/health`가 정상 응답한다.
+- 기존 token으로 인증 API를 호출하면 실패하고, 재로그인 후 새 token으로 성공한다.
+- 로그인 후 내 프로필 조회에서 numeric member id 기반 인증 흐름이 동작한다.
+- 회원 약관, follow/block, club membership, book story/comment/like, notification setting/list/read, push_device 등록/해제, report 생성/조회, team chat history 대표 API를 확인한다.
+- `auth_user.legacy_id`와 `member.legacy_id`는 기존 provider-shaped 값으로 남아야 한다.
+- `auth_user.provider_user_id`는 prefix를 제거한 provider 원본 id여야 한다.
+
+## Rollback order
+
+rollback은 smoke 실패가 외부 트래픽 재개 전에 발견된 경우에만 즉시 수행한다.
+
+1. 외부 트래픽과 scheduler/batch를 계속 중지한다.
+2. 실패 원인과 마지막 성공 단계, migration 로그, row-count output을 기록한다. secret 값은 기록하지 않는다.
+3. cutover 직전 snapshot으로 DB를 restore한다.
+4. 이전 애플리케이션 artifact로 되돌린다.
+5. restore된 DB에서 preflight row-count baseline과 핵심 auth/member count를 비교한다.
+6. `/health`와 로그인 smoke를 확인한다.
+7. 문제가 없으면 트래픽을 재개하고, 기존 token 정책은 rollback된 코드 기준으로 운영한다.
+8. 이미 numeric token을 발급한 짧은 구간이 있으면 해당 token은 폐기 대상으로 보고 사용자는 다시 로그인하게 한다.
+
+## 중단 조건
+
+- auth/member one-to-one mismatch가 1건 이상이다.
+- member reference orphan이 1건 이상이다.
+- provider/provider_user_id duplicate가 1건 이상이다.
+- `LOCAL`, `GOOGLE`, `APPLE`, `KAKAO` 외 prefix 또는 `_` 없는 legacy id가 존재한다.
+- `auth_user.id`와 `member.id`가 독립 생성될 수 있는 migration 설계가 발견된다.
+- target schema에 `auth_user.member_id` 또는 `member.auth_user_id`가 추가된다.
+- backup/snapshot 생성 여부가 확인되지 않는다.
+- secret 값이 문서, evidence, terminal transcript에 노출된다.

--- a/docs/member_auth_bigint_identity_migration.md
+++ b/docs/member_auth_bigint_identity_migration.md
@@ -16,10 +16,24 @@
 
 운영자가 이 문서로 작업할 때도 secret-bearing 값을 읽거나 기록하지 않는다.
 
-- `.env`, AWS credentials, RDS_PASSWORD, AWS_ACCESS_KEY, AWS_SECRET, JWT_SECRET, OAuth secret, GitHub secret 값을 읽지 않는다.
+- local secret files, cloud credentials, database passwords, token signing material, OAuth client secrets, GitHub secrets 값을 읽지 않는다.
 - 터미널, 문서, PR, 이슈, 로그, evidence 파일에 credential, endpoint URL, host name, token 값을 붙여 넣지 않는다.
 - DB 접속은 운영자가 이미 승인된 secret manager 또는 사내 접속 절차로 수행하고, 이 runbook에는 접속 문자열을 기록하지 않는다.
 - preflight와 smoke output은 aggregate/count 또는 필요한 진단 컬럼만 남긴다. 인증 secret 컬럼 값은 출력하지 않는다.
+
+## 운영 산출물
+
+운영자는 아래 산출물을 내부 운영 기록에 남긴다. 이 문서나 PR에는 값을 붙여 넣지 않는다.
+
+- maintenance window 시작/종료 시각
+- 배포 대상 애플리케이션 artifact 식별자
+- 적용 대상 Flyway migration 파일명
+- cutover 직전 snapshot 식별자
+- preflight SQL 실행 결과 요약
+- row-count baseline과 post-cutover row-count 비교 결과
+- smoke test 결과
+- rollback 여부와 판단 사유
+- token invalidation 공지 여부
 
 ## 사전 운영 조건
 
@@ -29,6 +43,16 @@
 - RDS snapshot 또는 동등한 point-in-time restore 가능한 backup을 생성한다.
 - rollback은 migration 역실행이 아니라 snapshot restore 기준으로 수행한다.
 - preflight query 결과가 모두 0건 또는 기대 count 일치일 때만 진행한다.
+- restore는 원본 DB를 직접 덮어쓰는 작업이 아니라 snapshot에서 새 DB instance를 만든 뒤 애플리케이션 연결 대상을 되돌리는 방식으로 계획한다.
+- snapshot restore 시 원본 DB의 VPC, subnet group, security group, parameter group, option group, engine version, encryption/KMS 설정을 확인한다.
+- 다른 Region 또는 계정으로 snapshot을 복사해 restore하는 경우 parameter group과 option group이 자동으로 그대로 따라오지 않을 수 있으므로 별도 확인한다.
+- encrypted shared snapshot은 직접 restore하지 못할 수 있으므로, 필요한 경우 복사본을 만든 뒤 restore하는 절차를 사전에 검증한다.
+
+참고 문서:
+
+- Amazon RDS User Guide: Restoring to a DB instance from a DB snapshot
+- AWS CLI Command Reference: `create-db-snapshot`
+- AWS CLI Command Reference: `restore-db-instance-from-db-snapshot`
 
 ## Preflight SQL
 
@@ -322,19 +346,46 @@ WHERE a.row_count <> b.row_count
 ORDER BY b.table_name;
 ```
 
-## Rollout order
+## Maintenance checklist
 
-1. maintenance window 시작을 공지하고 신규 쓰기 요청과 batch/scheduler 실행을 중지한다.
-2. RDS snapshot 또는 동등한 backup을 생성하고 snapshot 식별자만 내부 운영 기록에 남긴다.
-3. 기존 token은 cutover 후 무효화된다고 공지한다.
-4. 위 preflight SQL을 실행한다. mismatch, orphan, duplicate provider identity, unknown prefix 결과가 있으면 중단한다.
-5. row-count baseline을 캡처한다.
-6. 새 Flyway migration과 애플리케이션 코드를 같은 배포 단위로 반영한다.
-7. migration은 `member_identity_map`을 생성해 old legacy id와 new bigint id 매핑을 고정해야 한다.
-8. migration은 `auth_user.legacy_id`, `member.legacy_id`, `auth_user.provider`, `auth_user.provider_user_id`를 채우고 `UNIQUE(provider, provider_user_id)`를 생성해야 한다.
-9. 모든 member reference column을 `member_identity_map`으로 `BIGINT`에 backfill한 뒤 FK와 unique index를 다시 검증한다. `notification.sender_id = 'SYSTEM'`은 nullable `BIGINT` 컬럼의 `NULL`로 변환한다.
-10. refresh token 저장소는 기존 문자열 subject 기반 key를 제거하거나 만료되도록 둔다. 재로그인 후 numeric subject 기반 token만 유효해야 한다.
-11. smoke test가 끝날 때까지 외부 트래픽을 재개하지 않는다.
+아래 순서를 벗어나면 중단하고 rollback 판단 회의로 전환한다.
+
+1. maintenance window 시작을 공지한다.
+2. 외부 쓰기 트래픽을 차단한다.
+3. 애플리케이션 scheduler, batch, push delivery worker를 중지한다.
+4. 현재 배포 중인 application artifact와 DB migration 버전을 내부 운영 기록에 남긴다.
+5. cutover 대상 새 application artifact와 Flyway migration 파일명을 내부 운영 기록에 남긴다.
+6. RDS manual snapshot 또는 동등한 backup을 생성하고 완료 상태를 확인한다.
+7. snapshot 식별자만 내부 운영 기록에 남긴다.
+8. preflight SQL을 실행한다.
+9. mismatch, orphan, duplicate provider identity, unknown prefix 결과가 있으면 배포하지 않고 maintenance를 종료하거나 데이터 정리 절차로 전환한다.
+10. row-count baseline을 캡처한다.
+11. 기존 token은 cutover 후 무효화되고 사용자가 재로그인해야 한다는 공지를 확정한다.
+
+## Deploy checklist
+
+1. 새 애플리케이션 코드와 Flyway migration을 같은 배포 단위로 반영한다.
+2. migration은 `member_identity_map`을 생성해 old legacy id와 new bigint id 매핑을 고정해야 한다.
+3. migration은 `auth_user.legacy_id`, `member.legacy_id`, `auth_user.provider`, `auth_user.provider_user_id`를 채우고 `UNIQUE(provider, provider_user_id)`를 생성해야 한다.
+4. 모든 member reference column을 `member_identity_map`으로 `BIGINT`에 backfill한 뒤 FK와 unique index를 다시 검증한다.
+5. `notification.sender_id = 'SYSTEM'`은 nullable `BIGINT` 컬럼의 `NULL`로 변환한다.
+6. 애플리케이션 시작 로그에서 Flyway 성공과 Spring Boot startup 성공을 확인한다.
+7. post-cutover validation SQL을 실행한다.
+8. refresh token 저장소를 token invalidation checklist에 따라 처리한다.
+9. smoke test가 끝날 때까지 외부 트래픽을 재개하지 않는다.
+
+## Token invalidation checklist
+
+cutover 후 JWT subject는 numeric `auth_user.id`의 decimal string이어야 한다. 기존 access token은 provider-shaped subject를 담고 있으므로 새 인증 boundary에서 실패해야 한다.
+
+1. 사용자는 cutover 후 재로그인해야 한다고 공지한다.
+2. Redis refresh-token key는 `refreshToken::` prefix를 사용한다.
+3. 운영자가 승인된 Redis 접속 절차로 `refreshToken::` prefix key를 삭제하거나, 모든 기존 key가 만료될 때까지 refresh endpoint를 닫는다.
+4. refresh token 삭제는 운영 Redis 규모에 맞게 `SCAN` 기반으로 수행한다. 운영 DB에서 blocking `KEYS` 명령을 사용하지 않는다.
+5. access token blacklist key는 `blacklist::` prefix를 사용한다. JWT signing material이 유지되는 경우 기존 blacklist는 보존해도 된다.
+6. smoke test에서 stale pre-cutover token으로 인증 요청이 실패하는지 확인한다.
+7. 재로그인 후 발급된 token으로 내 프로필과 대표 authenticated API가 성공하는지 확인한다.
+8. token 또는 Redis value 원문은 운영 기록에 남기지 않는다.
 
 ## Post-cutover validation SQL
 
@@ -465,18 +516,43 @@ WHERE r.sender_member_id IS NOT NULL AND m.id IS NULL;
 - `auth_user.legacy_id`와 `member.legacy_id`는 기존 provider-shaped 값으로 남아야 한다.
 - `auth_user.provider_user_id`는 prefix를 제거한 provider 원본 id여야 한다.
 
+## Reopen traffic checklist
+
+아래 조건을 모두 만족할 때만 maintenance를 종료한다.
+
+- post-cutover validation SQL이 모두 기대 결과다.
+- row-count baseline과 post-cutover row-count가 일치한다.
+- stale token은 실패하고 재로그인 token은 성공한다.
+- 대표 authenticated API smoke가 통과한다.
+- scheduler, batch, push delivery worker를 재개해도 pending 작업이 정상 처리된다.
+- error log와 monitoring에서 migration 관련 신규 예외가 없다.
+- rollback 판단 시간이 지나기 전에 외부 트래픽을 재개하지 않는다.
+
 ## Rollback order
 
-rollback은 smoke 실패가 외부 트래픽 재개 전에 발견된 경우에만 즉시 수행한다.
+rollback은 smoke 실패가 외부 트래픽 재개 전에 발견된 경우 즉시 수행한다. 외부 트래픽 재개 후에는 snapshot restore가 데이터 손실을 만들 수 있으므로 별도 incident 의사결정이 필요하다.
 
 1. 외부 트래픽과 scheduler/batch를 계속 중지한다.
 2. 실패 원인과 마지막 성공 단계, migration 로그, row-count output을 기록한다. secret 값은 기록하지 않는다.
-3. cutover 직전 snapshot으로 DB를 restore한다.
-4. 이전 애플리케이션 artifact로 되돌린다.
-5. restore된 DB에서 preflight row-count baseline과 핵심 auth/member count를 비교한다.
-6. `/health`와 로그인 smoke를 확인한다.
-7. 문제가 없으면 트래픽을 재개하고, 기존 token 정책은 rollback된 코드 기준으로 운영한다.
-8. 이미 numeric token을 발급한 짧은 구간이 있으면 해당 token은 폐기 대상으로 보고 사용자는 다시 로그인하게 한다.
+3. 이전 애플리케이션 artifact로 되돌릴 준비를 완료한다.
+4. cutover 직전 snapshot에서 새 DB instance를 restore한다.
+5. restore된 DB instance가 available 상태가 될 때까지 기다린다.
+6. restore된 DB instance의 network, security group, parameter group, option group, engine version 설정을 원본과 비교한다.
+7. 애플리케이션 연결 대상을 restore된 DB로 되돌린다.
+8. 이전 애플리케이션 artifact를 배포한다.
+9. restore된 DB에서 preflight row-count baseline과 핵심 auth/member count를 비교한다.
+10. `/health`와 로그인 smoke를 확인한다.
+11. 문제가 없으면 scheduler/batch를 재개하고 트래픽을 다시 연다.
+12. 이미 numeric token을 발급한 짧은 구간이 있으면 해당 token은 폐기 대상으로 보고 사용자는 다시 로그인하게 한다.
+
+## Rollback smoke checklist
+
+- `/health`가 정상 응답한다.
+- rollback된 코드 기준 로그인과 refresh token 흐름이 성공한다.
+- auth/member one-to-one count가 rollback 전 baseline과 일치한다.
+- club/bookStory/notification/report 대표 읽기 API가 성공한다.
+- 신규 cutover migration version이 restore된 DB의 Flyway history에 남아 있지 않다.
+- restore 전후 생성된 운영 기록에 credential, endpoint, token 원문이 없다.
 
 ## 중단 조건
 
@@ -488,3 +564,6 @@ rollback은 smoke 실패가 외부 트래픽 재개 전에 발견된 경우에�
 - target schema에 `auth_user.member_id` 또는 `member.auth_user_id`가 추가된다.
 - backup/snapshot 생성 여부가 확인되지 않는다.
 - secret 값이 문서, evidence, terminal transcript에 노출된다.
+- stale token이 cutover 후 인증에 성공한다.
+- 재로그인 token으로 대표 authenticated API가 실패한다.
+- rollback 시 restore 대상 DB 설정이 원본 운영 DB와 다르다.

--- a/src/main/java/checkmo/authentication/AuthenticationAPI.java
+++ b/src/main/java/checkmo/authentication/AuthenticationAPI.java
@@ -10,22 +10,22 @@ public interface AuthenticationAPI {
      *
      * @param memberId 현재 로그인 중인 memberId
      */
-    void completeProfile(String memberId);
+    void completeProfile(Long memberId);
 
     /**
      * 특정 회원의 인증 계정을 비활성화하고 세션을 만료시킵니다.
      */
-    void deactivateMember(String memberId, HttpServletRequest request, HttpServletResponse response);
+    void deactivateMember(Long memberId, HttpServletRequest request, HttpServletResponse response);
 
     /**
      * 특정 회원의 인증 관련 데이터(계정 정보, 권한, 토큰 등)를 완전히 삭제합니다.
      */
-    void deleteAuthData(String memberId);
+    void deleteAuthData(Long memberId);
 
     /**
      * 추가정보 입력 시 특정 회원의 닉네임을 저장합니다.
      */
-    void updateNickname(String memberId, String nickname);
+    void updateNickname(Long memberId, String nickname);
 
     /**
      * 비밀번호를 변경합니다. authUser가 없거나 기존 비밀번호와 일치하면 에러 반환.
@@ -35,16 +35,18 @@ public interface AuthenticationAPI {
      * @param newPassword     새 비밀번호
      * @return 비밀번호 변경 성공 여부
      */
-    boolean updatePassword(String memberId, String currentPassword, String newPassword);
+    boolean updatePassword(Long memberId, String currentPassword, String newPassword);
 
 
     /**
      * 이메일을 변강합니다.
      */
-    void updateEmail(String memberId, String currentEmail, String newEmail, String verificationCode);
+    void updateEmail(Long memberId, String currentEmail, String newEmail, String verificationCode);
 
     /**
      * 관리자 페이지 접근 권한 여부를 반환합니다.
      */
-    boolean canAccessAdmin(String memberId);
+    boolean canAccessAdmin(Long memberId);
+
+    String fetchProvider(Long memberId);
 }

--- a/src/main/java/checkmo/authentication/AuthenticationEvent.java
+++ b/src/main/java/checkmo/authentication/AuthenticationEvent.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 public class AuthenticationEvent {
 
     @Builder
-    public record CreateMember(String id, String email, List<TermsAgreement> agreements) {
+    public record CreateMember(Long id, String legacyId, String email, List<TermsAgreement> agreements) {
     }
 
     public record TermsAgreement(Long termsId, boolean agreed) {
@@ -21,7 +21,7 @@ public class AuthenticationEvent {
     }
 
     @Builder
-    public record ReactivateMember(String id) {
+    public record ReactivateMember(Long id) {
     }
 
     public enum VerificationType {

--- a/src/main/java/checkmo/authentication/internal/AuthenticationAPIImpl.java
+++ b/src/main/java/checkmo/authentication/internal/AuthenticationAPIImpl.java
@@ -23,41 +23,48 @@ public class AuthenticationAPIImpl implements AuthenticationAPI {
     private final AuthRepository authRepository;
 
     @Override
-    public void deleteAuthData(String memberId) {
+    public void deleteAuthData(Long memberId) {
         tokenCacheService.deleteRefreshToken(memberId);
         authRepository.findById(memberId).ifPresent(authRepository::delete);
     }
 
     @Override
-    public void completeProfile(String memberId) {
+    public void completeProfile(Long memberId) {
         authUserCommandService.completeProfile(memberId);
     }
 
     @Override
-    public void deactivateMember(String memberId, HttpServletRequest request, HttpServletResponse response) {
+    public void deactivateMember(Long memberId, HttpServletRequest request, HttpServletResponse response) {
         authSessionCommandService.logout(request, response);
         authUserCommandService.deactivateMember(memberId);
     }
 
     @Override
-    public boolean updatePassword(String memberId, String currentPassword, String newPassword) {
+    public boolean updatePassword(Long memberId, String currentPassword, String newPassword) {
         return authUserCommandService.updatePassword(memberId, currentPassword, newPassword);
     }
 
     @Override
-    public void updateEmail(String memberId, String currentEmail, String newEmail, String verificationCode) {
+    public void updateEmail(Long memberId, String currentEmail, String newEmail, String verificationCode) {
         authUserCommandService.updateEmail(memberId, currentEmail, newEmail, verificationCode);
     }
 
     @Override
-    public void updateNickname(String memberId, String nickname) {
+    public void updateNickname(Long memberId, String nickname) {
         authUserCommandService.updateNickname(memberId, nickname);
     }
 
     @Override
-    public boolean canAccessAdmin(String memberId) {
+    public boolean canAccessAdmin(Long memberId) {
         AuthUser authUser = authRepository.findById(memberId)
                 .orElseThrow(() -> new AuthException(AuthErrorStatus.MEMBER_NOT_FOUND));
         return authUser.isAdmin();
+    }
+
+    @Override
+    public String fetchProvider(Long memberId) {
+        return authRepository.findById(memberId)
+                .map(AuthUser::getProvider)
+                .orElseThrow(() -> new AuthException(AuthErrorStatus.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/checkmo/authentication/internal/converter/AuthConverter.java
+++ b/src/main/java/checkmo/authentication/internal/converter/AuthConverter.java
@@ -12,35 +12,40 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuthConverter {
 
+    private static final String LOCAL_PROVIDER = "LOCAL";
+
     public static AuthSignUpResult toSignUpResult(AuthUser user) {
         return new AuthSignUpResult(user.getEmail(), user.isProfileCompleted());
     }
 
     public static AuthUser toOAuth2User(OAuth2Attributes attributes, String registrationId) {
-        String newMemberId = toOAuth2MemberId(registrationId, attributes.getProviderId());
+        String provider = registrationId.toUpperCase();
 
         return AuthUser.builder()
-                .id(newMemberId)
+                .legacyId(toLegacyId(provider, attributes.getProviderId()))
                 .email(attributes.getEmail())
                 .password("")
+                .provider(provider)
+                .providerUserId(attributes.getProviderId())
                 .role(Role.USER)
                 .deactivatedAt(null)
                 .profileCompleted(false)
                 .build();
     }
 
-    public static String toOAuth2MemberId(String registrationId, String providerId) {
-        return registrationId.toUpperCase() + "_" + providerId;
+    public static String toLegacyId(String provider, String providerUserId) {
+        return provider.toUpperCase() + "_" + providerUserId;
     }
 
     public static AuthUser toLocalUser(AuthRequestDTO.SignUp request, String encodedPassword) {
-        String uuid = UUID.randomUUID().toString().substring(0, 8);
-        String newUserId = "LOCAL_" + uuid;
+        String providerUserId = UUID.randomUUID().toString().substring(0, 8);
 
         return AuthUser.builder()
-                .id(newUserId)
+                .legacyId(toLegacyId(LOCAL_PROVIDER, providerUserId))
                 .email(request.getEmail())
                 .password(encodedPassword)
+                .provider(LOCAL_PROVIDER)
+                .providerUserId(providerUserId)
                 .role(Role.USER)
                 .deactivatedAt(null)
                 .profileCompleted(false)

--- a/src/main/java/checkmo/authentication/internal/entity/AuthUser.java
+++ b/src/main/java/checkmo/authentication/internal/entity/AuthUser.java
@@ -3,12 +3,17 @@ package checkmo.authentication.internal.entity;
 import checkmo.common.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.*;
-
 import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
@@ -37,6 +42,7 @@ public class AuthUser extends BaseEntity {
     private String providerUserId;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private Role role;
 
     @Column(nullable = false)

--- a/src/main/java/checkmo/authentication/internal/entity/AuthUser.java
+++ b/src/main/java/checkmo/authentication/internal/entity/AuthUser.java
@@ -1,7 +1,11 @@
 package checkmo.authentication.internal.entity;
 
 import checkmo.common.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -14,7 +18,11 @@ import java.time.LocalDateTime;
 public class AuthUser extends BaseEntity {
 
     @Id
-    private String id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String legacyId;
 
     @Column(nullable = false, unique = true)
     private String email;
@@ -22,7 +30,12 @@ public class AuthUser extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private String provider;
+
+    @Column(nullable = false)
+    private String providerUserId;
+
     @Column(nullable = false)
     private Role role;
 

--- a/src/main/java/checkmo/authentication/internal/repository/AuthRepository.java
+++ b/src/main/java/checkmo/authentication/internal/repository/AuthRepository.java
@@ -1,15 +1,16 @@
 package checkmo.authentication.internal.repository;
 
 import checkmo.authentication.internal.entity.AuthUser;
-import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface AuthRepository extends JpaRepository<AuthUser, String> {
+public interface AuthRepository extends JpaRepository<AuthUser, Long> {
 
     Optional<AuthUser> findByEmail(String email);
-    Optional<AuthUser> findByIdAndDeactivatedAtIsNotNull(String id);
+    Optional<AuthUser> findByIdAndDeactivatedAtIsNotNull(Long id);
+    Optional<AuthUser> findByProviderAndProviderUserId(String provider, String providerUserId);
 
     boolean existsByEmail(String email);
 

--- a/src/main/java/checkmo/authentication/internal/resolver/CurrentMemberArgumentResolver.java
+++ b/src/main/java/checkmo/authentication/internal/resolver/CurrentMemberArgumentResolver.java
@@ -18,11 +18,11 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        // @CurrentId String 타입 지원
         boolean isCurrentIdAnnotation = parameter.getParameterAnnotation(CurrentId.class) != null;
         boolean isStringClass = String.class.equals(parameter.getParameterType());
+        boolean isLongClass = Long.class.equals(parameter.getParameterType()) || long.class.equals(parameter.getParameterType());
 
-        return (isCurrentIdAnnotation && isStringClass);
+        return isCurrentIdAnnotation && (isStringClass || isLongClass);
     }
 
     @Override
@@ -39,10 +39,9 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
             return null;
         }
 
-        // PrincipalDetails에서 memberId 추출 (Member 엔티티의 id가 memberId로 사용됨)
-        String memberId = null;
+        Long memberId = null;
         if (authentication.getPrincipal() instanceof PrincipalDetails principalDetails) {
-            memberId = principalDetails.getUsername();
+            memberId = principalDetails.getUser().getId();
         }
 
         if (memberId == null) {
@@ -50,9 +49,11 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
             return null;
         }
 
-        // @CurrentId인 경우 memberId 반환
         if (parameter.getParameterAnnotation(CurrentId.class) != null) {
             log.info("loginId 주입: {}", memberId);
+            if (String.class.equals(parameter.getParameterType())) {
+                return String.valueOf(memberId);
+            }
             return memberId;
         }
 

--- a/src/main/java/checkmo/authentication/internal/resolver/CurrentMemberArgumentResolver.java
+++ b/src/main/java/checkmo/authentication/internal/resolver/CurrentMemberArgumentResolver.java
@@ -19,10 +19,9 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         boolean isCurrentIdAnnotation = parameter.getParameterAnnotation(CurrentId.class) != null;
-        boolean isStringClass = String.class.equals(parameter.getParameterType());
         boolean isLongClass = Long.class.equals(parameter.getParameterType()) || long.class.equals(parameter.getParameterType());
 
-        return isCurrentIdAnnotation && (isStringClass || isLongClass);
+        return isCurrentIdAnnotation && isLongClass;
     }
 
     @Override
@@ -51,9 +50,6 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
 
         if (parameter.getParameterAnnotation(CurrentId.class) != null) {
             log.info("loginId 주입: {}", memberId);
-            if (String.class.equals(parameter.getParameterType())) {
-                return String.valueOf(memberId);
-            }
             return memberId;
         }
 

--- a/src/main/java/checkmo/authentication/internal/security/auth/CustomUserDetailsService.java
+++ b/src/main/java/checkmo/authentication/internal/security/auth/CustomUserDetailsService.java
@@ -31,7 +31,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         return new PrincipalDetails(user);
     }
 
-    public UserDetails loadUserById(String id) {
+    public UserDetails loadUserById(Long id) {
         AuthUser user = authRepository.findById(id)
                 .orElseThrow(() -> new AuthException(AuthErrorStatus.MEMBER_NOT_FOUND));
 

--- a/src/main/java/checkmo/authentication/internal/security/auth/PrincipalDetails.java
+++ b/src/main/java/checkmo/authentication/internal/security/auth/PrincipalDetails.java
@@ -43,7 +43,7 @@ public class PrincipalDetails implements UserDetails, OAuth2User {
 
     @Override
     public String getUsername() {
-        return user.getId();
+        return String.valueOf(user.getId());
     }
 
     @Override

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtAuthenticationFilter.java
@@ -92,7 +92,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 }
 
                 // 유령 회원(삭제된 회원) 여부 확인
-                String memberId = jwtTokenProvider.getUserIdFromToken(accessToken);
+                Long memberId = jwtTokenProvider.getUserIdFromToken(accessToken);
                 if (!authRepository.existsById(memberId)) {
                     log.warn("[JWT 필터] 존재하지 않는 계정(유령 회원) 감지: memberId={}", memberId);
                     tokenCacheService.saveBlacklistToken(accessToken);

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtLoginProcessor.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtLoginProcessor.java
@@ -35,7 +35,7 @@ public class JwtLoginProcessor {
     }
 
     private JwtToken issueToken(Authentication authentication) {
-        String userId = ((PrincipalDetails) authentication.getPrincipal()).getUser().getId();
+        Long userId = ((PrincipalDetails) authentication.getPrincipal()).getUser().getId();
 
         // 인증 성공 시점에만 계정 자동 복구
         authReactivationCommandService.reactivateIfDeactivated(userId);

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProvider.java
@@ -17,11 +17,11 @@ public interface JwtTokenProvider {
 
     boolean validateToken(String token);
 
-    String getUserIdFromToken(String token);
+    Long getUserIdFromToken(String token);
 
     boolean isRefreshTokenValid(String refreshToken);
 
-    Authentication getAuthenticationFromMemberId(String memberId);
+    Authentication getAuthenticationFromMemberId(Long memberId);
 
     long getAccessTokenExpirationTime();
 

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImpl.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImpl.java
@@ -1,6 +1,8 @@
 package checkmo.authentication.internal.security.jwt;
 
 import checkmo.authentication.internal.config.properties.JwtProperties;
+import checkmo.authentication.internal.exception.AuthErrorStatus;
+import checkmo.authentication.internal.exception.AuthException;
 import checkmo.authentication.internal.security.auth.CustomUserDetailsService;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -134,9 +136,17 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
                     .parseSignedClaims(token)
                     .getPayload()
                     .getSubject();
-            return Long.valueOf(subject);
+            return parseMemberIdSubject(subject);
         } catch (ExpiredJwtException e) {
-            return Long.valueOf(e.getClaims().getSubject());
+            return parseMemberIdSubject(e.getClaims().getSubject());
+        }
+    }
+
+    private Long parseMemberIdSubject(String subject) {
+        try {
+            return Long.valueOf(subject);
+        } catch (NumberFormatException e) {
+            throw new AuthException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
         }
     }
 

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImpl.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImpl.java
@@ -79,7 +79,7 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
 
     @Override
     public Authentication getAuthentication(String accessToken) {
-        String userId = this.getUserIdFromToken(accessToken);
+        Long userId = this.getUserIdFromToken(accessToken);
 
         UserDetails userDetails = customUserDetailsService.loadUserById(userId);
         return new UsernamePasswordAuthenticationToken(userDetails, "",
@@ -126,21 +126,22 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
     }
 
     @Override
-    public String getUserIdFromToken(String token) {
+    public Long getUserIdFromToken(String token) {
         try {
-            return Jwts.parser()
+            String subject = Jwts.parser()
                     .verifyWith((SecretKey) key)
                     .build()
                     .parseSignedClaims(token)
                     .getPayload()
                     .getSubject();
+            return Long.valueOf(subject);
         } catch (ExpiredJwtException e) {
-            return e.getClaims().getSubject();
+            return Long.valueOf(e.getClaims().getSubject());
         }
     }
 
     @Override
-    public Authentication getAuthenticationFromMemberId(String memberId) {
+    public Authentication getAuthenticationFromMemberId(Long memberId) {
         UserDetails userDetails = customUserDetailsService.loadUserById(memberId);
 
         return new UsernamePasswordAuthenticationToken(

--- a/src/main/java/checkmo/authentication/internal/security/jwt/TokenCacheService.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/TokenCacheService.java
@@ -52,6 +52,10 @@ public class TokenCacheService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final JwtProperties jwtProperties;
 
+    public void saveRefreshToken(Long userId, String refreshToken) {
+        saveRefreshToken(String.valueOf(userId), refreshToken);
+    }
+
     public void saveRefreshToken(String userId, String refreshToken) {
         log.info("리프레시 토큰 저장 - userId={}", userId);
         long ttlMs = jwtProperties.getTokenValidity().getRefreshToken();
@@ -67,6 +71,10 @@ public class TokenCacheService {
         );
     }
 
+    public String getRefreshToken(Long userId) {
+        return getRefreshToken(String.valueOf(userId));
+    }
+
     public String getRefreshToken(String userId) {
         log.info("리프레시 토큰 조회 - userId={}", userId);
         byte[] key = serialize(REFRESH_TOKEN_PREFIX + userId);
@@ -74,6 +82,15 @@ public class TokenCacheService {
                 connection.stringCommands().get(key)
         );
         return value == null ? null : deserializeRefreshToken(value);
+    }
+
+    public boolean compareAndRotateRefreshToken(
+            Long userId,
+            String expectedRefreshToken,
+            String newRefreshToken,
+            Duration ttl
+    ) {
+        return compareAndRotateRefreshToken(String.valueOf(userId), expectedRefreshToken, newRefreshToken, ttl);
     }
 
     public boolean compareAndRotateRefreshToken(
@@ -91,9 +108,17 @@ public class TokenCacheService {
         return executeBooleanScript(COMPARE_AND_ROTATE_REFRESH_TOKEN_SCRIPT, key, expected, legacyExpected, next, ttlMs);
     }
 
+    public void deleteRefreshToken(Long userId) {
+        deleteRefreshToken(String.valueOf(userId));
+    }
+
     public void deleteRefreshToken(String userId) {
         log.info("리프레시 토큰 삭제 - userId={}", userId);
         redisTemplate.delete(REFRESH_TOKEN_PREFIX + userId);
+    }
+
+    public boolean deleteRefreshTokenIfMatches(Long userId, String expectedRefreshToken) {
+        return deleteRefreshTokenIfMatches(String.valueOf(userId), expectedRefreshToken);
     }
 
     public boolean deleteRefreshTokenIfMatches(String userId, String expectedRefreshToken) {

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreator.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreator.java
@@ -26,6 +26,7 @@ class SocialAccountCreator {
         eventPublisher.publishEvent(
                 AuthenticationEvent.CreateMember.builder()
                         .id(newUser.getId())
+                        .legacyId(newUser.getLegacyId())
                         .email(newUser.getEmail())
                         .build());
 

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolver.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolver.java
@@ -1,6 +1,5 @@
 package checkmo.authentication.internal.security.oauth2;
 
-import checkmo.authentication.internal.converter.AuthConverter;
 import checkmo.authentication.internal.entity.AuthUser;
 import checkmo.authentication.internal.entity.Provider;
 import checkmo.authentication.internal.exception.AuthErrorStatus;
@@ -32,17 +31,17 @@ public class SocialAccountResolver {
         if (!StringUtils.hasText(attributes.getProviderId())) {
             throw new OAuth2AuthenticationException("소셜 계정 식별자를 가져올 수 없습니다");
         }
-        String expectedUserId = AuthConverter.toOAuth2MemberId(registrationId, attributes.getProviderId());
+        String provider = registrationId.toUpperCase();
 
-        return authRepository.findById(expectedUserId)
+        return authRepository.findByProviderAndProviderUserId(provider, attributes.getProviderId())
                 .map(user -> new SocialAccountResolution(user, false))
-                .orElseGet(() -> createAppleUser(attributes, registrationId, expectedUserId));
+                .orElseGet(() -> createAppleUser(attributes, registrationId, provider));
     }
 
     private SocialAccountResolution createAppleUser(
             OAuth2Attributes attributes,
             String registrationId,
-            String expectedUserId
+            String provider
     ) {
         String email = attributes.getEmail();
         if (!StringUtils.hasText(email)) {
@@ -57,13 +56,15 @@ public class SocialAccountResolver {
             AuthUser savedUser = socialAccountCreator.create(attributes, registrationId);
             return new SocialAccountResolution(savedUser, true);
         } catch (DataIntegrityViolationException | PersistenceException e) {
-            return refetchAppleAfterDuplicate(expectedUserId, email);
+            return refetchAppleAfterDuplicate(provider, attributes.getProviderId(), email);
         }
     }
 
-    private SocialAccountResolution refetchAppleAfterDuplicate(String expectedUserId, String email) {
-        AuthUser user = authRepository.findById(expectedUserId)
-                .or(() -> authRepository.findByEmail(email).filter(foundUser -> foundUser.getId().equals(expectedUserId)))
+    private SocialAccountResolution refetchAppleAfterDuplicate(String provider, String providerUserId, String email) {
+        AuthUser user = authRepository.findByProviderAndProviderUserId(provider, providerUserId)
+                .or(() -> authRepository.findByEmail(email)
+                        .filter(foundUser -> provider.equals(foundUser.getProvider())
+                                && providerUserId.equals(foundUser.getProviderUserId())))
                 .orElseThrow(() -> new AuthException(AuthErrorStatus.SOCIAL_ACCOUNT_EMAIL_CONFLICT));
 
         return new SocialAccountResolution(user, false);

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolver.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolver.java
@@ -56,15 +56,12 @@ public class SocialAccountResolver {
             AuthUser savedUser = socialAccountCreator.create(attributes, registrationId);
             return new SocialAccountResolution(savedUser, true);
         } catch (DataIntegrityViolationException | PersistenceException e) {
-            return refetchAppleAfterDuplicate(provider, attributes.getProviderId(), email);
+            return refetchAppleAfterDuplicate(provider, attributes.getProviderId());
         }
     }
 
-    private SocialAccountResolution refetchAppleAfterDuplicate(String provider, String providerUserId, String email) {
+    private SocialAccountResolution refetchAppleAfterDuplicate(String provider, String providerUserId) {
         AuthUser user = authRepository.findByProviderAndProviderUserId(provider, providerUserId)
-                .or(() -> authRepository.findByEmail(email)
-                        .filter(foundUser -> provider.equals(foundUser.getProvider())
-                                && providerUserId.equals(foundUser.getProviderUserId())))
                 .orElseThrow(() -> new AuthException(AuthErrorStatus.SOCIAL_ACCOUNT_EMAIL_CONFLICT));
 
         return new SocialAccountResolution(user, false);

--- a/src/main/java/checkmo/authentication/internal/service/command/AuthReactivationCommandService.java
+++ b/src/main/java/checkmo/authentication/internal/service/command/AuthReactivationCommandService.java
@@ -15,7 +15,7 @@ public class AuthReactivationCommandService {
     private final AuthRepository authRepository;
     private final ApplicationEventPublisher eventPublisher;
 
-    public void reactivateIfDeactivated(String memberId) {
+    public void reactivateIfDeactivated(Long memberId) {
         authRepository.findByIdAndDeactivatedAtIsNotNull(memberId)
                 .ifPresent(authUser -> {
                     authUser.reactivate();

--- a/src/main/java/checkmo/authentication/internal/service/command/AuthSessionCommandService.java
+++ b/src/main/java/checkmo/authentication/internal/service/command/AuthSessionCommandService.java
@@ -76,7 +76,7 @@ public class AuthSessionCommandService {
         if (StringUtils.hasText(refreshToken)) {
             try {
                 if (jwtTokenProvider.isRefreshTokenValid(refreshToken)) {
-                    String memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+                    Long memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
                     tokenCacheService.deleteRefreshTokenIfMatches(memberId, refreshToken);
                 }
             } catch (Exception e) {
@@ -91,8 +91,8 @@ public class AuthSessionCommandService {
         }
 
         try {
-            String memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
-            if (!StringUtils.hasText(memberId)) {
+            Long memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+            if (memberId == null) {
                 throw new AuthException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
             }
             if (!tokenCacheService.deleteRefreshTokenIfMatches(memberId, refreshToken)) {

--- a/src/main/java/checkmo/authentication/internal/service/command/AuthTokenRotationService.java
+++ b/src/main/java/checkmo/authentication/internal/service/command/AuthTokenRotationService.java
@@ -27,8 +27,8 @@ public class AuthTokenRotationService {
             throw new AuthException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
         }
 
-        String memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
-        if (!StringUtils.hasText(memberId)) {
+        Long memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+        if (memberId == null) {
             throw new AuthException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
         }
 

--- a/src/main/java/checkmo/authentication/internal/service/command/AuthUserCommandService.java
+++ b/src/main/java/checkmo/authentication/internal/service/command/AuthUserCommandService.java
@@ -57,6 +57,7 @@ public class AuthUserCommandService {
         eventPublisher.publishEvent(
                 AuthenticationEvent.CreateMember.builder()
                         .id(savedUser.getId())
+                        .legacyId(savedUser.getLegacyId())
                         .email(savedUser.getEmail())
                         .agreements(toTermsAgreements(request))
                         .build());
@@ -94,7 +95,7 @@ public class AuthUserCommandService {
         });
     }
 
-    public void completeProfile(String userId) {
+    public void completeProfile(Long userId) {
         AuthUser authUser = authRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorStatus.MEMBER_NOT_FOUND));
 
@@ -105,7 +106,7 @@ public class AuthUserCommandService {
         authUser.completeProfile();
     }
 
-    public void deactivateMember(String memberId) {
+    public void deactivateMember(Long memberId) {
         AuthUser authUser = authRepository.findById(memberId)
                 .orElseThrow(() -> new AuthException(AuthErrorStatus.MEMBER_NOT_FOUND));
 
@@ -116,7 +117,7 @@ public class AuthUserCommandService {
         authUser.deactivate();
     }
 
-    public boolean updatePassword(String userId, String oldPassword, String newPassword) {
+    public boolean updatePassword(Long userId, String oldPassword, String newPassword) {
         AuthUser user = authRepository.findById(userId)
                                       .orElseThrow(() -> new AuthException(AuthErrorStatus.MEMBER_NOT_FOUND));
 
@@ -132,12 +133,12 @@ public class AuthUserCommandService {
         return true;
     }
 
-    public void updateEmail(String memberId, String currentEmail, String newEmail, String verificationCode) {
+    public void updateEmail(Long memberId, String currentEmail, String newEmail, String verificationCode) {
         AuthUser authUser = authRepository.findById(memberId)
                                           .orElseThrow(() -> new AuthException(AuthErrorStatus.MEMBER_NOT_FOUND));
 
         // 소셜 유저 차단
-        if (!authUser.getId().startsWith("LOCAL_")) {
+        if (!"LOCAL".equals(authUser.getProvider())) {
             throw new AuthException(AuthErrorStatus.SOCIAL_MEMBER_CANNOT_CHANGE_EMAIL);
         }
 
@@ -152,7 +153,7 @@ public class AuthUserCommandService {
         authUser.updateEmail(newEmail);
     }
 
-    public void updateNickname(String memberId, String nickname) {
+    public void updateNickname(Long memberId, String nickname) {
         if (!StringUtils.hasText(nickname)) {
             throw new AuthException(AuthErrorStatus.NICKNAME_REQUIRED);
         }

--- a/src/main/java/checkmo/authentication/internal/service/result/AuthTokenRotationResult.java
+++ b/src/main/java/checkmo/authentication/internal/service/result/AuthTokenRotationResult.java
@@ -9,7 +9,7 @@ import org.springframework.security.core.Authentication;
 @RequiredArgsConstructor
 public class AuthTokenRotationResult {
 
-    private final String memberId;
+    private final Long memberId;
     private final Authentication authentication;
     private final JwtToken jwtToken;
 }

--- a/src/main/java/checkmo/book/internal/entity/BookLiked.java
+++ b/src/main/java/checkmo/book/internal/entity/BookLiked.java
@@ -32,7 +32,7 @@ public class BookLiked extends BaseEntity {
     private Long id;
 
     @Column(name = "member_id", nullable = false)
-    private String memberId;
+    private Long memberId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id")

--- a/src/main/java/checkmo/book/internal/repository/BookLikedRepository.java
+++ b/src/main/java/checkmo/book/internal/repository/BookLikedRepository.java
@@ -14,12 +14,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface BookLikedRepository extends JpaRepository<BookLiked, Long> {
 
-    Optional<BookLiked> findByBook_IdAndMemberId(String bookId, String memberId);
+    Optional<BookLiked> findByBook_IdAndMemberId(String bookId, Long memberId);
 
     @Query("SELECT bl.book.id FROM BookLiked bl WHERE bl.memberId = :memberId AND bl.book.id IN :bookIds")
-    List<String> findLikedBookIds(@Param("memberId") String memberId, @Param("bookIds") List<String> bookIds);
+    List<String> findLikedBookIds(@Param("memberId") Long memberId, @Param("bookIds") List<String> bookIds);
 
-    default Set<String> findLikedBookIdSet(String memberId, List<String> bookIds) {
+    default Set<String> findLikedBookIdSet(Long memberId, List<String> bookIds) {
         if (memberId == null || bookIds == null || bookIds.isEmpty()) {
             return Collections.emptySet();
         }
@@ -27,8 +27,8 @@ public interface BookLikedRepository extends JpaRepository<BookLiked, Long> {
     }
 
     @EntityGraph(attributePaths = "book")
-    List<BookLiked> findByMemberIdOrderByIdDesc(String memberId, Pageable pageable);
+    List<BookLiked> findByMemberIdOrderByIdDesc(Long memberId, Pageable pageable);
 
     @EntityGraph(attributePaths = "book")
-    List<BookLiked> findByMemberIdAndIdLessThanOrderByIdDesc(String memberId, Long cursorId, Pageable pageable);
+    List<BookLiked> findByMemberIdAndIdLessThanOrderByIdDesc(Long memberId, Long cursorId, Pageable pageable);
 }

--- a/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
+++ b/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
@@ -29,7 +29,7 @@ public class BookRecommendationService {
     private final AladinRecommendationRefreshClient recommendationRefreshClient;
     private final SentryCaptureClient sentryCaptureClient;
 
-    public BookResponseDTO.BookList retrieveRecommendedBooks(String memberId) {
+    public BookResponseDTO.BookList retrieveRecommendedBooks(Long memberId) {
         BookResponseDTO.BookList cachedBooks = retrieveUsableCachedBooks();
 
         if (cachedBooks != null && !isRecommendedBooksStale()) {

--- a/src/main/java/checkmo/book/internal/service/command/BookSocialCommandService.java
+++ b/src/main/java/checkmo/book/internal/service/command/BookSocialCommandService.java
@@ -28,7 +28,7 @@ public class BookSocialCommandService {
      * @param isbn  좋아요 대상 책 ISBN
      * @return 토글 결과 DTO
      */
-    public BookResponseDTO.LikeResult toggleLikeOnBook(String memberId, String isbn) {
+    public BookResponseDTO.LikeResult toggleLikeOnBook(Long memberId, String isbn) {
         Book book = retrieveOrCreateBook(isbn);
 
         return bookLikedRepository.findByBook_IdAndMemberId(book.getId(), memberId)
@@ -68,7 +68,7 @@ public class BookSocialCommandService {
         book.removeBookLiked(bookLiked);
     }
 
-    private void addBookLiked(Book book, String memberId) {
+    private void addBookLiked(Book book, Long memberId) {
         BookLiked bookLiked = BookLiked.builder()
                 .book(book)
                 .memberId(memberId)

--- a/src/main/java/checkmo/book/internal/service/query/AladinApiService.java
+++ b/src/main/java/checkmo/book/internal/service/query/AladinApiService.java
@@ -37,7 +37,7 @@ public class AladinApiService {
     private final AladinSearchPrefetchService aladinSearchPrefetchService;
     private final SentryCaptureClient sentryCaptureClient;
 
-    public BookResponseDTO.BookList retrieveSearchBooks(String keyword, int page, String memberId) {
+    public BookResponseDTO.BookList retrieveSearchBooks(String keyword, int page, Long memberId) {
         if (keyword == null || keyword.isBlank()) {
             return emptySearchResult(page);
         }
@@ -232,7 +232,7 @@ public class AladinApiService {
         return value.substring(0, LOG_BODY_MAX_LENGTH) + "...";
     }
 
-    public BookResponseDTO.BookList applyLikedByMe(BookResponseDTO.BookList bookList, String memberId) {
+    public BookResponseDTO.BookList applyLikedByMe(BookResponseDTO.BookList bookList, Long memberId) {
         if (bookList == null || bookList.getDetailInfoList() == null || bookList.getDetailInfoList().isEmpty()) {
             return bookList;
         }

--- a/src/main/java/checkmo/book/internal/service/query/BookLikeQueryService.java
+++ b/src/main/java/checkmo/book/internal/service/query/BookLikeQueryService.java
@@ -31,8 +31,8 @@ public class BookLikeQueryService {
     }
 
     public BookResponseDTO.LikedBookList retrieveMemberLikedBooks(String memberNickname, Long currentMemberId, Long cursorId) {
-        Long targetMemberId = Long.valueOf(memberAPI.fetchMemberId(memberNickname));
-        memberAPI.validateProfileAccessible(toMemberApiId(currentMemberId), toMemberApiId(targetMemberId));
+        Long targetMemberId = memberAPI.fetchMemberId(memberNickname);
+        memberAPI.validateProfileAccessible(currentMemberId, targetMemberId);
         return retrieveLikedBooksByMemberId(targetMemberId, currentMemberId, cursorId);
     }
 
@@ -72,7 +72,4 @@ public class BookLikeQueryService {
         return BookConverter.toLikedBookInfo(book, likedBookIdSet.contains(book.getId()));
     }
 
-    private String toMemberApiId(Long memberId) {
-        return String.valueOf(memberId);
-    }
 }

--- a/src/main/java/checkmo/book/internal/service/query/BookLikeQueryService.java
+++ b/src/main/java/checkmo/book/internal/service/query/BookLikeQueryService.java
@@ -26,17 +26,17 @@ public class BookLikeQueryService {
     private final BookLikedRepository bookLikedRepository;
     private final MemberAPI memberAPI;
 
-    public BookResponseDTO.LikedBookList retrieveMyLikedBooks(String memberId, Long cursorId) {
+    public BookResponseDTO.LikedBookList retrieveMyLikedBooks(Long memberId, Long cursorId) {
         return retrieveLikedBooksByMemberId(memberId, memberId, cursorId);
     }
 
-    public BookResponseDTO.LikedBookList retrieveMemberLikedBooks(String memberNickname, String currentMemberId, Long cursorId) {
-        String targetMemberId = memberAPI.fetchMemberId(memberNickname);
-        memberAPI.validateProfileAccessible(currentMemberId, targetMemberId);
+    public BookResponseDTO.LikedBookList retrieveMemberLikedBooks(String memberNickname, Long currentMemberId, Long cursorId) {
+        Long targetMemberId = Long.valueOf(memberAPI.fetchMemberId(memberNickname));
+        memberAPI.validateProfileAccessible(toMemberApiId(currentMemberId), toMemberApiId(targetMemberId));
         return retrieveLikedBooksByMemberId(targetMemberId, currentMemberId, cursorId);
     }
 
-    private BookResponseDTO.LikedBookList retrieveLikedBooksByMemberId(String memberId, String currentMemberId, Long cursorId) {
+    private BookResponseDTO.LikedBookList retrieveLikedBooksByMemberId(Long memberId, Long currentMemberId, Long cursorId) {
         CursorResult<BookLiked> cursorResult = CursorPagingHelper.getPage(
                 size -> retrieveBookLikes(memberId, cursorId, size),
                 BookLiked::getId,
@@ -59,7 +59,7 @@ public class BookLikeQueryService {
                 .build();
     }
 
-    private List<BookLiked> retrieveBookLikes(String memberId, Long cursorId, int pageSize) {
+    private List<BookLiked> retrieveBookLikes(Long memberId, Long cursorId, int pageSize) {
         Pageable pageable = PageRequest.of(0, pageSize);
         if (cursorId == null) {
             return bookLikedRepository.findByMemberIdOrderByIdDesc(memberId, pageable);
@@ -70,5 +70,9 @@ public class BookLikeQueryService {
     private BookResponseDTO.LikedBookInfo toLikedBookInfo(BookLiked liked, Set<String> likedBookIdSet) {
         Book book = liked.getBook();
         return BookConverter.toLikedBookInfo(book, likedBookIdSet.contains(book.getId()));
+    }
+
+    private String toMemberApiId(Long memberId) {
+        return String.valueOf(memberId);
     }
 }

--- a/src/main/java/checkmo/book/web/controller/BookController.java
+++ b/src/main/java/checkmo/book/web/controller/BookController.java
@@ -44,7 +44,7 @@ public class BookController {
     })
     @GetMapping("/search")
     public ApiResponse<BookResponseDTO.BookList> searchBook(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam String keyword,
             @RequestParam(required = false, defaultValue = "1")
             @Min(value = 1, message = "페이지 번호는 1 이상이어야 합니다.")
@@ -72,7 +72,7 @@ public class BookController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "책 정보를 찾을 수 없음"),
     })
     @GetMapping("/recommend")
-    public ApiResponse<BookResponseDTO.BookList> recommendBooks(@CurrentId String memberId) {
+    public ApiResponse<BookResponseDTO.BookList> recommendBooks(@CurrentId Long memberId) {
         BookResponseDTO.BookList result = bookRecommendationService.retrieveRecommendedBooks(memberId);
         return ApiResponse.onSuccess(result);
     }
@@ -85,7 +85,7 @@ public class BookController {
     })
     @PostMapping("/{isbn}/like")
     public ApiResponse<BookResponseDTO.LikeResult> toggleLikeBook(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String isbn
     ) {
         BookResponseDTO.LikeResult result = bookSocialCommandService.toggleLikeOnBook(memberId, isbn);
@@ -105,7 +105,7 @@ public class BookController {
     })
     @GetMapping("/me/likes")
     public ApiResponse<BookResponseDTO.LikedBookList> getMyLikedBooks(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam(required = false) Long cursorId
     ) {
         BookResponseDTO.LikedBookList result = bookLikeQueryService.retrieveMyLikedBooks(memberId, cursorId);
@@ -124,7 +124,7 @@ public class BookController {
     })
     @GetMapping("/{memberNickname}/likes")
     public ApiResponse<BookResponseDTO.LikedBookList> getMemberLikedBooks(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String memberNickname,
             @RequestParam(required = false) Long cursorId
     ) {

--- a/src/main/java/checkmo/bookStory/BookStoryAPI.java
+++ b/src/main/java/checkmo/bookStory/BookStoryAPI.java
@@ -5,7 +5,7 @@ public interface BookStoryAPI {
 
     Long fetchBookStoryIdByBookStoryCommentId(Long bookStoryCommentId);
 
-    String fetchBookStoryAuthorId(Long bookStoryId);
+    Long fetchBookStoryAuthorId(Long bookStoryId);
 
-    String fetchBookStoryCommentAuthorId(Long commentId);
+    Long fetchBookStoryCommentAuthorId(Long commentId);
 }

--- a/src/main/java/checkmo/bookStory/BookStoryEvent.java
+++ b/src/main/java/checkmo/bookStory/BookStoryEvent.java
@@ -9,10 +9,10 @@ import lombok.RequiredArgsConstructor;
 public class BookStoryEvent {
 
     @Builder
-    public record BookStoryLiked(Long eventId, String senderId, String receiverId, Long bookStoryId) {
+    public record BookStoryLiked(Long eventId, Long senderId, Long receiverId, Long bookStoryId) {
     }
 
     @Builder
-    public record BookStoryComment(Long eventId, String senderId, String receiverId, Long bookStoryId) {
+    public record BookStoryComment(Long eventId, Long senderId, Long receiverId, Long bookStoryId) {
     }
 }

--- a/src/main/java/checkmo/bookStory/internal/BookStoryAPIImpl.java
+++ b/src/main/java/checkmo/bookStory/internal/BookStoryAPIImpl.java
@@ -26,14 +26,14 @@ public class BookStoryAPIImpl implements BookStoryAPI {
     }
 
     @Override
-    public String fetchBookStoryAuthorId(Long bookStoryId) {
+    public Long fetchBookStoryAuthorId(Long bookStoryId) {
         BookStory bookStory = bookStoryQueryService.retrieveBookStory(bookStoryId);
-        return String.valueOf(bookStory.getMemberId());
+        return bookStory.getMemberId();
     }
 
     @Override
-    public String fetchBookStoryCommentAuthorId(Long commentId) {
+    public Long fetchBookStoryCommentAuthorId(Long commentId) {
         Comment comment = bookStoryQueryService.retrieveBookStoryComment(commentId);
-        return String.valueOf(comment.getMemberId());
+        return comment.getMemberId();
     }
 }

--- a/src/main/java/checkmo/bookStory/internal/BookStoryAPIImpl.java
+++ b/src/main/java/checkmo/bookStory/internal/BookStoryAPIImpl.java
@@ -28,12 +28,12 @@ public class BookStoryAPIImpl implements BookStoryAPI {
     @Override
     public String fetchBookStoryAuthorId(Long bookStoryId) {
         BookStory bookStory = bookStoryQueryService.retrieveBookStory(bookStoryId);
-        return bookStory.getMemberId();
+        return String.valueOf(bookStory.getMemberId());
     }
 
     @Override
     public String fetchBookStoryCommentAuthorId(Long commentId) {
         Comment comment = bookStoryQueryService.retrieveBookStoryComment(commentId);
-        return comment.getMemberId();
+        return String.valueOf(comment.getMemberId());
     }
 }

--- a/src/main/java/checkmo/bookStory/internal/converter/BookStoryConverter.java
+++ b/src/main/java/checkmo/bookStory/internal/converter/BookStoryConverter.java
@@ -22,7 +22,7 @@ public class BookStoryConverter {
 
     public static BookStory toBookStory(
             BookStoryRequestDTO.BookStoryCreate request,
-            String memberId,
+            Long memberId,
             String bookId,
             BookStoryStatus status
     ) {
@@ -37,7 +37,7 @@ public class BookStoryConverter {
 
     public static BookStoryResponseDTO.BasicInfo toBookStoryDetailDTO(
             BookStory bookStory,
-            String currentMemberId,
+            Long currentMemberId,
             BookExternalDTO.BasicInfo bookInfo,
             BasicInfoWithFollow authorInfo,
             boolean isLiked
@@ -61,7 +61,7 @@ public class BookStoryConverter {
 
     public static BookStoryResponseDTO.DetailInfo toBookStoryDetailWithComment(
             BookStory bookStory,
-            String currentMemberId,
+            Long currentMemberId,
             BookExternalDTO.BasicInfo bookInfo,
             BasicInfoWithFollow authorInfo,
             boolean isLiked,
@@ -105,9 +105,9 @@ public class BookStoryConverter {
 
     public static List<BookStoryResponseDTO.CommentInfo> toCommentDetailList(
             List<Comment> comments,
-            String currentMemberId,
-            Map<String, MemberExternalDTO.BasicInfo> memberInfoMap,
-            Set<String> blockedMemberIds
+            Long currentMemberId,
+            Map<Long, MemberExternalDTO.BasicInfo> memberInfoMap,
+            Set<Long> blockedMemberIds
     ) {
         return comments.stream()
                 .map(comment -> {
@@ -134,7 +134,7 @@ public class BookStoryConverter {
 
     private static BookStoryResponseDTO.CommentInfo fromCommentToResponse(
             Comment comment,
-            String currentMemberId,
+            Long currentMemberId,
             MemberExternalDTO.BasicInfo authorInfo,
             boolean blocked,
             List<BookStoryResponseDTO.CommentInfo> replies
@@ -165,7 +165,7 @@ public class BookStoryConverter {
                 .build();
     }
 
-    private static boolean isBlocked(String memberId, Set<String> blockedMemberIds) {
+    private static boolean isBlocked(Long memberId, Set<Long> blockedMemberIds) {
         return memberId != null && blockedMemberIds != null && blockedMemberIds.contains(memberId);
     }
 

--- a/src/main/java/checkmo/bookStory/internal/entity/BookStory.java
+++ b/src/main/java/checkmo/bookStory/internal/entity/BookStory.java
@@ -58,7 +58,7 @@ public class BookStory extends BaseEntity {
     private BookStoryStatus status = BookStoryStatus.PUBLISHED;
 
     @Column(name = "member_id", nullable = false)
-    private String memberId;
+    private Long memberId;
 
     @Column(name = "book_id", nullable = false)
     private String bookId;
@@ -106,7 +106,7 @@ public class BookStory extends BaseEntity {
         }
     }
 
-    public boolean verifyOwner(String memberId) {
+    public boolean verifyOwner(Long memberId) {
         return this.memberId.equals(memberId);
     }
 }

--- a/src/main/java/checkmo/bookStory/internal/entity/BookStoryLiked.java
+++ b/src/main/java/checkmo/bookStory/internal/entity/BookStoryLiked.java
@@ -32,7 +32,7 @@ public class BookStoryLiked extends BaseEntity {
     private Long id;
 
     @Column(name = "member_id", nullable = false)
-    private String memberId;
+    private Long memberId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_story_id")

--- a/src/main/java/checkmo/bookStory/internal/entity/Comment.java
+++ b/src/main/java/checkmo/bookStory/internal/entity/Comment.java
@@ -37,7 +37,7 @@ public class Comment extends BaseEntity {
     private String content;
 
     @JoinColumn(name = "member_id", nullable = false)
-    private String memberId;
+    private Long memberId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_story_id")
@@ -73,7 +73,7 @@ public class Comment extends BaseEntity {
         }
     }
 
-    public void verifyOwner(String memberId) {
+    public void verifyOwner(Long memberId) {
         if (!this.memberId.equals(memberId)) {
             throw new BookStoryException(BookStoryErrorStatus.COMMENT_NOT_AUTHORIZED);
         }

--- a/src/main/java/checkmo/bookStory/internal/repository/BookStoryLikedRepository.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/BookStoryLikedRepository.java
@@ -11,17 +11,17 @@ import org.springframework.data.repository.query.Param;
 public interface BookStoryLikedRepository extends JpaRepository<BookStoryLiked, Long> {
 
     @Query("SELECT COUNT(bsl) > 0 FROM BookStoryLiked bsl WHERE bsl.memberId = :memberId AND bsl.bookStory.id = :bookStoryId")
-    boolean existsByMemberIdAndBookStoryId(@Param("memberId") String memberId, @Param("bookStoryId") Long bookStoryId);
+    boolean existsByMemberIdAndBookStoryId(@Param("memberId") Long memberId, @Param("bookStoryId") Long bookStoryId);
 
     @Query("SELECT bsl.bookStory.id FROM BookStoryLiked bsl WHERE bsl.memberId = :memberId AND bsl.bookStory.id IN :bookStoryIds")
     List<Long> findLikedBookStoryIds(
-            @Param("memberId") String memberId,
+            @Param("memberId") Long memberId,
             @Param("bookStoryIds") List<Long> bookStoryIds
     );
 
     @Query("SELECT bsl FROM BookStoryLiked bsl WHERE bsl.bookStory.id = :bookStoryId AND bsl.memberId = :memberId")
     Optional<BookStoryLiked> findByBookStoryAndMember(@Param("bookStoryId") Long bookStoryId,
-                                                      @Param("memberId") String memberId);
+                                                      @Param("memberId") Long memberId);
 
     @Modifying
     @Query("DELETE FROM BookStoryLiked bsl WHERE bsl.bookStory.id = :bookStoryId")

--- a/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepository.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepository.java
@@ -9,19 +9,19 @@ import org.springframework.data.domain.Pageable;
 
 public interface BookStoryQueryRepository {
     List<BookStory> searchBookStories(
-            String memberId,
-            List<String> excludedMemberIds,
-            List<String> followingMemberIds,
+            Long memberId,
+            List<Long> excludedMemberIds,
+            List<Long> followingMemberIds,
             BookStoryRequestDTO.BookStoryScope scope,
             Long clubId,
-            String targetMemberId,
+            Long targetMemberId,
             Long cursorId,
             int pageSize
     );
 
     List<BookStory> searchBookStories(
             String bookId,
-            List<String> excludedMemberIds,
+            List<Long> excludedMemberIds,
             Long cursorId,
             int pageSize
     );

--- a/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepositoryImpl.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepositoryImpl.java
@@ -27,12 +27,12 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
 
     @Override
     public List<BookStory> searchBookStories(
-            String memberId,
-            List<String> excludedMemberIds,
-            List<String> followingMemberIds,
+            Long memberId,
+            List<Long> excludedMemberIds,
+            List<Long> followingMemberIds,
             BookStoryRequestDTO.BookStoryScope scope,
             Long clubId,
-            String targetMemberId,
+            Long targetMemberId,
             Long cursorId,
             int pageSize
     ) {
@@ -46,7 +46,7 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
     }
 
     @Override
-    public List<BookStory> searchBookStories(String bookId, List<String> excludedMemberIds, Long cursorId, int pageSize) {
+    public List<BookStory> searchBookStories(String bookId, List<Long> excludedMemberIds, Long cursorId, int pageSize) {
         return queryFactory
                 .selectFrom(bookStory)
                 .where(
@@ -107,7 +107,7 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
                 .fetch();
     }
 
-    private List<BookStory> findAllBookStories(List<String> excludedMemberIds, Long cursorId, int pageSize) {
+    private List<BookStory> findAllBookStories(List<Long> excludedMemberIds, Long cursorId, int pageSize) {
         return queryFactory
                 .selectFrom(bookStory)
                 .where(
@@ -122,8 +122,8 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
     }
 
     private List<BookStory> findFollowBookStories(
-            List<String> followingMemberIds,
-            List<String> excludedMemberIds,
+            List<Long> followingMemberIds,
+            List<Long> excludedMemberIds,
             Long cursorId,
             int pageSize
     ) {
@@ -145,7 +145,7 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
                 .fetch();
     }
 
-    private List<BookStory> findMyBookStories(String memberId, Long cursorId, int pageSize) {
+    private List<BookStory> findMyBookStories(Long memberId, Long cursorId, int pageSize) {
         return queryFactory
                 .selectFrom(bookStory)
                 .where(
@@ -158,14 +158,14 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
                 .fetch();
     }
 
-    private List<BookStory> findClubBookStories(String memberId, Long clubId, Long cursorId, int pageSize) {
+    private List<BookStory> findClubBookStories(Long memberId, Long clubId, Long cursorId, int pageSize) {
         if (clubId == null) {
             throw new IllegalArgumentException("scope가 club인 경우 clubId는 필수입니다.");
         }
 
         validateClubMember(memberId, clubId);
 
-        List<String> clubMemberIds = getClubMemberIds(clubId);
+        List<Long> clubMemberIds = getClubMemberIds(clubId);
         if (clubMemberIds.isEmpty()) {
             return List.of();
         }
@@ -183,7 +183,7 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
                 .fetch();
     }
 
-    private List<BookStory> findTargetMemberBookStories(String targetMemberId, Long cursorId, int pageSize) {
+    private List<BookStory> findTargetMemberBookStories(Long targetMemberId, Long cursorId, int pageSize) {
         if (targetMemberId == null) {
             throw new IllegalArgumentException("scope가 target인 경우 targetMemberId는 필수입니다.");
         }
@@ -261,17 +261,15 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
         return bookStory.title.containsIgnoreCase(keyword.trim());
     }
 
-    private BooleanExpression notInExcludedMemberIds(List<String> excludedMemberIds) {
+    private BooleanExpression notInExcludedMemberIds(List<Long> excludedMemberIds) {
         return excludedMemberIds == null || excludedMemberIds.isEmpty() ? null : bookStory.memberId.notIn(excludedMemberIds);
     }
 
-    private void validateClubMember(String memberId, Long clubId) {
-        clubManagementAPI.validateAndFetchActiveClubMemberId(clubId, Long.valueOf(memberId));
+    private void validateClubMember(Long memberId, Long clubId) {
+        clubManagementAPI.validateAndFetchActiveClubMemberId(clubId, memberId);
     }
 
-    private List<String> getClubMemberIds(Long clubId) {
-        return clubManagementAPI.fetchActiveMemberIds(clubId).stream()
-                .map(String::valueOf)
-                .toList();
+    private List<Long> getClubMemberIds(Long clubId) {
+        return clubManagementAPI.fetchActiveMemberIds(clubId);
     }
 }

--- a/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepositoryImpl.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/BookStoryQueryRepositoryImpl.java
@@ -266,10 +266,12 @@ public class BookStoryQueryRepositoryImpl implements BookStoryQueryRepository {
     }
 
     private void validateClubMember(String memberId, Long clubId) {
-        clubManagementAPI.validateAndFetchActiveClubMemberId(clubId, memberId);
+        clubManagementAPI.validateAndFetchActiveClubMemberId(clubId, Long.valueOf(memberId));
     }
 
     private List<String> getClubMemberIds(Long clubId) {
-        return clubManagementAPI.fetchActiveMemberIds(clubId);
+        return clubManagementAPI.fetchActiveMemberIds(clubId).stream()
+                .map(String::valueOf)
+                .toList();
     }
 }

--- a/src/main/java/checkmo/bookStory/internal/repository/BookStoryRepository.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/BookStoryRepository.java
@@ -29,12 +29,12 @@ public interface BookStoryRepository extends JpaRepository<BookStory, Long>, Boo
                 WHERE b.id = :id
             """)
     BookStoryPrevNextProjection findPrevNextBookStoryId(
-            @Param("memberId") String memberId,
+            @Param("memberId") Long memberId,
             @Param("id") Long bookStoryId,
             @Param("status") BookStoryStatus status
     );
 
     @Modifying
     @Query("UPDATE BookStory b SET b.deleted = true, b.deletedAt = CURRENT_TIMESTAMP WHERE b.memberId = :memberId AND b.deleted = false")
-    void softDeleteAllByMemberId(@Param("memberId") String memberId);
+    void softDeleteAllByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/checkmo/bookStory/internal/repository/CommentRepository.java
+++ b/src/main/java/checkmo/bookStory/internal/repository/CommentRepository.java
@@ -18,7 +18,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     @Modifying
     @Query("UPDATE Comment c SET c.deleted = true, c.deletedAt = CURRENT_TIMESTAMP WHERE c.memberId = :memberId AND c.deleted = false")
-    void softDeleteAllByMemberId(@Param("memberId") String memberId);
+    void softDeleteAllByMemberId(@Param("memberId") Long memberId);
 
     @Modifying
     @Query("DELETE FROM Comment c WHERE c.bookStory.id = :bookStoryId AND c.parentComment IS NOT NULL")

--- a/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
+++ b/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
@@ -51,16 +51,16 @@ public class BookStoryQueryFacade {
      * @param bookStoryId 조회할 책 이야기 ID
      * @return 조회된 책 이야기 상세 정보 DTO
      */
-    public DetailInfo fetchBookStoryDetailInfo(String memberId, Long bookStoryId) {
+    public DetailInfo fetchBookStoryDetailInfo(Long memberId, Long bookStoryId) {
         return fetchBookStoryDetailInfoInternal(memberId, bookStoryId, true, true);
     }
 
-    public DetailInfo fetchBookStoryDetailInfoForAdmin(String memberId, Long bookStoryId) {
+    public DetailInfo fetchBookStoryDetailInfoForAdmin(Long memberId, Long bookStoryId) {
         return fetchBookStoryDetailInfoInternal(memberId, bookStoryId, false, false);
     }
 
     private DetailInfo fetchBookStoryDetailInfoInternal(
-            String memberId,
+            Long memberId,
             Long bookStoryId,
             boolean increaseViewCount,
             boolean validateBlockRelation
@@ -69,7 +69,7 @@ public class BookStoryQueryFacade {
         BookStory bookStory = bookStoryQueryService.retrieveAccessibleBookStory(memberId, bookStoryId);
 
         if (validateBlockRelation) {
-            memberAPI.validateProfileAccessible(memberId, bookStory.getMemberId());
+            memberAPI.validateProfileAccessible(toMemberApiId(memberId), toMemberApiId(bookStory.getMemberId()));
         }
 
         // 2. 사용자 상세 조회에서만 조회 수 카운트 증가
@@ -82,7 +82,9 @@ public class BookStoryQueryFacade {
 
         // 4. 작성자 정보 조회
         BasicInfoWithFollow authorInfo = memberAPI.fetchMemberBasicInfoWithFollow(
-                bookStory.getMemberId(), memberId);
+                toMemberApiId(bookStory.getMemberId()),
+                toMemberApiId(memberId)
+        );
 
         // 5. 좋아요 여부 조회
         Boolean isLiked = bookStoryQueryService.checkBookStoryLikeByMemberId(memberId, List.of(bookStory))
@@ -93,7 +95,7 @@ public class BookStoryQueryFacade {
 
         // 7. 댓글 작성자들 정보 조회
         // 7-1. 댓글 작성자들 Id 목록 조회 (Set으로 중복 제거)
-        Set<String> commentMemberIds = comments.stream()
+        Set<Long> commentMemberIds = comments.stream()
                 .flatMap(comment -> Stream.concat(
                         Stream.of(comment.getMemberId()),
                         comment.getChildrenComment().stream().map(Comment::getMemberId)
@@ -101,12 +103,14 @@ public class BookStoryQueryFacade {
                 .collect(Collectors.toSet());
 
         // 7-2. 댓글 작성자들 정보를 배치 조회 (6-1에서 조회된 정보를 리스트로 변환 후 한번에 조회)
-        Map<String, MemberExternalDTO.BasicInfo> commentMemberInfoMap =
+        Map<Long, MemberExternalDTO.BasicInfo> commentMemberInfoMap =
                 commentMemberIds.isEmpty() ? Map.of() :
-                        memberAPI.fetchMemberBasicInfoByMemberIds(new ArrayList<>(commentMemberIds));
+                        toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
+                                toMemberApiIds(new ArrayList<>(commentMemberIds))
+                        ));
 
         // 8. 댓글 DTO 변환
-        Set<String> blockedMemberIds = Set.copyOf(memberAPI.fetchBlockRelatedMemberIds(memberId));
+        Set<Long> blockedMemberIds = toLongSet(memberAPI.fetchBlockRelatedMemberIds(toMemberApiId(memberId)));
         List<CommentInfo> commentDTOList =
                 BookStoryConverter.toCommentDetailList(comments, memberId, commentMemberInfoMap, blockedMemberIds);
 
@@ -130,21 +134,21 @@ public class BookStoryQueryFacade {
     /**
      * 전체 책이야기 목록을 조회합니다.
      */
-    public BookStoryResponseDTO.BookStoryList fetchAllBookStories(String memberId, Long cursorId) {
+    public BookStoryResponseDTO.BookStoryList fetchAllBookStories(Long memberId, Long cursorId) {
         return fetchBookStoriesInternal(memberId, BookStoryRequestDTO.BookStoryScope.ALL, null, null, cursorId);
     }
 
     /**
      * 내가 작성한 책이야기 목록을 조회합니다.
      */
-    public BookStoryResponseDTO.BookStoryList fetchMyBookStories(String memberId, Long cursorId) {
+    public BookStoryResponseDTO.BookStoryList fetchMyBookStories(Long memberId, Long cursorId) {
         return fetchBookStoriesInternal(memberId, BookStoryRequestDTO.BookStoryScope.MY, null, null, cursorId);
     }
 
     /**
      * 팔로우한 회원들의 책이야기 목록을 조회합니다.
      */
-    public BookStoryResponseDTO.BookStoryList fetchFollowingBookStories(String memberId, Long cursorId) {
+    public BookStoryResponseDTO.BookStoryList fetchFollowingBookStories(Long memberId, Long cursorId) {
         return fetchBookStoriesInternal(memberId, BookStoryRequestDTO.BookStoryScope.FOLLOWING, null, null, cursorId);
     }
 
@@ -152,12 +156,12 @@ public class BookStoryQueryFacade {
      * 특정 회원의 책이야기 목록을 조회합니다.
      */
     public BookStoryResponseDTO.BookStoryList fetchMemberBookStories(
-            String memberId,
+            Long memberId,
             String targetNickname,
             Long cursorId
     ) {
-        String targetMemberId = memberAPI.fetchMemberId(targetNickname);
-        memberAPI.validateProfileAccessible(memberId, targetMemberId);
+        Long targetMemberId = Long.valueOf(memberAPI.fetchMemberId(targetNickname));
+        memberAPI.validateProfileAccessible(toMemberApiId(memberId), toMemberApiId(targetMemberId));
         return fetchBookStoriesInternal(memberId, BookStoryRequestDTO.BookStoryScope.TARGET, null, targetMemberId, cursorId);
     }
 
@@ -165,7 +169,7 @@ public class BookStoryQueryFacade {
      * 특정 클럽 멤버들의 책이야기 목록을 조회합니다.
      */
     public BookStoryResponseDTO.BookStoryList fetchClubBookStories(
-            String memberId,
+            Long memberId,
             Long clubId,
             Long cursorId
     ) {
@@ -218,17 +222,17 @@ public class BookStoryQueryFacade {
      * @return scope에 따른 책 이야기 목록 DTO
      */
     private BookStoryResponseDTO.BookStoryList fetchBookStoriesInternal(
-            String memberId,
+            Long memberId,
             BookStoryRequestDTO.BookStoryScope scope,
             Long clubId,
-            String targetMemberId,
+            Long targetMemberId,
             Long cursorId
     ) {
-        List<String> excludedMemberIds = requiresBlockFilter(scope)
-                ? memberAPI.fetchBlockRelatedMemberIds(memberId)
+        List<Long> excludedMemberIds = memberId != null && requiresBlockFilter(scope)
+                ? toLongList(memberAPI.fetchBlockRelatedMemberIds(toMemberApiId(memberId)))
                 : List.of();
-        List<String> followingMemberIds = scope == BookStoryRequestDTO.BookStoryScope.FOLLOWING
-                ? memberAPI.fetchFollowingIds(memberId)
+        List<Long> followingMemberIds = memberId != null && scope == BookStoryRequestDTO.BookStoryScope.FOLLOWING
+                ? toLongList(memberAPI.fetchFollowingIds(toMemberApiId(memberId)))
                 : List.of();
 
         // 1. BookStory 리스트 조회
@@ -248,7 +252,7 @@ public class BookStoryQueryFacade {
         Map<String, BookExternalDTO.BasicInfo> bookInfoMap = fetchBookInfo(bookStories);
 
         // 4. 작성자 정보 조회
-        Map<String, BasicInfoWithFollow> authorInfoMap = fetchAuthorInfo(memberId, bookStories);
+        Map<Long, BasicInfoWithFollow> authorInfoMap = fetchAuthorInfo(memberId, bookStories);
 
         // 5. DTO 변환
         List<BookStoryResponseDTO.BasicInfo> basicInfoList = convertToBookStoryResponses(memberId,
@@ -270,7 +274,7 @@ public class BookStoryQueryFacade {
     /**
      * 좋아요 정보 배치 조회
      */
-    private Map<Long, Boolean> fetchLikedInfo(String memberId, List<BookStory> bookStories) {
+    private Map<Long, Boolean> fetchLikedInfo(Long memberId, List<BookStory> bookStories) {
         return bookStoryQueryService.checkBookStoryLikeByMemberId(memberId, bookStories);
     }
 
@@ -288,26 +292,29 @@ public class BookStoryQueryFacade {
     /**
      * 작성자 정보 배치 조회
      */
-    private Map<String, BasicInfoWithFollow> fetchAuthorInfo(
-            String memberId,
+    private Map<Long, BasicInfoWithFollow> fetchAuthorInfo(
+            Long memberId,
             List<BookStory> bookStories
     ) {
-        List<String> targetMemberIds = bookStories.stream()
+        List<Long> targetMemberIds = bookStories.stream()
                 .map(checkmo.bookStory.internal.entity.BookStory::getMemberId)
                 .distinct()
                 .toList();
-        return memberAPI.fetchMemberBasicInfoWithFollowByMemberId(targetMemberIds, memberId);
+        return toLongKeyMap(memberAPI.fetchMemberBasicInfoWithFollowByMemberId(
+                toMemberApiIds(targetMemberIds),
+                toMemberApiId(memberId)
+        ));
     }
 
     /**
      * BookStory 엔티티들을 Response DTO로 변환
      */
     private List<BookStoryResponseDTO.BasicInfo> convertToBookStoryResponses(
-            String memberId,
+            Long memberId,
             List<BookStory> bookStoryList,
             Map<Long, Boolean> isLikedMap,
             Map<String, BookExternalDTO.BasicInfo> bookInfoMap,
-            Map<String, BasicInfoWithFollow> authorInfoMap
+            Map<Long, BasicInfoWithFollow> authorInfoMap
     ) {
 
         return bookStoryList.stream()
@@ -329,13 +336,15 @@ public class BookStoryQueryFacade {
      * @return bookId에 따른 책 이야기 목록 DTO
      */
     public BookStoryResponseDTO.BookStoryList fetchBookStoriesByBook(
-            String memberId,
+            Long memberId,
             String bookId,
             Long cursorId
     ) {
 
         // 1. BookStory 리스트 조회
-        List<String> excludedMemberIds = memberAPI.fetchBlockRelatedMemberIds(memberId);
+        List<Long> excludedMemberIds = memberId == null
+                ? List.of()
+                : toLongList(memberAPI.fetchBlockRelatedMemberIds(toMemberApiId(memberId)));
         CursorResult<BookStory> bookStoryCursorResult = CursorPagingHelper.getPage(
                 (pageSize) -> bookStoryQueryService.retrieveBookStories(
                         bookId, excludedMemberIds, cursorId, pageSize
@@ -352,7 +361,7 @@ public class BookStoryQueryFacade {
         Map<String, BookExternalDTO.BasicInfo> bookInfoMap = fetchBookInfo(bookStories);
 
         // 작성자 정보 조회
-        Map<String, BasicInfoWithFollow> authorInfoMap = fetchAuthorInfo(memberId, bookStories);
+        Map<Long, BasicInfoWithFollow> authorInfoMap = fetchAuthorInfo(memberId, bookStories);
 
         // DTO 변환
         List<BookStoryResponseDTO.BasicInfo> basicInfoList = convertToBookStoryResponses(memberId,
@@ -372,7 +381,7 @@ public class BookStoryQueryFacade {
                 bookStoryQueryService.retrieveBookStoriesForAdmin(keyword, safePage - 1, ADMIN_PAGE_SIZE);
 
         List<BookStory> bookStories = bookStoryPage.getContent();
-        List<String> memberIds = bookStories.stream()
+        List<Long> memberIds = bookStories.stream()
                 .map(BookStory::getMemberId)
                 .distinct()
                 .toList();
@@ -381,8 +390,8 @@ public class BookStoryQueryFacade {
                 .distinct()
                 .toList();
 
-        Map<String, MemberExternalDTO.DetailInfo> authorInfoMap =
-                memberAPI.fetchMemberDetailInfoByMemberIds(memberIds);
+        Map<Long, MemberExternalDTO.DetailInfo> authorInfoMap =
+                toLongKeyMap(memberAPI.fetchMemberDetailInfoByMemberIds(toMemberApiIds(memberIds)));
         Map<String, BookExternalDTO.BasicInfo> bookInfoMap =
                 bookAPI.fetchBookBasicInfoByBookIds(bookIds);
 
@@ -402,5 +411,41 @@ public class BookStoryQueryFacade {
                 .totalElements(bookStoryPage.getTotalElements())
                 .hasNext(bookStoryPage.hasNext())
                 .build();
+    }
+
+    private List<String> toMemberApiIds(List<Long> memberIds) {
+        return memberIds.stream()
+                .map(String::valueOf)
+                .toList();
+    }
+
+    private String toMemberApiId(Long memberId) {
+        return memberId == null ? null : String.valueOf(memberId);
+    }
+
+    private List<Long> toLongList(List<String> memberApiIds) {
+        if (memberApiIds == null || memberApiIds.isEmpty()) {
+            return List.of();
+        }
+        return memberApiIds.stream()
+                .map(Long::valueOf)
+                .toList();
+    }
+
+    private Set<Long> toLongSet(List<String> memberApiIds) {
+        if (memberApiIds == null || memberApiIds.isEmpty()) {
+            return Set.of();
+        }
+        return memberApiIds.stream()
+                .map(Long::valueOf)
+                .collect(Collectors.toSet());
+    }
+
+    private <T> Map<Long, T> toLongKeyMap(Map<String, T> source) {
+        return source.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> Long.valueOf(entry.getKey()),
+                        Map.Entry::getValue
+                ));
     }
 }

--- a/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
+++ b/src/main/java/checkmo/bookStory/internal/service/BookStoryQueryFacade.java
@@ -69,7 +69,7 @@ public class BookStoryQueryFacade {
         BookStory bookStory = bookStoryQueryService.retrieveAccessibleBookStory(memberId, bookStoryId);
 
         if (validateBlockRelation) {
-            memberAPI.validateProfileAccessible(toMemberApiId(memberId), toMemberApiId(bookStory.getMemberId()));
+            memberAPI.validateProfileAccessible(memberId, bookStory.getMemberId());
         }
 
         // 2. 사용자 상세 조회에서만 조회 수 카운트 증가
@@ -82,8 +82,8 @@ public class BookStoryQueryFacade {
 
         // 4. 작성자 정보 조회
         BasicInfoWithFollow authorInfo = memberAPI.fetchMemberBasicInfoWithFollow(
-                toMemberApiId(bookStory.getMemberId()),
-                toMemberApiId(memberId)
+                bookStory.getMemberId(),
+                memberId
         );
 
         // 5. 좋아요 여부 조회
@@ -105,12 +105,10 @@ public class BookStoryQueryFacade {
         // 7-2. 댓글 작성자들 정보를 배치 조회 (6-1에서 조회된 정보를 리스트로 변환 후 한번에 조회)
         Map<Long, MemberExternalDTO.BasicInfo> commentMemberInfoMap =
                 commentMemberIds.isEmpty() ? Map.of() :
-                        toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
-                                toMemberApiIds(new ArrayList<>(commentMemberIds))
-                        ));
+                        memberAPI.fetchMemberBasicInfoByMemberIds(new ArrayList<>(commentMemberIds));
 
         // 8. 댓글 DTO 변환
-        Set<Long> blockedMemberIds = toLongSet(memberAPI.fetchBlockRelatedMemberIds(toMemberApiId(memberId)));
+        Set<Long> blockedMemberIds = Set.copyOf(memberAPI.fetchBlockRelatedMemberIds(memberId));
         List<CommentInfo> commentDTOList =
                 BookStoryConverter.toCommentDetailList(comments, memberId, commentMemberInfoMap, blockedMemberIds);
 
@@ -160,8 +158,8 @@ public class BookStoryQueryFacade {
             String targetNickname,
             Long cursorId
     ) {
-        Long targetMemberId = Long.valueOf(memberAPI.fetchMemberId(targetNickname));
-        memberAPI.validateProfileAccessible(toMemberApiId(memberId), toMemberApiId(targetMemberId));
+        Long targetMemberId = memberAPI.fetchMemberId(targetNickname);
+        memberAPI.validateProfileAccessible(memberId, targetMemberId);
         return fetchBookStoriesInternal(memberId, BookStoryRequestDTO.BookStoryScope.TARGET, null, targetMemberId, cursorId);
     }
 
@@ -229,10 +227,10 @@ public class BookStoryQueryFacade {
             Long cursorId
     ) {
         List<Long> excludedMemberIds = memberId != null && requiresBlockFilter(scope)
-                ? toLongList(memberAPI.fetchBlockRelatedMemberIds(toMemberApiId(memberId)))
+                ? memberAPI.fetchBlockRelatedMemberIds(memberId)
                 : List.of();
         List<Long> followingMemberIds = memberId != null && scope == BookStoryRequestDTO.BookStoryScope.FOLLOWING
-                ? toLongList(memberAPI.fetchFollowingIds(toMemberApiId(memberId)))
+                ? memberAPI.fetchFollowingIds(memberId)
                 : List.of();
 
         // 1. BookStory 리스트 조회
@@ -300,10 +298,7 @@ public class BookStoryQueryFacade {
                 .map(checkmo.bookStory.internal.entity.BookStory::getMemberId)
                 .distinct()
                 .toList();
-        return toLongKeyMap(memberAPI.fetchMemberBasicInfoWithFollowByMemberId(
-                toMemberApiIds(targetMemberIds),
-                toMemberApiId(memberId)
-        ));
+        return memberAPI.fetchMemberBasicInfoWithFollowByMemberId(targetMemberIds, memberId);
     }
 
     /**
@@ -344,7 +339,7 @@ public class BookStoryQueryFacade {
         // 1. BookStory 리스트 조회
         List<Long> excludedMemberIds = memberId == null
                 ? List.of()
-                : toLongList(memberAPI.fetchBlockRelatedMemberIds(toMemberApiId(memberId)));
+                : memberAPI.fetchBlockRelatedMemberIds(memberId);
         CursorResult<BookStory> bookStoryCursorResult = CursorPagingHelper.getPage(
                 (pageSize) -> bookStoryQueryService.retrieveBookStories(
                         bookId, excludedMemberIds, cursorId, pageSize
@@ -391,7 +386,7 @@ public class BookStoryQueryFacade {
                 .toList();
 
         Map<Long, MemberExternalDTO.DetailInfo> authorInfoMap =
-                toLongKeyMap(memberAPI.fetchMemberDetailInfoByMemberIds(toMemberApiIds(memberIds)));
+                memberAPI.fetchMemberDetailInfoByMemberIds(memberIds);
         Map<String, BookExternalDTO.BasicInfo> bookInfoMap =
                 bookAPI.fetchBookBasicInfoByBookIds(bookIds);
 
@@ -413,39 +408,4 @@ public class BookStoryQueryFacade {
                 .build();
     }
 
-    private List<String> toMemberApiIds(List<Long> memberIds) {
-        return memberIds.stream()
-                .map(String::valueOf)
-                .toList();
-    }
-
-    private String toMemberApiId(Long memberId) {
-        return memberId == null ? null : String.valueOf(memberId);
-    }
-
-    private List<Long> toLongList(List<String> memberApiIds) {
-        if (memberApiIds == null || memberApiIds.isEmpty()) {
-            return List.of();
-        }
-        return memberApiIds.stream()
-                .map(Long::valueOf)
-                .toList();
-    }
-
-    private Set<Long> toLongSet(List<String> memberApiIds) {
-        if (memberApiIds == null || memberApiIds.isEmpty()) {
-            return Set.of();
-        }
-        return memberApiIds.stream()
-                .map(Long::valueOf)
-                .collect(Collectors.toSet());
-    }
-
-    private <T> Map<Long, T> toLongKeyMap(Map<String, T> source) {
-        return source.entrySet().stream()
-                .collect(Collectors.toMap(
-                        entry -> Long.valueOf(entry.getKey()),
-                        Map.Entry::getValue
-                ));
-    }
 }

--- a/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommandService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommandService.java
@@ -33,7 +33,7 @@ public class BookStoryCommandService {
      * @param memberId 책이야기를 작성하는 회원의 ID
      * @param request  책이야기 요청 DTO
      */
-    public Long createBookStory(String memberId, BookStoryRequestDTO.BookStoryCreate request) {
+    public Long createBookStory(Long memberId, BookStoryRequestDTO.BookStoryCreate request) {
         BookStoryStatus status = resolveStatus(request.getStatus());
         validateDescriptionForPublished(status, request.getDescription());
 
@@ -52,7 +52,7 @@ public class BookStoryCommandService {
      * @param bookStoryId 수정할 책 이야기의 ID
      * @param request     수정할 책 이야기 정보 DTO
      */
-    public Long updateBookStory(String memberId, Long bookStoryId, BookStoryRequestDTO.BookStoryUpdate request) {
+    public Long updateBookStory(Long memberId, Long bookStoryId, BookStoryRequestDTO.BookStoryUpdate request) {
         BookStory bookStory = bookStoryRepository.findById(bookStoryId)
                 .orElseThrow(() -> new BookStoryException(BookStoryErrorStatus.BOOK_STORY_NOT_FOUND));
 
@@ -80,7 +80,7 @@ public class BookStoryCommandService {
      *
      * @param bookStoryId 삭제할 책이야기의 ID
      */
-    public void deleteBookStory(String memberId, Long bookStoryId) {
+    public void deleteBookStory(Long memberId, Long bookStoryId) {
         BookStory bookStory = bookStoryRepository.findById(bookStoryId)
                 .orElseThrow(() -> new BookStoryException(BookStoryErrorStatus.BOOK_STORY_NOT_FOUND));
 
@@ -116,7 +116,7 @@ public class BookStoryCommandService {
      *
      * @param memberId 탈퇴하는 회원의 ID
      */
-    public void softDeleteAllByMemberId(String memberId) {
+    public void softDeleteAllByMemberId(Long memberId) {
         bookStoryRepository.softDeleteAllByMemberId(memberId);
     }
 

--- a/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommentCommandService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommentCommandService.java
@@ -97,19 +97,15 @@ public class BookStoryCommentCommandService {
 
     private void validateNotBlockedByCommentTarget(BookStory bookStory, Comment parentComment, Long memberId) {
         if (!memberId.equals(bookStory.getMemberId())
-                && memberAPI.hasBlockBetween(toMemberApiId(bookStory.getMemberId()), toMemberApiId(memberId))) {
+                && memberAPI.hasBlockBetween(bookStory.getMemberId(), memberId)) {
             throw new BookStoryException(BookStoryErrorStatus.COMMENT_BLOCKED);
         }
 
         if (parentComment != null
                 && !memberId.equals(parentComment.getMemberId())
-                && memberAPI.hasBlockBetween(toMemberApiId(parentComment.getMemberId()), toMemberApiId(memberId))) {
+                && memberAPI.hasBlockBetween(parentComment.getMemberId(), memberId)) {
             throw new BookStoryException(BookStoryErrorStatus.COMMENT_BLOCKED);
         }
-    }
-
-    private String toMemberApiId(Long memberId) {
-        return String.valueOf(memberId);
     }
 
     /**

--- a/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommentCommandService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/command/BookStoryCommentCommandService.java
@@ -34,7 +34,7 @@ public class BookStoryCommentCommandService {
      * @return 작성된 책이야기 ID
      */
     public Long createComment(
-            String memberId,
+            Long memberId,
             Long bookStoryId,
             Long parentCommentId,
             BookStoryRequestDTO.CommentCreate request
@@ -77,7 +77,7 @@ public class BookStoryCommentCommandService {
         commentRepository.save(comment);
 
         // 7. 댓글 작성자가 책이야기 작성자와 다를 때만 알림 이벤트 발행
-        String receiverId = parentComment != null
+        Long receiverId = parentComment != null
                 ? parentComment.getMemberId()
                 : bookStory.getMemberId();
         if (!memberId.equals(receiverId)) {
@@ -95,16 +95,21 @@ public class BookStoryCommentCommandService {
         return bookStoryId;
     }
 
-    private void validateNotBlockedByCommentTarget(BookStory bookStory, Comment parentComment, String memberId) {
-        if (!memberId.equals(bookStory.getMemberId()) && memberAPI.hasBlockBetween(bookStory.getMemberId(), memberId)) {
+    private void validateNotBlockedByCommentTarget(BookStory bookStory, Comment parentComment, Long memberId) {
+        if (!memberId.equals(bookStory.getMemberId())
+                && memberAPI.hasBlockBetween(toMemberApiId(bookStory.getMemberId()), toMemberApiId(memberId))) {
             throw new BookStoryException(BookStoryErrorStatus.COMMENT_BLOCKED);
         }
 
         if (parentComment != null
                 && !memberId.equals(parentComment.getMemberId())
-                && memberAPI.hasBlockBetween(parentComment.getMemberId(), memberId)) {
+                && memberAPI.hasBlockBetween(toMemberApiId(parentComment.getMemberId()), toMemberApiId(memberId))) {
             throw new BookStoryException(BookStoryErrorStatus.COMMENT_BLOCKED);
         }
+    }
+
+    private String toMemberApiId(Long memberId) {
+        return String.valueOf(memberId);
     }
 
     /**
@@ -117,7 +122,7 @@ public class BookStoryCommentCommandService {
      * @return 수정된 댓글 ID
      */
     public Long updateComment(
-            String memberId,
+            Long memberId,
             Long bookStoryId,
             Long commentId,
             BookStoryRequestDTO.CommentUpdate request
@@ -151,7 +156,7 @@ public class BookStoryCommentCommandService {
      * @return 삭제된 댓글 ID
      */
     public Long deleteComment(
-            String memberId,
+            Long memberId,
             Long bookStoryId,
             Long commentId
     ) {
@@ -208,7 +213,7 @@ public class BookStoryCommentCommandService {
      *
      * @param memberId 탈퇴하는 회원의 ID
      */
-    public void softDeleteAllByMemberId(String memberId) {
+    public void softDeleteAllByMemberId(Long memberId) {
         commentRepository.softDeleteAllByMemberId(memberId);
     }
 }

--- a/src/main/java/checkmo/bookStory/internal/service/command/BookStorySocialCommandService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/command/BookStorySocialCommandService.java
@@ -76,13 +76,9 @@ public class BookStorySocialCommandService {
 
     private void validateNotBlockedByAuthor(BookStory bookStory, Long memberId) {
         if (!memberId.equals(bookStory.getMemberId())
-                && memberAPI.hasBlockBetween(toMemberApiId(bookStory.getMemberId()), toMemberApiId(memberId))) {
+                && memberAPI.hasBlockBetween(bookStory.getMemberId(), memberId)) {
             throw new BookStoryException(BookStoryErrorStatus.BOOK_STORY_LIKE_BLOCKED);
         }
-    }
-
-    private String toMemberApiId(Long memberId) {
-        return String.valueOf(memberId);
     }
 
     private void deleteBookStoryLiked(BookStory bookStory, BookStoryLiked bookStoryLiked) {

--- a/src/main/java/checkmo/bookStory/internal/service/command/BookStorySocialCommandService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/command/BookStorySocialCommandService.java
@@ -33,7 +33,7 @@ public class BookStorySocialCommandService {
      * @param bookStoryId 토글할 책이야기의 ID
      * @return 좋아요가 추가됐는지/제거됐는지 여부
      */
-    public boolean toggleLikeOnBookStory(String memberId, Long bookStoryId) {
+    public boolean toggleLikeOnBookStory(Long memberId, Long bookStoryId) {
         BookStory bookStory = bookStoryRepository.findById(bookStoryId)
                 .orElseThrow(() -> new BookStoryException(BookStoryErrorStatus.BOOK_STORY_NOT_FOUND));
 
@@ -74,10 +74,15 @@ public class BookStorySocialCommandService {
                 });
     }
 
-    private void validateNotBlockedByAuthor(BookStory bookStory, String memberId) {
-        if (!memberId.equals(bookStory.getMemberId()) && memberAPI.hasBlockBetween(bookStory.getMemberId(), memberId)) {
+    private void validateNotBlockedByAuthor(BookStory bookStory, Long memberId) {
+        if (!memberId.equals(bookStory.getMemberId())
+                && memberAPI.hasBlockBetween(toMemberApiId(bookStory.getMemberId()), toMemberApiId(memberId))) {
             throw new BookStoryException(BookStoryErrorStatus.BOOK_STORY_LIKE_BLOCKED);
         }
+    }
+
+    private String toMemberApiId(Long memberId) {
+        return String.valueOf(memberId);
     }
 
     private void deleteBookStoryLiked(BookStory bookStory, BookStoryLiked bookStoryLiked) {
@@ -85,7 +90,7 @@ public class BookStorySocialCommandService {
         bookStory.removeBookStoryLiked(bookStoryLiked);
     }
 
-    private Optional<BookStoryLiked> createBookStoryLiked(BookStory bookStory, String memberId) {
+    private Optional<BookStoryLiked> createBookStoryLiked(BookStory bookStory, Long memberId) {
         try {
             BookStoryLiked bookStoryLiked = BookStoryLiked.builder()
                     .bookStory(bookStory)

--- a/src/main/java/checkmo/bookStory/internal/service/query/BookStoryQueryService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/query/BookStoryQueryService.java
@@ -46,12 +46,12 @@ public class BookStoryQueryService {
      * @return 조회된 책 이야기 엔티티 목록
      */
     public List<BookStory> retrieveBookStories(
-            String memberId,
-            List<String> excludedMemberIds,
-            List<String> followingMemberIds,
+            Long memberId,
+            List<Long> excludedMemberIds,
+            List<Long> followingMemberIds,
             BookStoryRequestDTO.BookStoryScope scope,
             Long clubId,
-            String targetMemberId,
+            Long targetMemberId,
             Long cursorId,
             int pageSize
     ) {
@@ -62,7 +62,7 @@ public class BookStoryQueryService {
 
     public List<BookStory> retrieveBookStories(
             String bookId,
-            List<String> excludedMemberIds,
+            List<Long> excludedMemberIds,
             Long cursorId,
             int pageSize
     ) {
@@ -94,7 +94,7 @@ public class BookStoryQueryService {
         return bookStory;
     }
 
-    public BookStory retrieveAccessibleBookStory(String memberId, Long bookStoryId) {
+    public BookStory retrieveAccessibleBookStory(Long memberId, Long bookStoryId) {
         BookStory bookStory = bookStoryRepository.findByIdAndDeletedFalse(bookStoryId)
                 .orElseThrow(() -> new BookStoryException(BookStoryErrorStatus.BOOK_STORY_NOT_FOUND));
 
@@ -122,7 +122,7 @@ public class BookStoryQueryService {
      * @param bookStories 조회된 책 이야기 목록
      * @return 책 이야기 ID와 좋아요 여부를 매핑한 Map
      */
-    public Map<Long, Boolean> checkBookStoryLikeByMemberId(String memberId, List<BookStory> bookStories) {
+    public Map<Long, Boolean> checkBookStoryLikeByMemberId(Long memberId, List<BookStory> bookStories) {
         if (bookStories == null || bookStories.isEmpty()) {
             return Map.of();
         }
@@ -153,7 +153,7 @@ public class BookStoryQueryService {
                 ));
     }
 
-    public BookStoryPrevNextProjection retrievePrevNextBookStoryId(String memberId, Long bookStoryId) {
+    public BookStoryPrevNextProjection retrievePrevNextBookStoryId(Long memberId, Long bookStoryId) {
         return bookStoryRepository.findPrevNextBookStoryId(memberId, bookStoryId, BookStoryStatus.PUBLISHED);
     }
 

--- a/src/main/java/checkmo/bookStory/internal/service/query/BookStoryViewCacheService.java
+++ b/src/main/java/checkmo/bookStory/internal/service/query/BookStoryViewCacheService.java
@@ -24,7 +24,7 @@ public class BookStoryViewCacheService {
      * @param memberId 조회한 유저 ID
      */
     @Async
-    public void incrementViewCount(Long bookStoryId, String memberId) {
+    public void incrementViewCount(Long bookStoryId, Long memberId) {
         String userLogKey = VIEW_USER_LOG_KEY + bookStoryId + ":" + memberId;
         String viewCountKey = VIEW_COUNT_KEY + bookStoryId;
 

--- a/src/main/java/checkmo/bookStory/web/controller/BookStoryAdminController.java
+++ b/src/main/java/checkmo/bookStory/web/controller/BookStoryAdminController.java
@@ -53,7 +53,7 @@ public class BookStoryAdminController {
     })
     @GetMapping("/{bookStoryId}")
     public ApiResponse<BookStoryResponseDTO.DetailInfo> getBookStoryForAdmin(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long bookStoryId
     ) {
         return ApiResponse.onSuccess(bookStoryQueryFacade.fetchBookStoryDetailInfoForAdmin(memberId, bookStoryId));
@@ -102,7 +102,7 @@ public class BookStoryAdminController {
     })
     @GetMapping("/members/{memberNickname}")
     public ApiResponse<BookStoryResponseDTO.BookStoryList> getMemberBookStoriesForAdmin(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String memberNickname,
             @RequestParam(required = false) Long cursorId
     ) {

--- a/src/main/java/checkmo/bookStory/web/controller/BookStoryController.java
+++ b/src/main/java/checkmo/bookStory/web/controller/BookStoryController.java
@@ -47,7 +47,7 @@ public class BookStoryController {
     })
     @PostMapping
     public ApiResponse<Long> createBookStory(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @Valid @RequestBody BookStoryRequestDTO.BookStoryCreate request
     ) {
         Long bookStoryId = bookStoryCommandService.createBookStory(memberId, request);
@@ -63,7 +63,7 @@ public class BookStoryController {
     })
     @GetMapping
     public ApiResponse<BookStoryResponseDTO.BookStoryList> getAllBookStories(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam(required = false) Long cursorId
     ) {
         var bookStories = bookStoryQueryFacade.fetchAllBookStories(memberId, cursorId);
@@ -79,7 +79,7 @@ public class BookStoryController {
     })
     @GetMapping("/me")
     public ApiResponse<BookStoryResponseDTO.BookStoryList> getMyBookStories(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam(required = false) Long cursorId
     ) {
         var bookStories = bookStoryQueryFacade.fetchMyBookStories(memberId, cursorId);
@@ -95,7 +95,7 @@ public class BookStoryController {
     })
     @GetMapping("/following")
     public ApiResponse<BookStoryResponseDTO.BookStoryList> getFollowingBookStories(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam(required = false) Long cursorId
     ) {
         var bookStories = bookStoryQueryFacade.fetchFollowingBookStories(memberId, cursorId);
@@ -114,7 +114,7 @@ public class BookStoryController {
     })
     @GetMapping("/members/{nickname}")
     public ApiResponse<BookStoryResponseDTO.BookStoryList> getMemberBookStories(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String nickname,
             @RequestParam(required = false) Long cursorId
     ) {
@@ -134,7 +134,7 @@ public class BookStoryController {
     })
     @GetMapping("/clubs/{clubId}")
     public ApiResponse<BookStoryResponseDTO.BookStoryList> getClubBookStories(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long clubId,
             @RequestParam(required = false) Long cursorId
     ) {
@@ -166,7 +166,7 @@ public class BookStoryController {
     })
     @GetMapping("/{bookStoryId}")
     public ApiResponse<BookStoryResponseDTO.DetailInfo> getBookStory(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long bookStoryId
     ) {
         var bookStory = bookStoryQueryFacade.fetchBookStoryDetailInfo(memberId, bookStoryId);
@@ -183,7 +183,7 @@ public class BookStoryController {
     })
     @PostMapping("/{bookStoryId}/like")
     public ApiResponse<Long> toggleLikeBookStory(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long bookStoryId
     ) {
         boolean isLiked = bookStorySocialCommandService.toggleLikeOnBookStory(memberId, bookStoryId);
@@ -206,7 +206,7 @@ public class BookStoryController {
     })
     @PatchMapping("/{bookStoryId}")
     public ApiResponse<Long> updateBookStory(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long bookStoryId,
             @Valid @RequestBody BookStoryRequestDTO.BookStoryUpdate request
     ) {
@@ -225,7 +225,7 @@ public class BookStoryController {
     })
     @DeleteMapping("/{bookStoryId}")
     public ApiResponse<String> deleteBookStory(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long bookStoryId
     ) {
         bookStoryCommandService.deleteBookStory(memberId, bookStoryId);
@@ -245,7 +245,7 @@ public class BookStoryController {
     })
     @PostMapping("/{bookStoryId}/comments")
     public ApiResponse<Long> createComment(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long bookStoryId,
             @RequestParam(required = false) Long parentCommentId,
             @Valid @RequestBody BookStoryRequestDTO.CommentCreate request
@@ -269,7 +269,7 @@ public class BookStoryController {
     })
     @PatchMapping("/{bookStoryId}/comments/{commentId}")
     public ApiResponse<Long> updateComment(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long bookStoryId,
             @PathVariable Long commentId,
             @Valid @RequestBody BookStoryRequestDTO.CommentUpdate request
@@ -292,7 +292,7 @@ public class BookStoryController {
     })
     @DeleteMapping("/{bookStoryId}/comments/{commentId}")
     public ApiResponse<Long> deleteComment(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long bookStoryId,
             @PathVariable Long commentId
     ) {
@@ -312,7 +312,7 @@ public class BookStoryController {
     })
     @GetMapping("/search/{bookId}")
     public ApiResponse<BookStoryResponseDTO.BookStoryList> getBookStoriesByBook(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String bookId,
             @RequestParam(required = false) Long cursorId
     ) {

--- a/src/main/java/checkmo/clubManagement/ClubManagementAPI.java
+++ b/src/main/java/checkmo/clubManagement/ClubManagementAPI.java
@@ -40,7 +40,7 @@ public interface ClubManagementAPI {
      * @param clubId 클럽 ID
      * @return 클럽에 속한 회원 ID 목록
      */
-    List<String> fetchActiveMemberIds(Long clubId);
+    List<Long> fetchActiveMemberIds(Long clubId);
 
     /**
      * 특정 모임의 특정 회원이 STAFF 상태인지 여부를 조회
@@ -49,7 +49,7 @@ public interface ClubManagementAPI {
      * @param memberId 회원 ID
      * @return true (STAFF 상태인 경우), false (STAFF 상태가 아닌 경우)
      */
-    boolean isStaffClubMember(Long clubId, String memberId);
+    boolean isStaffClubMember(Long clubId, Long memberId);
 
     /**
      * 특정 모임의 특정 회원이 STAFF 상태인지 검증
@@ -58,7 +58,7 @@ public interface ClubManagementAPI {
      * @param memberId 회원 ID
      * @throws ClubManagementException STAFF 상태가 아닐 경우 예외 발생
      */
-    void validateStaffClubMember(Long clubId, String memberId) throws ClubManagementException;
+    void validateStaffClubMember(Long clubId, Long memberId) throws ClubManagementException;
 
     /**
      * 특정 모임의 특정 회원들이 club에 속하고, ACTIVE 상태인지 검증
@@ -76,7 +76,7 @@ public interface ClubManagementAPI {
      * @param memberId 회원 ID
      * @return 멤버십 ID (ACTIVE 상태인 경우), null (ACTIVE 상태가 아닌 경우)
      */
-    Long fetchActiveClubMemberId(Long clubId, String memberId);
+    Long fetchActiveClubMemberId(Long clubId, Long memberId);
 
     /**
      * 특정 모임의 특정 회원이 ACTIVE 상태인지 검증
@@ -85,7 +85,7 @@ public interface ClubManagementAPI {
      * @param memberId 회원 ID
      * @return ClubMemberId
      */
-    Long validateAndFetchActiveClubMemberId(Long clubId, String memberId) throws ClubManagementException;
+    Long validateAndFetchActiveClubMemberId(Long clubId, Long memberId) throws ClubManagementException;
 
     /**
      * 특정 모임의 특정 회원의 멤버십 정보를 조회
@@ -94,7 +94,7 @@ public interface ClubManagementAPI {
      * @param memberId 회원 ID
      * @return MembershipDTO
      */
-    MembershipInfo fetchMembershipInfo(Long clubId, String memberId)
+    MembershipInfo fetchMembershipInfo(Long clubId, Long memberId)
             throws ClubManagementException;
 
     /**

--- a/src/main/java/checkmo/clubManagement/ClubManagementEvent.java
+++ b/src/main/java/checkmo/clubManagement/ClubManagementEvent.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 public class ClubManagementEvent {
 
     @Builder
-    public record JoinClubEvent(Long eventId, String memberId, Long clubId, String clubName) {
+    public record JoinClubEvent(Long eventId, Long memberId, Long clubId, String clubName) {
     }
 
     @Builder

--- a/src/main/java/checkmo/clubManagement/ClubManagementExternalDTO.java
+++ b/src/main/java/checkmo/clubManagement/ClubManagementExternalDTO.java
@@ -44,7 +44,7 @@ public class ClubManagementExternalDTO {
     @AllArgsConstructor
     @Builder
     public static class MembershipInfo {
-        private String memberId;
+        private Long memberId;
         private Long clubMemberId;
         private boolean active;
         private boolean staff;

--- a/src/main/java/checkmo/clubManagement/internal/ClubManagementAPIImpl.java
+++ b/src/main/java/checkmo/clubManagement/internal/ClubManagementAPIImpl.java
@@ -51,19 +51,19 @@ public class ClubManagementAPIImpl implements ClubManagementAPI {
     }
 
     @Override
-    public List<String> fetchActiveMemberIds(Long clubId) {
+    public List<Long> fetchActiveMemberIds(Long clubId) {
         return clubMemberQueryService.retrieveActiveMemberIds(clubId);
     }
 
     @Override
-    public boolean isStaffClubMember(Long clubId, String memberId) {
+    public boolean isStaffClubMember(Long clubId, Long memberId) {
         return clubMemberQueryService.findClubMember(clubId, memberId)
                 .map(ClubMember::isStaff)
                 .orElse(false);
     }
 
     @Override
-    public void validateStaffClubMember(Long clubId, String memberId) throws ClubManagementException {
+    public void validateStaffClubMember(Long clubId, Long memberId) throws ClubManagementException {
         ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
 
         if (!clubMember.isStaff()) {
@@ -94,7 +94,7 @@ public class ClubManagementAPIImpl implements ClubManagementAPI {
     }
 
     @Override
-    public Long fetchActiveClubMemberId(Long clubId, String memberId) {
+    public Long fetchActiveClubMemberId(Long clubId, Long memberId) {
         try {
             ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
 
@@ -109,7 +109,7 @@ public class ClubManagementAPIImpl implements ClubManagementAPI {
     }
 
     @Override
-    public Long validateAndFetchActiveClubMemberId(Long clubId, String memberId) throws ClubManagementException {
+    public Long validateAndFetchActiveClubMemberId(Long clubId, Long memberId) throws ClubManagementException {
         ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
 
         if (!clubMember.isActive()) {
@@ -120,7 +120,7 @@ public class ClubManagementAPIImpl implements ClubManagementAPI {
     }
 
     @Override
-    public MembershipInfo fetchMembershipInfo(Long clubId, String memberId)
+    public MembershipInfo fetchMembershipInfo(Long clubId, Long memberId)
             throws ClubManagementException {
         ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
         return ClubManagementConverter.toMembershipDTO(clubMember);

--- a/src/main/java/checkmo/clubManagement/internal/entity/Club.java
+++ b/src/main/java/checkmo/clubManagement/internal/entity/Club.java
@@ -129,11 +129,11 @@ public class Club extends BaseEntity {
     }
 
     // ============= 클럽 멤버 관련 메서드 ==============
-    public ClubMember createOwnerMember(String memberId, LocalDateTime now) {
+    public ClubMember createOwnerMember(Long memberId, LocalDateTime now) {
         return ClubMember.ownerOf(this, memberId, now);
     }
 
-    public ClubMember applyForMembership(String memberId, String joinMessage, LocalDateTime now) {
+    public ClubMember applyForMembership(Long memberId, String joinMessage, LocalDateTime now) {
         ClubMemberStatus status = decideInitialStatus();
         return ClubMember.applyTo(this, memberId, status, joinMessage, now);
     }

--- a/src/main/java/checkmo/clubManagement/internal/entity/ClubMember.java
+++ b/src/main/java/checkmo/clubManagement/internal/entity/ClubMember.java
@@ -49,14 +49,14 @@ public class ClubMember extends BaseEntity {
     private Club club;
 
     @Column(name = "member_id", nullable = false)
-    private String memberId;
+    private Long memberId;
 
     /**
      * package-private으로 엔티티 외부에서 함부로 호출 불가능하게 설정
      *
      * 클럽장 전용 메서드
      */
-    static ClubMember ownerOf(Club club, String memberId, LocalDateTime now) {
+    static ClubMember ownerOf(Club club, Long memberId, LocalDateTime now) {
         return ClubMember.builder()
                 .club(club)
                 .memberId(memberId)
@@ -71,7 +71,7 @@ public class ClubMember extends BaseEntity {
      *
      * 신규 가입 신청 전용 메서드
      */
-    static ClubMember applyTo(Club club, String memberId, ClubMemberStatus status, String message, LocalDateTime now) {
+    static ClubMember applyTo(Club club, Long memberId, ClubMemberStatus status, String message, LocalDateTime now) {
         return ClubMember.builder()
                 .club(club)
                 .memberId(memberId)

--- a/src/main/java/checkmo/clubManagement/internal/repository/ClubMemberRepository.java
+++ b/src/main/java/checkmo/clubManagement/internal/repository/ClubMemberRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
-    Optional<ClubMember> findByClubIdAndMemberId(Long clubId, String memberId);
+    Optional<ClubMember> findByClubIdAndMemberId(Long clubId, Long memberId);
 
     Optional<ClubMember> findByIdAndClubId(Long id, Long clubId);
 
@@ -24,7 +24,7 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
             + "WHERE cm.memberId = :memberId "
             + "AND cm.clubMemberStatus IN :statuses "
             + "ORDER BY cm.id ASC")
-    List<ClubIdAndName> findClubIdAndNameByMemberIdAndStatuses(String memberId, EnumSet<ClubMemberStatus> statuses);
+    List<ClubIdAndName> findClubIdAndNameByMemberIdAndStatuses(Long memberId, EnumSet<ClubMemberStatus> statuses);
 
     @Query("SELECT cm FROM ClubMember cm "
             + "WHERE cm.club.id = :clubId "
@@ -39,7 +39,7 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
             + "ORDER BY cm.id DESC")
     List<ClubMember> findByClubIdAndStatuses(Long clubId, EnumSet<ClubMemberStatus> statuses, Long cursorId, Pageable pageable);
 
-    List<ClubMember> findAllByMemberIdAndClubIdIn(String memberId, List<Long> clubIds);
+    List<ClubMember> findAllByMemberIdAndClubIdIn(Long memberId, List<Long> clubIds);
 
     long countByClubIdAndClubMemberStatusIn(Long clubId, EnumSet<ClubMemberStatus> statuses);
 }

--- a/src/main/java/checkmo/clubManagement/internal/repository/ClubRepositoryCustom.java
+++ b/src/main/java/checkmo/clubManagement/internal/repository/ClubRepositoryCustom.java
@@ -17,7 +17,7 @@ public interface ClubRepositoryCustom {
     List<ClubRecommendation> findRecommendations(
             EnumSet<ClubInterestCategory> memberCategories,
             LocalDateTime lastActivityAt,
-            String memberId,
+            Long memberId,
             int size
     );
 }

--- a/src/main/java/checkmo/clubManagement/internal/repository/ClubRepositoryCustomImpl.java
+++ b/src/main/java/checkmo/clubManagement/internal/repository/ClubRepositoryCustomImpl.java
@@ -96,7 +96,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
     public List<ClubRecommendation> findRecommendations(
             EnumSet<ClubInterestCategory> memberCategories,
             LocalDateTime lastActivityAt,
-            String memberId,
+            Long memberId,
             int size
     ) {
         // 공통 조건: 공개 여부 + 최근 활동 + 이미 클럽 가입 이력(어떤 상태이든) 제외
@@ -190,7 +190,7 @@ public class ClubRepositoryCustomImpl implements ClubRepositoryCustom {
         return club.lastActivityAt.goe(lastActivityAt);
     }
 
-    private BooleanExpression notRelated(String memberId) {
+    private BooleanExpression notRelated(Long memberId) {
         QClubMember subClubMember = new QClubMember("subClubMember");
         return JPAExpressions.selectOne()
                 .from(subClubMember)

--- a/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
@@ -201,7 +201,7 @@ public class ClubManagementQueryFacade {
         List<Long> memberIds = ExtractHelper.extractDistinctList(clubMembers, ClubMember::getMemberId);
 
         Map<Long, MemberExternalDTO.DetailInfo> memberInfoMap =
-                toLongKeyMap(memberAPI.fetchMemberDetailInfoByMemberIds(toMemberApiIds(memberIds)));
+                memberAPI.fetchMemberDetailInfoByMemberIds(memberIds);
 
         List<ClubResponseDTO.ClubMember> dtoList = clubMembers.stream()
                 .map(cm -> {
@@ -234,10 +234,7 @@ public class ClubManagementQueryFacade {
         List<Long> memberIds = ExtractHelper.extractDistinctList(clubMembers, ClubMember::getMemberId);
 
         Map<Long, MemberExternalDTO.BasicInfoWithFollow> memberInfoMap =
-                toLongKeyMap(memberAPI.fetchMemberBasicInfoWithFollowByMemberId(
-                        toMemberApiIds(memberIds),
-                        toMemberApiId(requesterId)
-                ));
+                memberAPI.fetchMemberBasicInfoWithFollowByMemberId(memberIds, requesterId);
 
         List<ClubResponseDTO.ClubParticipant> dtoList = clubMembers.stream()
                 .map(cm -> ClubManagementConverter.toClubParticipantDTO(cm, memberInfoMap.get(cm.getMemberId())))
@@ -265,7 +262,7 @@ public class ClubManagementQueryFacade {
     }
 
     public ClubRecommendationList recommend(Long memberId) {
-        List<String> memberInterestCategories = memberAPI.fetchInterestCategory(toMemberApiId(memberId)).getCategories();
+        List<String> memberInterestCategories = memberAPI.fetchInterestCategory(memberId).getCategories();
         EnumSet<ClubInterestCategory> interestCategories = mapToClubInterestCategories(memberInterestCategories);
 
         LocalDateTime lastActivityAt = LocalDateTime.now().minusYears(1);
@@ -324,7 +321,7 @@ public class ClubManagementQueryFacade {
     }
 
     public ClubPreviewList retrieveClubListByMemberNickname(String memberNickname) {
-        Long memberId = Long.valueOf(memberAPI.fetchMemberId(memberNickname));
+        Long memberId = memberAPI.fetchMemberId(memberNickname);
         List<ClubIdAndName> clubIdAndNames = clubMemberQueryService.retrieveAllActiveClubsByMemberId(memberId);
         List<ClubInfo> clubInfoList = clubIdAndNames.stream()
                 .map(c -> ClubInfo.builder()
@@ -368,7 +365,7 @@ public class ClubManagementQueryFacade {
                 .filter(ClubMember::isOwner)
                 .findFirst()
                 .orElseThrow(() -> new ClubManagementException(ClubManagementErrorStatus.CLUB_OWNER_NOT_FOUND));
-        String ownerEmail = memberAPI.fetchMemberEmail(toMemberApiId(owner.getMemberId()));
+        String ownerEmail = memberAPI.fetchMemberEmail(owner.getMemberId());
 
         long activeMemberCount = clubMembers.stream()
                 .filter(ClubMember::isActive)
@@ -399,7 +396,7 @@ public class ClubManagementQueryFacade {
 
         List<Long> memberIds = ExtractHelper.extractDistinctList(pageResult.content(), ClubMember::getMemberId);
         Map<Long, MemberExternalDTO.PersonalInfo> memberInfoMap =
-                toLongKeyMap(memberAPI.fetchMemberPersonalInfoByMemberIds(toMemberApiIds(memberIds)));
+                memberAPI.fetchMemberPersonalInfoByMemberIds(memberIds);
 
         List<ClubAdminResponseDTO.ClubActiveMemberPreview> members = pageResult.content().stream()
                 .map(clubMember -> toClubActiveMemberPreview(
@@ -431,23 +428,5 @@ public class ClubManagementQueryFacade {
                 .joinedAt(clubMember.getJoinedAt())
                 .role(ClubAdminResponseDTO.ActiveClubMemberStatus.of(clubMember.getClubMemberStatus()))
                 .build();
-    }
-
-    private List<String> toMemberApiIds(List<Long> memberIds) {
-        return memberIds.stream()
-                .map(String::valueOf)
-                .toList();
-    }
-
-    private String toMemberApiId(Long memberId) {
-        return String.valueOf(memberId);
-    }
-
-    private <T> Map<Long, T> toLongKeyMap(Map<String, T> source) {
-        return source.entrySet().stream()
-                .collect(Collectors.toMap(
-                        entry -> Long.valueOf(entry.getKey()),
-                        Map.Entry::getValue
-                ));
     }
 }

--- a/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
@@ -43,7 +43,7 @@ public class ClubManagementQueryFacade {
     private final ClubManagementQueryService clubManagementQueryService;
     private final ClubMemberQueryService clubMemberQueryService;
 
-    public ClubResponseDTO.ClubDetail retrieveClubDetail(Long clubId, String memberId) {
+    public ClubResponseDTO.ClubDetail retrieveClubDetail(Long clubId, Long memberId) {
         Club club = clubManagementQueryService.validateClub(clubId);
         ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
         boolean isStaff = clubMember.isStaff();
@@ -60,7 +60,7 @@ public class ClubManagementQueryFacade {
     }
 
     public ClubResponseDTO.ClubList retrieveClubList(
-            String memberId,
+            Long memberId,
             ClubRequestDTO.ClubSearchFilter filter,
             Long cursorId
     ) {
@@ -75,7 +75,7 @@ public class ClubManagementQueryFacade {
 
         // 클럽별 멤버 상태 배치 조회
         Map<Long, ClubMemberStatus> statusMap
-                = (memberId == null || memberId.isBlank()) ?
+                = (memberId == null) ?
                 Map.of() : clubMemberQueryService.retrieveClubMemberStatusByClubIds(memberId, clubIds);
 
         List<ClubDetailWithMyStatus> clubList = clubs.stream()
@@ -139,7 +139,7 @@ public class ClubManagementQueryFacade {
                 .build();
     }
 
-    public MyClubResponseDTO.MyClubList retrieveMyClubList(String memberId) {
+    public MyClubResponseDTO.MyClubList retrieveMyClubList(Long memberId) {
         List<ClubIdAndName> clubIdAndNames = clubMemberQueryService.retrieveAllActiveClubsByMemberId(memberId);
         List<MyClubResponseDTO.ClubInfo> clubInfoList = clubIdAndNames.stream()
                 .map(c -> MyClubResponseDTO.ClubInfo.builder()
@@ -154,7 +154,7 @@ public class ClubManagementQueryFacade {
                 .build();
     }
 
-    public ClubResponseDTO.MyMembership retrieveMyMembership(Long clubId, String memberId) {
+    public ClubResponseDTO.MyMembership retrieveMyMembership(Long clubId, Long memberId) {
         clubManagementQueryService.validateClub(clubId);
         Optional<ClubMember> clubMemberOpt = clubMemberQueryService.findClubMember(clubId, memberId);
         if (clubMemberOpt.isEmpty()) {
@@ -182,7 +182,7 @@ public class ClubManagementQueryFacade {
 
     public ClubResponseDTO.ClubMemberList retrieveClubMemberList(
             Long clubId,
-            String memberId,
+            Long memberId,
             ClubMemberStatusFilter statusFilter,
             Long cursorId
     ) {
@@ -198,9 +198,10 @@ public class ClubManagementQueryFacade {
                 DEFAULT_PAGE_SIZE
         );
         List<ClubMember> clubMembers = clubMemberCursorResult.content();
-        List<String> memberIds = ExtractHelper.extractDistinctList(clubMembers, ClubMember::getMemberId);
+        List<Long> memberIds = ExtractHelper.extractDistinctList(clubMembers, ClubMember::getMemberId);
 
-        Map<String, MemberExternalDTO.DetailInfo> memberInfoMap = memberAPI.fetchMemberDetailInfoByMemberIds(memberIds);
+        Map<Long, MemberExternalDTO.DetailInfo> memberInfoMap =
+                toLongKeyMap(memberAPI.fetchMemberDetailInfoByMemberIds(toMemberApiIds(memberIds)));
 
         List<ClubResponseDTO.ClubMember> dtoList = clubMembers.stream()
                 .map(cm -> {
@@ -218,7 +219,7 @@ public class ClubManagementQueryFacade {
 
     public ClubResponseDTO.ClubParticipantList retrieveClubParticipantList(
             Long clubId,
-            String requesterId,
+            Long requesterId,
             Long cursorId
     ) {
         Club club = clubManagementQueryService.validateClub(clubId);
@@ -230,10 +231,13 @@ public class ClubManagementQueryFacade {
                 DEFAULT_PAGE_SIZE
         );
         List<ClubMember> clubMembers = clubMemberCursorResult.content();
-        List<String> memberIds = ExtractHelper.extractDistinctList(clubMembers, ClubMember::getMemberId);
+        List<Long> memberIds = ExtractHelper.extractDistinctList(clubMembers, ClubMember::getMemberId);
 
-        Map<String, MemberExternalDTO.BasicInfoWithFollow> memberInfoMap =
-                memberAPI.fetchMemberBasicInfoWithFollowByMemberId(memberIds, requesterId);
+        Map<Long, MemberExternalDTO.BasicInfoWithFollow> memberInfoMap =
+                toLongKeyMap(memberAPI.fetchMemberBasicInfoWithFollowByMemberId(
+                        toMemberApiIds(memberIds),
+                        toMemberApiId(requesterId)
+                ));
 
         List<ClubResponseDTO.ClubParticipant> dtoList = clubMembers.stream()
                 .map(cm -> ClubManagementConverter.toClubParticipantDTO(cm, memberInfoMap.get(cm.getMemberId())))
@@ -247,7 +251,7 @@ public class ClubManagementQueryFacade {
                 .build();
     }
 
-    private void validateClubParticipantListAccess(Club club, Long clubId, String requesterId) {
+    private void validateClubParticipantListAccess(Club club, Long clubId, Long requesterId) {
         if (club.isOpen()) {
             return;
         }
@@ -260,8 +264,8 @@ public class ClubManagementQueryFacade {
         }
     }
 
-    public ClubRecommendationList recommend(String memberId) {
-        List<String> memberInterestCategories = memberAPI.fetchInterestCategory(memberId).getCategories();
+    public ClubRecommendationList recommend(Long memberId) {
+        List<String> memberInterestCategories = memberAPI.fetchInterestCategory(toMemberApiId(memberId)).getCategories();
         EnumSet<ClubInterestCategory> interestCategories = mapToClubInterestCategories(memberInterestCategories);
 
         LocalDateTime lastActivityAt = LocalDateTime.now().minusYears(1);
@@ -320,7 +324,7 @@ public class ClubManagementQueryFacade {
     }
 
     public ClubPreviewList retrieveClubListByMemberNickname(String memberNickname) {
-        String memberId = memberAPI.fetchMemberId(memberNickname);
+        Long memberId = Long.valueOf(memberAPI.fetchMemberId(memberNickname));
         List<ClubIdAndName> clubIdAndNames = clubMemberQueryService.retrieveAllActiveClubsByMemberId(memberId);
         List<ClubInfo> clubInfoList = clubIdAndNames.stream()
                 .map(c -> ClubInfo.builder()
@@ -364,7 +368,7 @@ public class ClubManagementQueryFacade {
                 .filter(ClubMember::isOwner)
                 .findFirst()
                 .orElseThrow(() -> new ClubManagementException(ClubManagementErrorStatus.CLUB_OWNER_NOT_FOUND));
-        String ownerEmail = memberAPI.fetchMemberEmail(owner.getMemberId());
+        String ownerEmail = memberAPI.fetchMemberEmail(toMemberApiId(owner.getMemberId()));
 
         long activeMemberCount = clubMembers.stream()
                 .filter(ClubMember::isActive)
@@ -393,8 +397,9 @@ public class ClubManagementQueryFacade {
                 ADMIN_PAGE_SIZE
         );
 
-        List<String> memberIds = ExtractHelper.extractDistinctList(pageResult.content(), ClubMember::getMemberId);
-        Map<String, MemberExternalDTO.PersonalInfo> memberInfoMap = memberAPI.fetchMemberPersonalInfoByMemberIds(memberIds);
+        List<Long> memberIds = ExtractHelper.extractDistinctList(pageResult.content(), ClubMember::getMemberId);
+        Map<Long, MemberExternalDTO.PersonalInfo> memberInfoMap =
+                toLongKeyMap(memberAPI.fetchMemberPersonalInfoByMemberIds(toMemberApiIds(memberIds)));
 
         List<ClubAdminResponseDTO.ClubActiveMemberPreview> members = pageResult.content().stream()
                 .map(clubMember -> toClubActiveMemberPreview(
@@ -426,5 +431,23 @@ public class ClubManagementQueryFacade {
                 .joinedAt(clubMember.getJoinedAt())
                 .role(ClubAdminResponseDTO.ActiveClubMemberStatus.of(clubMember.getClubMemberStatus()))
                 .build();
+    }
+
+    private List<String> toMemberApiIds(List<Long> memberIds) {
+        return memberIds.stream()
+                .map(String::valueOf)
+                .toList();
+    }
+
+    private String toMemberApiId(Long memberId) {
+        return String.valueOf(memberId);
+    }
+
+    private <T> Map<Long, T> toLongKeyMap(Map<String, T> source) {
+        return source.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> Long.valueOf(entry.getKey()),
+                        Map.Entry::getValue
+                ));
     }
 }

--- a/src/main/java/checkmo/clubManagement/internal/service/command/ClubManagementCommandService.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/command/ClubManagementCommandService.java
@@ -36,7 +36,7 @@ public class ClubManagementCommandService {
 
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    public void createClub(String memberId, ClubDetail request) {
+    public void createClub(Long memberId, ClubDetail request) {
         if (clubManagementQueryService.isDuplicateClubName(request.getName().trim())) {
             throw new ClubManagementException(ClubManagementErrorStatus.CLUB_DUPLICATED_NAME);
         }
@@ -50,7 +50,7 @@ public class ClubManagementCommandService {
         clubMemberRepository.save(owner);
     }
 
-    public void updateClub(Long clubId, String memberId, ClubDetail request) {
+    public void updateClub(Long clubId, Long memberId, ClubDetail request) {
         Club club = clubManagementQueryService.validateClub(clubId);
         ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
         if (!clubMember.isStaff()) {
@@ -73,7 +73,7 @@ public class ClubManagementCommandService {
         }
     }
 
-    public void deleteClub(Long clubId, String memberId) {
+    public void deleteClub(Long clubId, Long memberId) {
         Club club = clubManagementQueryService.validateClub(clubId);
         ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
         if (!clubMember.isOwner()) {

--- a/src/main/java/checkmo/clubManagement/internal/service/command/ClubMemberCommandService.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/command/ClubMemberCommandService.java
@@ -28,7 +28,7 @@ public class ClubMemberCommandService {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    public void joinClub(Long clubId, String memberId, JoinClub request) {
+    public void joinClub(Long clubId, Long memberId, JoinClub request) {
         Club club = clubManagementQueryService.validateClub(clubId);
         LocalDateTime now = LocalDateTime.now();
 
@@ -48,10 +48,10 @@ public class ClubMemberCommandService {
                         });
     }
 
-    public void updateClubMemberStatus(Long clubId, String actorId, Long targetId, ClubMemberStatusAction request) {
+    public void updateClubMemberStatus(Long clubId, Long actorId, Long targetId, ClubMemberStatusAction request) {
         Club club = clubManagementQueryService.validateClub(clubId);
         ClubMember actor = clubMemberQueryService.validateClubMember(clubId, actorId);
-        ClubMember target = clubMemberQueryService.validateClubMember(clubId, targetId);
+        ClubMember target = clubMemberQueryService.validateClubMemberById(clubId, targetId);
         LocalDateTime now = LocalDateTime.now();
 
         switch (request.getCommand()) {
@@ -63,7 +63,7 @@ public class ClubMemberCommandService {
         }
     }
 
-    public void leaveClub(Long clubId, String memberId) {
+    public void leaveClub(Long clubId, Long memberId) {
         clubManagementQueryService.validateClub(clubId);
         ClubMember clubMember = clubMemberQueryService.validateClubMember(clubId, memberId);
         clubMember.leave(LocalDateTime.now());
@@ -91,7 +91,7 @@ public class ClubMemberCommandService {
         log.info("{} Club 멤버 강제 탈퇴: actorId={}, targetId={}", club.getName(), actor.getId(), target.getId());
     }
 
-    private void publishJoinClubEvent(String memberId, Club club, ClubMember clubMember) {
+    private void publishJoinClubEvent(Long memberId, Club club, ClubMember clubMember) {
         JoinClubEvent joinClubEvent = new JoinClubEvent(clubMember.getId(), memberId, club.getId(), club.getName());
         eventPublisher.publishEvent(joinClubEvent);
     }

--- a/src/main/java/checkmo/clubManagement/internal/service/query/ClubManagementQueryService.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/query/ClubManagementQueryService.java
@@ -64,7 +64,7 @@ public class ClubManagementQueryService {
     public List<ClubRecommendation> recommend(
             EnumSet<ClubInterestCategory> interestCategories,
             LocalDateTime lastActivityAt,
-            String memberId
+            Long memberId
     ) {
         return clubRepository.findRecommendations(interestCategories, lastActivityAt, memberId, 3);
     }

--- a/src/main/java/checkmo/clubManagement/internal/service/query/ClubMemberQueryService.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/query/ClubMemberQueryService.java
@@ -23,27 +23,27 @@ public class ClubMemberQueryService {
 
     private final ClubMemberRepository clubMemberRepository;
 
-    public ClubMember validateClubMember(Long clubId, String memberId) throws ClubManagementException {
+    public ClubMember validateClubMember(Long clubId, Long memberId) throws ClubManagementException {
         return clubMemberRepository.findByClubIdAndMemberId(clubId, memberId)
                 .orElseThrow(() -> new ClubManagementException(ClubManagementErrorStatus.CLUB_MEMBER_NOT_FOUND));
     }
 
-    public ClubMember validateClubMember(Long clubId, Long clubMemberId) throws ClubManagementException {
+    public ClubMember validateClubMemberById(Long clubId, Long clubMemberId) throws ClubManagementException {
         return clubMemberRepository.findByIdAndClubId(clubMemberId, clubId)
                 .orElseThrow(() -> new ClubManagementException(ClubManagementErrorStatus.CLUB_MEMBER_NOT_FOUND));
     }
 
-    public List<ClubIdAndName> retrieveAllActiveClubsByMemberId(String memberId) {
+    public List<ClubIdAndName> retrieveAllActiveClubsByMemberId(Long memberId) {
         EnumSet<ClubMemberStatus> activeStatuses = ClubMemberStatus.activeStatuses();
         return clubMemberRepository.findClubIdAndNameByMemberIdAndStatuses(memberId, activeStatuses);
     }
 
-    public Optional<ClubMember> findClubMember(Long clubId, String memberId) {
+    public Optional<ClubMember> findClubMember(Long clubId, Long memberId) {
         return clubMemberRepository.findByClubIdAndMemberId(clubId, memberId);
     }
 
     public Map<Long, ClubMemberStatus> retrieveClubMemberStatusByClubIds(
-            String memberId,
+            Long memberId,
             List<Long> clubIds
     ) {
         // clubMemberRepository에서 clubId IN :clubIds AND memberId = :memberId 조건으로 여러 상태를 한 번에 조회
@@ -79,7 +79,7 @@ public class ClubMemberQueryService {
         return clubMemberRepository.countByClubIdAndClubMemberStatusIn(clubId, ClubMemberStatus.activeStatuses());
     }
 
-    public List<String> retrieveActiveMemberIds(Long clubId) {
+    public List<Long> retrieveActiveMemberIds(Long clubId) {
         return clubMemberRepository.findByClubIdAndStatuses(clubId, ClubMemberStatus.activeStatuses(), null,
                         Pageable.unpaged())
                 .stream()

--- a/src/main/java/checkmo/clubManagement/web/controller/ClubController.java
+++ b/src/main/java/checkmo/clubManagement/web/controller/ClubController.java
@@ -58,7 +58,7 @@ public class ClubController {
     @PostMapping
     public ApiResponse<String> createClub(
             @RequestBody @Valid ClubRequestDTO.ClubDetail request,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubManagementCommandService.createClub(memberId, request);
         return ApiResponse.onSuccess("독서 모임이 정상적으로 생성되었습니다.");
@@ -77,7 +77,7 @@ public class ClubController {
     public ApiResponse<String> updateClub(
             @PathVariable Long clubId,
             @RequestBody @Valid ClubRequestDTO.ClubDetail request,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubManagementCommandService.updateClub(clubId, memberId, request);
         return ApiResponse.onSuccess("독서모임이 정상적으로 수정되었습니다.");
@@ -108,7 +108,7 @@ public class ClubController {
     @GetMapping("/{clubId}")
     public ApiResponse<ClubResponseDTO.ClubDetail> getClubDetail(
             @PathVariable Long clubId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveClubDetail(clubId, memberId));
     }
@@ -125,7 +125,7 @@ public class ClubController {
     @DeleteMapping("/{clubId}")
     public ApiResponse<String> deleteClub(
             @PathVariable Long clubId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubManagementCommandService.deleteClub(clubId, memberId);
         return ApiResponse.onSuccess("독서모임이 정상적으로 삭제되었습니다.");
@@ -143,7 +143,7 @@ public class ClubController {
     public ApiResponse<ClubResponseDTO.ClubList> searchClubs(
             @ModelAttribute @ParameterObject ClubRequestDTO.ClubSearchFilter filter,
             @RequestParam(required = false) Long cursorId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveClubList(memberId, filter, cursorId));
     }
@@ -154,7 +154,7 @@ public class ClubController {
     })
     @GetMapping("/recommendations")
     public ApiResponse<ClubResponseDTO.ClubRecommendationList> recommendClubs(
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubManagementQueryFacade.recommend(memberId));
     }
@@ -187,7 +187,7 @@ public class ClubController {
     public ApiResponse<String> joinClub(
             @PathVariable Long clubId,
             @RequestBody @Valid ClubRequestDTO.JoinClub request,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubMemberCommandService.joinClub(clubId, memberId, request);
         return ApiResponse.onSuccess("독서 모임 가입 신청이 완료되었습니다.");
@@ -204,7 +204,7 @@ public class ClubController {
     @GetMapping("/{clubId}/me")
     public ApiResponse<ClubResponseDTO.MyMembership> checkMyStatusInClub(
             @PathVariable Long clubId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveMyMembership(clubId, memberId));
     }
@@ -234,7 +234,7 @@ public class ClubController {
             @PathVariable Long clubId,
             @RequestParam ClubMemberStatusFilter status,
             @RequestParam(required = false) Long cursorId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveClubMemberList(clubId, memberId, status, cursorId));
     }
@@ -254,7 +254,7 @@ public class ClubController {
     public ApiResponse<ClubResponseDTO.ClubParticipantList> getClubParticipants(
             @PathVariable Long clubId,
             @RequestParam(required = false) Long cursorId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveClubParticipantList(clubId, memberId, cursorId));
     }
@@ -274,7 +274,7 @@ public class ClubController {
             @PathVariable Long clubId,
             @PathVariable Long clubMemberId,
             @RequestBody @Valid ClubRequestDTO.ClubMemberStatusAction request,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubMemberCommandService.updateClubMemberStatus(clubId, memberId, clubMemberId, request);
         return ApiResponse.onSuccess("독서 모임 회원 등급이 정상적으로 수정되었습니다.");
@@ -289,7 +289,7 @@ public class ClubController {
     @DeleteMapping("/{clubId}/leave")
     public ApiResponse<String> leaveClub(
             @PathVariable Long clubId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubMemberCommandService.leaveClub(clubId, memberId);
         return ApiResponse.onSuccess("독서모임에서 탈퇴되었습니다.");

--- a/src/main/java/checkmo/clubManagement/web/controller/MyClubController.java
+++ b/src/main/java/checkmo/clubManagement/web/controller/MyClubController.java
@@ -29,7 +29,7 @@ public class MyClubController {
     })
     @GetMapping
     public ApiResponse<MyClubResponseDTO.MyClubList> getMyClubs(
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubManagementQueryFacade.retrieveMyClubList(memberId));
     }

--- a/src/main/java/checkmo/clubMeeting/ClubMeetingAPI.java
+++ b/src/main/java/checkmo/clubMeeting/ClubMeetingAPI.java
@@ -59,7 +59,7 @@ public interface ClubMeetingAPI {
 
     ClubMeetingExternalDTO.BookReviewReportInfo fetchBookReviewReportInfo(Long bookReviewId);
 
-    String fetchTopicAuthorId(Long topicId);
+    Long fetchTopicAuthorId(Long topicId);
 
-    String fetchBookReviewAuthorId(Long bookReviewId);
+    Long fetchBookReviewAuthorId(Long bookReviewId);
 }

--- a/src/main/java/checkmo/clubMeeting/internal/ClubMeetingAPIImpl.java
+++ b/src/main/java/checkmo/clubMeeting/internal/ClubMeetingAPIImpl.java
@@ -129,14 +129,14 @@ public class ClubMeetingAPIImpl implements ClubMeetingAPI {
     }
 
     @Override
-    public String fetchTopicAuthorId(Long topicId) {
+    public Long fetchTopicAuthorId(Long topicId) {
         Topic topic = clubTopicQueryService.validateTopic(topicId);
-        return String.valueOf(topic.getMemberId());
+        return topic.getMemberId();
     }
 
     @Override
-    public String fetchBookReviewAuthorId(Long bookReviewId) {
+    public Long fetchBookReviewAuthorId(Long bookReviewId) {
         BookReview bookReview = clubBookReviewQueryService.validateBookReview(bookReviewId);
-        return String.valueOf(bookReview.getMemberId());
+        return bookReview.getMemberId();
     }
 }

--- a/src/main/java/checkmo/clubMeeting/internal/ClubMeetingAPIImpl.java
+++ b/src/main/java/checkmo/clubMeeting/internal/ClubMeetingAPIImpl.java
@@ -131,12 +131,12 @@ public class ClubMeetingAPIImpl implements ClubMeetingAPI {
     @Override
     public String fetchTopicAuthorId(Long topicId) {
         Topic topic = clubTopicQueryService.validateTopic(topicId);
-        return topic.getMemberId();
+        return String.valueOf(topic.getMemberId());
     }
 
     @Override
     public String fetchBookReviewAuthorId(Long bookReviewId) {
         BookReview bookReview = clubBookReviewQueryService.validateBookReview(bookReviewId);
-        return bookReview.getMemberId();
+        return String.valueOf(bookReview.getMemberId());
     }
 }

--- a/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
+++ b/src/main/java/checkmo/clubMeeting/internal/converter/ClubMeetingConverter.java
@@ -45,7 +45,7 @@ public class ClubMeetingConverter {
     public static BookReview toBookReview(
             BookShelfRequestDTO.BookReviewCreate request,
             Long clubMemberId,
-            String memberId
+            Long memberId
     ) {
         return BookReview.builder()
                 .description(request.getDescription())
@@ -57,7 +57,7 @@ public class ClubMeetingConverter {
 
     public static Topic toTopic(
             BookShelfRequestDTO.TopicCreate topicCreateDTO,
-            String memberId,
+            Long memberId,
             Long clubMemberId
     ) {
         return Topic.builder()
@@ -74,7 +74,7 @@ public class ClubMeetingConverter {
     public static BookShelfResponseDTO.TopicDetail toTopicDetailDTO(
             Topic topic,
             MemberExternalDTO.BasicInfo authorInfo,
-            String memberId
+            Long memberId
     ) {
         return BookShelfResponseDTO.TopicDetail.builder()
                 .topicId(topic.getId())
@@ -135,7 +135,7 @@ public class ClubMeetingConverter {
 
     public static MeetingResponseDTO.Topic toTopicDTO(
             Topic topic,
-            Map<String, MemberExternalDTO.BasicInfo> authorInfoMap,
+            Map<Long, MemberExternalDTO.BasicInfo> authorInfoMap,
             Set<Long> selectedTopicIds
     ) {
         return MeetingResponseDTO.Topic.builder()
@@ -194,12 +194,12 @@ public class ClubMeetingConverter {
 
     public static List<MeetingResponseDTO.MeetingMember> toMeetingMembersDTO(
             List<MembershipInfo> clubMemberships,
-            Map<String, MemberExternalDTO.BasicInfo> memberBasicInfoMap,
+            Map<Long, MemberExternalDTO.BasicInfo> memberBasicInfoMap,
             Map<Long, Long> clubMemberIdToTeamIdMap,
             Map<Long, Integer> teamIdToTeamNumberMap
     ) {
         List<MembershipInfo> safeMemberships = (clubMemberships != null) ? clubMemberships : List.of();
-        Map<String, MemberExternalDTO.BasicInfo> safeMemberInfoMap =
+        Map<Long, MemberExternalDTO.BasicInfo> safeMemberInfoMap =
                 (memberBasicInfoMap != null) ? memberBasicInfoMap : Map.of();
         Map<Long, Long> safeClubMemberToTeamIdMap =
                 (clubMemberIdToTeamIdMap != null) ? clubMemberIdToTeamIdMap : Map.of();
@@ -209,7 +209,7 @@ public class ClubMeetingConverter {
         return safeMemberships.stream()
                 .map(m -> {
                     Long clubMemberId = m.getClubMemberId();
-                    String memberId = m.getMemberId();
+                    Long memberId = m.getMemberId();
 
                     MemberExternalDTO.BasicInfo basic = safeMemberInfoMap.get(memberId);
 

--- a/src/main/java/checkmo/clubMeeting/internal/entity/BookReview.java
+++ b/src/main/java/checkmo/clubMeeting/internal/entity/BookReview.java
@@ -37,7 +37,7 @@ public class BookReview extends BaseEntity {
     private Long clubMemberId;
 
     @Column(name = "member_id", nullable = false)
-    private String memberId;
+    private Long memberId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_id")

--- a/src/main/java/checkmo/clubMeeting/internal/entity/Topic.java
+++ b/src/main/java/checkmo/clubMeeting/internal/entity/Topic.java
@@ -45,7 +45,7 @@ public class Topic extends BaseEntity {
     private Long clubMemberId;
 
     @Column(name = "member_id", nullable = false)
-    private String memberId;
+    private Long memberId;
 
     @Builder.Default
     @OneToMany(mappedBy = "topic", cascade = CascadeType.REMOVE, orphanRemoval = true)

--- a/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,7 @@ public class ClubMeetingQueryFacade {
     // ========== 책장 관련 조회 메서드 ==========
     public BookShelfResponseDTO.BookShelfList retrieveBookShelfList(
             Long clubId,
-            String memberId,
+            Long memberId,
             Long cursorId
     ) {
         MembershipInfo clubMembership = validateClubAndReturnClubMembership(clubId, memberId);
@@ -83,7 +84,7 @@ public class ClubMeetingQueryFacade {
                 .build();
     }
 
-    public BookShelfResponseDTO.BookShelfDetail retrieveBookShelf(Long clubId, Long meetingId, String memberId) {
+    public BookShelfResponseDTO.BookShelfDetail retrieveBookShelf(Long clubId, Long meetingId, Long memberId) {
         validateClubAndClubMembershipActive(clubId, memberId);
         Meeting meeting = clubMeetingQueryService.validateMeeting(clubId, meetingId);
 
@@ -95,7 +96,7 @@ public class ClubMeetingQueryFacade {
                 .build();
     }
 
-    public BookShelfUpdate retrieveBookShelfDetail(Long clubId, Long meetingId, String memberId) {
+    public BookShelfUpdate retrieveBookShelfDetail(Long clubId, Long meetingId, Long memberId) {
         MembershipInfo clubMembership = validateClubAndReturnClubMembership(clubId, memberId);
         if (!clubMembership.isStaff()) {
             throw new ClubMeetingException(ClubMeetingErrorStatus.CLUB_STAFF_ONLY);
@@ -111,7 +112,7 @@ public class ClubMeetingQueryFacade {
     public BookShelfResponseDTO.TopicList retrieveTopicList(
             Long clubId,
             Long meetingId,
-            String memberId,
+            Long memberId,
             Long cursorId
     ) {
         validateClubAndReturnClubMembership(clubId, memberId);
@@ -124,9 +125,10 @@ public class ClubMeetingQueryFacade {
         );
         List<Topic> topics = topicCursorResult.content();
 
-        Map<String, MemberExternalDTO.BasicInfo> authorInfoMap
-                = memberAPI.fetchMemberBasicInfoByMemberIds(
-                ExtractHelper.extractDistinctList(topics, Topic::getMemberId));
+        Map<Long, MemberExternalDTO.BasicInfo> authorInfoMap =
+                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
+                        toMemberApiIds(ExtractHelper.extractDistinctList(topics, Topic::getMemberId))
+                ));
 
         return BookShelfResponseDTO.TopicList.builder()
                 .topicDetailList(mapTopicsToTopicDetail(topics, authorInfoMap, memberId))
@@ -138,7 +140,7 @@ public class ClubMeetingQueryFacade {
     public BookShelfResponseDTO.BookReviewList retrieveBookReviewList(
             Long clubId,
             Long meetingId,
-            String memberId,
+            Long memberId,
             Long cursorId
     ) {
         MembershipInfo membershipInfo = validateClubAndReturnClubMembership(clubId, memberId);
@@ -154,9 +156,10 @@ public class ClubMeetingQueryFacade {
         );
         List<BookReview> bookReviews = bookReviewCursorResult.content();
 
-        Map<String, MemberExternalDTO.BasicInfo> authorInfoMap =
-                memberAPI.fetchMemberBasicInfoByMemberIds(
-                        ExtractHelper.extractDistinctList(bookReviews, BookReview::getMemberId));
+        Map<Long, MemberExternalDTO.BasicInfo> authorInfoMap =
+                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
+                        toMemberApiIds(ExtractHelper.extractDistinctList(bookReviews, BookReview::getMemberId))
+                ));
 
         return BookShelfResponseDTO.BookReviewList.builder()
                 .bookReviewDetailList(
@@ -167,7 +170,7 @@ public class ClubMeetingQueryFacade {
     }
 
     // ========== 미팅 관련 조회 메서드 ==========
-    public MeetingResponseDTO.NextMeetingRedirect retrieveNextMeeting(Long clubId, String memberId) {
+    public MeetingResponseDTO.NextMeetingRedirect retrieveNextMeeting(Long clubId, Long memberId) {
         validateClubAndClubMembershipActive(clubId, memberId);
 
         Meeting nextMeeting = clubMeetingQueryService.retrieveNextFutureMeeting(clubId, LocalDateTime.now());
@@ -180,7 +183,7 @@ public class ClubMeetingQueryFacade {
     public MeetingResponseDTO.MeetingInfo retrieveMeetingInfo(
             Long clubId,
             Long meetingId,
-            String memberId
+            Long memberId
     ) {
         MembershipInfo clubMembership = validateClubAndReturnClubMembership(clubId, memberId);
         if (!clubMembership.isActive()) {
@@ -208,8 +211,10 @@ public class ClubMeetingQueryFacade {
                 = clubManagementAPI.fetchMembershipInfoByClubMemberIds(clubMemberIdToTeamIdMap.keySet());
 
         // 멤버십에 해당하는 멤버 정보 배치 조회
-        Map<String, MemberExternalDTO.BasicInfo> memberBasicInfoMap
-                = memberAPI.fetchMemberBasicInfoByMemberIds(extractMemberIds(clubMemberIdToMembershipInfoMap));
+        Map<Long, MemberExternalDTO.BasicInfo> memberBasicInfoMap =
+                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
+                        toMemberApiIds(extractMemberIds(clubMemberIdToMembershipInfoMap))
+                ));
 
         // teamNumber -> members 리스트 맵 구성
         Map<Integer, List<MeetingResponseDTO.MeetingMember>> teamNumberToMembersMap = mapTeamNumberToMeetingMembers(
@@ -225,7 +230,7 @@ public class ClubMeetingQueryFacade {
     public MeetingResponseDTO.MeetingMemberList retrieveMeetingMemberList(
             Long clubId,
             Long meetingId,
-            String memberId
+            Long memberId
     ) {
         MembershipInfo clubMembership = validateClubAndReturnClubMembership(clubId, memberId);
         if (!clubMembership.isStaff()) {
@@ -246,10 +251,11 @@ public class ClubMeetingQueryFacade {
                     .build();
         }
         // 클럽 멤버의 멤버 정보 배치 조회
-        Map<String, MemberExternalDTO.BasicInfo> memberInfoMap
-                = memberAPI.fetchMemberBasicInfoByMemberIds(
-                ExtractHelper.extractDistinctList(clubMembershipList, MembershipInfo::getMemberId));
-        Map<String, MemberExternalDTO.BasicInfo> safeMemberInfoMap = (memberInfoMap != null) ? memberInfoMap : Map.of();
+        Map<Long, MemberExternalDTO.BasicInfo> memberInfoMap =
+                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
+                        toMemberApiIds(ExtractHelper.extractDistinctList(clubMembershipList, MembershipInfo::getMemberId))
+                ));
+        Map<Long, MemberExternalDTO.BasicInfo> safeMemberInfoMap = (memberInfoMap != null) ? memberInfoMap : Map.of();
 
         // 팀 배정 정보 조회
         Map<Long, Long> clubMemberIdToTeamIdMap = retrieveClubMemberIdToTeamIdMap(teams);
@@ -269,7 +275,7 @@ public class ClubMeetingQueryFacade {
     }
 
     public MeetingResponseDTO.TeamTopic retrieveSelectableTopics(
-            Long clubId, Long meetingId, Long teamId, String memberId
+            Long clubId, Long meetingId, Long teamId, Long memberId
     ) {
         clubManagementAPI.validateAndFetchActiveClubMemberId(clubId, memberId);
 
@@ -283,8 +289,10 @@ public class ClubMeetingQueryFacade {
         Set<Long> selectedTopicIds = clubMeetingTeamQueryService.retrieveSelectedTopicIds(team.getId(), topicIds);
 
         // 토픽 작성자 정보 배치 조회
-        Map<String, MemberExternalDTO.BasicInfo> authorInfoMap
-                = memberAPI.fetchMemberBasicInfoByMemberIds(ExtractHelper.extractDistinctList(topics, Topic::getMemberId));
+        Map<Long, MemberExternalDTO.BasicInfo> authorInfoMap =
+                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
+                        toMemberApiIds(ExtractHelper.extractDistinctList(topics, Topic::getMemberId))
+                ));
 
         List<TeamKey> existingTeams = ClubMeetingConverter.toExistingTeamsDTO(teams);
         return MeetingResponseDTO.TeamTopic.builder()
@@ -301,12 +309,12 @@ public class ClubMeetingQueryFacade {
                 .build();
     }
 
-    private MembershipInfo validateClubAndReturnClubMembership(Long clubId, String memberId) {
+    private MembershipInfo validateClubAndReturnClubMembership(Long clubId, Long memberId) {
         clubManagementAPI.validateClub(clubId);
         return clubManagementAPI.fetchMembershipInfo(clubId, memberId);
     }
 
-    private void validateClubAndClubMembershipActive(Long clubId, String memberId) {
+    private void validateClubAndClubMembershipActive(Long clubId, Long memberId) {
         clubManagementAPI.validateClub(clubId);
         clubManagementAPI.validateAndFetchActiveClubMemberId(clubId, memberId);
     }
@@ -321,8 +329,8 @@ public class ClubMeetingQueryFacade {
 
     private List<BookShelfResponseDTO.TopicDetail> mapTopicsToTopicDetail(
             List<Topic> topics,
-            Map<String, MemberExternalDTO.BasicInfo> authorInfoMap,
-            String memberId //요청한 회원 ID -> 작성자 판별용
+            Map<Long, MemberExternalDTO.BasicInfo> authorInfoMap,
+            Long memberId //요청한 회원 ID -> 작성자 판별용
     ) {
         return topics.stream()
                 .map(topic ->
@@ -342,7 +350,7 @@ public class ClubMeetingQueryFacade {
     private List<BookShelfResponseDTO.BookReviewDetail> mapReviewsToReviewDetail(
             List<BookReview> bookReviews,
             Long actorId,
-            Map<String, MemberExternalDTO.BasicInfo> authorInfoMap
+            Map<Long, MemberExternalDTO.BasicInfo> authorInfoMap
     ) {
         return bookReviews.stream()
                 .map(review -> ClubMeetingConverter.toBookReviewDetailDTO(
@@ -357,7 +365,7 @@ public class ClubMeetingQueryFacade {
             Map<Long, Long> clubMemberIdToTeamIdMap,
             Map<Long, Integer> teamIdToTeamNumberMap,
             Map<Long, MembershipInfo> clubMemberIdToMembershipMap,
-            Map<String, MemberExternalDTO.BasicInfo> memberInfoMap
+            Map<Long, MemberExternalDTO.BasicInfo> memberInfoMap
     ) {
         Map<Integer, List<MeetingResponseDTO.MeetingMember>> result = new HashMap<>();
 
@@ -386,7 +394,7 @@ public class ClubMeetingQueryFacade {
                     .teamKey(null)
                     .build();
 
-            result.computeIfAbsent(teamNumber, k -> new java.util.ArrayList<>()).add(dto);
+            result.computeIfAbsent(teamNumber, k -> new ArrayList<>()).add(dto);
         }
 
         return result;
@@ -404,7 +412,7 @@ public class ClubMeetingQueryFacade {
     }
 
     // ========== 추출 메서드 ==========
-    private List<String> extractMemberIds(Map<Long, MembershipInfo> clubMembershipMap) {
+    private List<Long> extractMemberIds(Map<Long, MembershipInfo> clubMembershipMap) {
         if (clubMembershipMap == null) {
             return List.of();
         }
@@ -412,5 +420,19 @@ public class ClubMeetingQueryFacade {
                 .map(MembershipInfo::getMemberId)
                 .distinct()
                 .toList();
+    }
+
+    private List<String> toMemberApiIds(List<Long> memberIds) {
+        return memberIds.stream()
+                .map(String::valueOf)
+                .toList();
+    }
+
+    private <T> Map<Long, T> toLongKeyMap(Map<String, T> source) {
+        return source.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> Long.valueOf(entry.getKey()),
+                        Map.Entry::getValue
+                ));
     }
 }

--- a/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/ClubMeetingQueryFacade.java
@@ -126,9 +126,7 @@ public class ClubMeetingQueryFacade {
         List<Topic> topics = topicCursorResult.content();
 
         Map<Long, MemberExternalDTO.BasicInfo> authorInfoMap =
-                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
-                        toMemberApiIds(ExtractHelper.extractDistinctList(topics, Topic::getMemberId))
-                ));
+                memberAPI.fetchMemberBasicInfoByMemberIds(ExtractHelper.extractDistinctList(topics, Topic::getMemberId));
 
         return BookShelfResponseDTO.TopicList.builder()
                 .topicDetailList(mapTopicsToTopicDetail(topics, authorInfoMap, memberId))
@@ -157,9 +155,7 @@ public class ClubMeetingQueryFacade {
         List<BookReview> bookReviews = bookReviewCursorResult.content();
 
         Map<Long, MemberExternalDTO.BasicInfo> authorInfoMap =
-                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
-                        toMemberApiIds(ExtractHelper.extractDistinctList(bookReviews, BookReview::getMemberId))
-                ));
+                memberAPI.fetchMemberBasicInfoByMemberIds(ExtractHelper.extractDistinctList(bookReviews, BookReview::getMemberId));
 
         return BookShelfResponseDTO.BookReviewList.builder()
                 .bookReviewDetailList(
@@ -212,9 +208,7 @@ public class ClubMeetingQueryFacade {
 
         // 멤버십에 해당하는 멤버 정보 배치 조회
         Map<Long, MemberExternalDTO.BasicInfo> memberBasicInfoMap =
-                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
-                        toMemberApiIds(extractMemberIds(clubMemberIdToMembershipInfoMap))
-                ));
+                memberAPI.fetchMemberBasicInfoByMemberIds(extractMemberIds(clubMemberIdToMembershipInfoMap));
 
         // teamNumber -> members 리스트 맵 구성
         Map<Integer, List<MeetingResponseDTO.MeetingMember>> teamNumberToMembersMap = mapTeamNumberToMeetingMembers(
@@ -252,9 +246,7 @@ public class ClubMeetingQueryFacade {
         }
         // 클럽 멤버의 멤버 정보 배치 조회
         Map<Long, MemberExternalDTO.BasicInfo> memberInfoMap =
-                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
-                        toMemberApiIds(ExtractHelper.extractDistinctList(clubMembershipList, MembershipInfo::getMemberId))
-                ));
+                memberAPI.fetchMemberBasicInfoByMemberIds(ExtractHelper.extractDistinctList(clubMembershipList, MembershipInfo::getMemberId));
         Map<Long, MemberExternalDTO.BasicInfo> safeMemberInfoMap = (memberInfoMap != null) ? memberInfoMap : Map.of();
 
         // 팀 배정 정보 조회
@@ -290,9 +282,7 @@ public class ClubMeetingQueryFacade {
 
         // 토픽 작성자 정보 배치 조회
         Map<Long, MemberExternalDTO.BasicInfo> authorInfoMap =
-                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(
-                        toMemberApiIds(ExtractHelper.extractDistinctList(topics, Topic::getMemberId))
-                ));
+                memberAPI.fetchMemberBasicInfoByMemberIds(ExtractHelper.extractDistinctList(topics, Topic::getMemberId));
 
         List<TeamKey> existingTeams = ClubMeetingConverter.toExistingTeamsDTO(teams);
         return MeetingResponseDTO.TeamTopic.builder()
@@ -422,17 +412,4 @@ public class ClubMeetingQueryFacade {
                 .toList();
     }
 
-    private List<String> toMemberApiIds(List<Long> memberIds) {
-        return memberIds.stream()
-                .map(String::valueOf)
-                .toList();
-    }
-
-    private <T> Map<Long, T> toLongKeyMap(Map<String, T> source) {
-        return source.entrySet().stream()
-                .collect(Collectors.toMap(
-                        entry -> Long.valueOf(entry.getKey()),
-                        Map.Entry::getValue
-                ));
-    }
 }

--- a/src/main/java/checkmo/clubMeeting/internal/service/command/ClubBookReviewCommandService.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/command/ClubBookReviewCommandService.java
@@ -37,7 +37,7 @@ public class ClubBookReviewCommandService {
             maxAttempts = 5,
             backoff = @Backoff(delay = 300)
     )
-    public void createBookReview(Long clubId, Long meetingId, String memberId, BookReviewCreate request) {
+    public void createBookReview(Long clubId, Long meetingId, Long memberId, BookReviewCreate request) {
         clubManagementAPI.validateClub(clubId);
         Long clubMemberId = clubManagementAPI.validateAndFetchActiveClubMemberId(clubId, memberId);
         Meeting meeting = clubMeetingQueryService.validateMeeting(clubId, meetingId);
@@ -55,7 +55,7 @@ public class ClubBookReviewCommandService {
             maxAttempts = 5,
             backoff = @Backoff(delay = 300)
     )
-    public void updateBookReview(Long clubId, Long meetingId, Long reviewId, String memberId, BookReviewCreate request) {
+    public void updateBookReview(Long clubId, Long meetingId, Long reviewId, Long memberId, BookReviewCreate request) {
         clubManagementAPI.validateClub(clubId);
         ClubManagementExternalDTO.MembershipInfo clubMembership = clubManagementAPI.fetchMembershipInfo(clubId, memberId);
         if (!clubMembership.isActive()) {
@@ -88,7 +88,7 @@ public class ClubBookReviewCommandService {
             maxAttempts = 5,
             backoff = @Backoff(delay = 300)
     )
-    public void deleteBookReview(Long clubId, Long meetingId, Long reviewId, String memberId) {
+    public void deleteBookReview(Long clubId, Long meetingId, Long reviewId, Long memberId) {
         clubManagementAPI.validateClub(clubId);
         ClubManagementExternalDTO.MembershipInfo clubMembership = clubManagementAPI.fetchMembershipInfo(clubId, memberId);
         if (!clubMembership.isActive()) {

--- a/src/main/java/checkmo/clubMeeting/internal/service/command/ClubMeetingCommandService.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/command/ClubMeetingCommandService.java
@@ -42,7 +42,7 @@ public class ClubMeetingCommandService {
 
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    public void createMeeting(Long clubId, String memberId, BookShelfCreate request) {
+    public void createMeeting(Long clubId, Long memberId, BookShelfCreate request) {
         clubManagementAPI.validateClub(clubId);
         clubManagementAPI.validateStaffClubMember(clubId, memberId);
 
@@ -66,7 +66,7 @@ public class ClubMeetingCommandService {
         applicationEventPublisher.publishEvent(event);
     }
 
-    public void updateMeeting(Long clubId, Long meetingId, String memberId, BookShelfUpdate request) {
+    public void updateMeeting(Long clubId, Long meetingId, Long memberId, BookShelfUpdate request) {
         clubManagementAPI.validateClub(clubId);
         clubManagementAPI.validateStaffClubMember(clubId, memberId);
         Meeting meeting = clubMeetingQueryService.validateMeeting(clubId, meetingId);
@@ -83,7 +83,7 @@ public class ClubMeetingCommandService {
         clubManagementAPI.touchLastActivity(clubId, LocalDateTime.now());
     }
 
-    public void deleteMeeting(Long clubId, Long meetingId, String memberId) {
+    public void deleteMeeting(Long clubId, Long meetingId, Long memberId) {
         clubManagementAPI.validateClub(clubId);
         clubManagementAPI.validateStaffClubMember(clubId, memberId);
         Meeting meeting = clubMeetingQueryService.validateMeeting(clubId, meetingId);
@@ -96,7 +96,7 @@ public class ClubMeetingCommandService {
         applicationEventPublisher.publishEvent(event);
     }
 
-    public void manageTeam(Long clubId, Long meetingId, String memberId, MeetingRequestDTO.TeamManage request) {
+    public void manageTeam(Long clubId, Long meetingId, Long memberId, MeetingRequestDTO.TeamManage request) {
         clubManagementAPI.validateClub(clubId);
         clubManagementAPI.validateStaffClubMember(clubId, memberId);
         Meeting meeting = clubMeetingQueryService.validateMeeting(clubId, meetingId);

--- a/src/main/java/checkmo/clubMeeting/internal/service/command/ClubTopicCommandService.java
+++ b/src/main/java/checkmo/clubMeeting/internal/service/command/ClubTopicCommandService.java
@@ -37,7 +37,7 @@ public class ClubTopicCommandService {
     private final TopicRepository topicRepository;
     private final TeamTopicRepository teamTopicRepository;
 
-    public void createTopic(Long clubId, Long meetingId, String memberId, TopicCreate request) {
+    public void createTopic(Long clubId, Long meetingId, Long memberId, TopicCreate request) {
         clubManagementAPI.validateClub(clubId);
         Long clubMemberId = clubManagementAPI.validateAndFetchActiveClubMemberId(clubId, memberId);
         Meeting meeting = clubMeetingQueryService.validateMeeting(clubId, meetingId);
@@ -48,7 +48,7 @@ public class ClubTopicCommandService {
         topicRepository.save(topic);
     }
 
-    public void updateTopic(Long clubId, Long meetingId, Long topicId, String memberId, TopicCreate request) {
+    public void updateTopic(Long clubId, Long meetingId, Long topicId, Long memberId, TopicCreate request) {
         clubManagementAPI.validateClub(clubId);
         ClubManagementExternalDTO.MembershipInfo clubMembership = clubManagementAPI.fetchMembershipInfo(clubId, memberId);
         if (!clubMembership.isActive()) {
@@ -66,7 +66,7 @@ public class ClubTopicCommandService {
         );
     }
 
-    public void deleteTopic(Long clubId, Long meetingId, Long topicId, String memberId) {
+    public void deleteTopic(Long clubId, Long meetingId, Long topicId, Long memberId) {
         clubManagementAPI.validateClub(clubId);
         ClubManagementExternalDTO.MembershipInfo clubMembership = clubManagementAPI.fetchMembershipInfo(clubId, memberId);
         if (!clubMembership.isActive()) {

--- a/src/main/java/checkmo/clubMeeting/web/controller/ClubBookshelfController.java
+++ b/src/main/java/checkmo/clubMeeting/web/controller/ClubBookshelfController.java
@@ -52,7 +52,7 @@ public class ClubBookshelfController {
     public ApiResponse<BookShelfResponseDTO.BookShelfList> getBookShelfList(
             @PathVariable Long clubId,
             @RequestParam(required = false) @ValidCursor Long cursorId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubMeetingQueryFacade.retrieveBookShelfList(clubId, memberId, cursorId));
     }
@@ -72,7 +72,7 @@ public class ClubBookshelfController {
     public ApiResponse<BookShelfResponseDTO.BookShelfDetail> getBookShelfDetail(
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubMeetingQueryFacade.retrieveBookShelf(clubId, meetingId, memberId));
     }
@@ -91,7 +91,7 @@ public class ClubBookshelfController {
     public ApiResponse<String> createMeeting(
             @PathVariable Long clubId,
             @RequestBody @Valid BookShelfRequestDTO.BookShelfCreate request,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubMeetingCommandService.createMeeting(clubId, memberId, request);
         return ApiResponse.onSuccess("책장이 정상적으로 생성되었습니다.");
@@ -112,7 +112,7 @@ public class ClubBookshelfController {
     public ApiResponse<BookShelfResponseDTO.BookShelfUpdate> getBookShelfEditInfo(
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubMeetingQueryFacade.retrieveBookShelfDetail(clubId, meetingId, memberId));
     }
@@ -133,7 +133,7 @@ public class ClubBookshelfController {
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
             @RequestBody @Valid BookShelfRequestDTO.BookShelfUpdate request,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubMeetingCommandService.updateMeeting(clubId, meetingId, memberId, request);
         return ApiResponse.onSuccess("책장이 정상적으로 수정되었습니다.");
@@ -154,7 +154,7 @@ public class ClubBookshelfController {
     public ApiResponse<String> deleteMeeting(
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubMeetingCommandService.deleteMeeting(clubId, meetingId, memberId);
         return ApiResponse.onSuccess("책장이 정상적으로 삭제되었습니다.");
@@ -178,7 +178,7 @@ public class ClubBookshelfController {
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
             @RequestParam(required = false) @ValidCursor Long cursorId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubMeetingQueryFacade.retrieveTopicList(clubId, meetingId, memberId, cursorId));
     }
@@ -199,7 +199,7 @@ public class ClubBookshelfController {
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
             @RequestBody @Valid BookShelfRequestDTO.TopicCreate request,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubTopicCommandService.createTopic(clubId, meetingId, memberId, request);
         return ApiResponse.onSuccess("발제가 정상적으로 생성되었습니다.");
@@ -225,7 +225,7 @@ public class ClubBookshelfController {
             @PathVariable Long meetingId,
             @PathVariable Long topicId,
             @RequestBody @Valid BookShelfRequestDTO.TopicCreate request,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubTopicCommandService.updateTopic(clubId, meetingId, topicId, memberId, request);
         return ApiResponse.onSuccess("발제가 정상적으로 수정되었습니다.");
@@ -250,7 +250,7 @@ public class ClubBookshelfController {
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
             @PathVariable Long topicId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubTopicCommandService.deleteTopic(clubId, meetingId, topicId, memberId);
         return ApiResponse.onSuccess("발제가 정상적으로 삭제되었습니다.");
@@ -274,7 +274,7 @@ public class ClubBookshelfController {
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
             @RequestParam(required = false) @ValidCursor Long cursorId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(
                 clubMeetingQueryFacade.retrieveBookReviewList(clubId, meetingId, memberId, cursorId));
@@ -299,7 +299,7 @@ public class ClubBookshelfController {
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
             @RequestBody @Valid BookShelfRequestDTO.BookReviewCreate request,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubBookReviewCommandService.createBookReview(clubId, meetingId, memberId, request);
         return ApiResponse.onSuccess("한줄평이 생성되었습니다.");
@@ -328,7 +328,7 @@ public class ClubBookshelfController {
             @PathVariable Long meetingId,
             @PathVariable Long reviewId,
             @RequestBody @Valid BookShelfRequestDTO.BookReviewCreate request,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubBookReviewCommandService.updateBookReview(clubId, meetingId, reviewId, memberId, request);
         return ApiResponse.onSuccess("한줄평이 수정되었습니다.");
@@ -353,7 +353,7 @@ public class ClubBookshelfController {
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
             @PathVariable Long reviewId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubBookReviewCommandService.deleteBookReview(clubId, meetingId, reviewId, memberId);
         return ApiResponse.onSuccess("한줄평이 삭제되었습니다.");

--- a/src/main/java/checkmo/clubMeeting/web/controller/ClubMeetingController.java
+++ b/src/main/java/checkmo/clubMeeting/web/controller/ClubMeetingController.java
@@ -43,7 +43,7 @@ public class ClubMeetingController {
     @GetMapping("/next")
     public ApiResponse<NextMeetingRedirect> getNextMeetingRedirect(
             @PathVariable Long clubId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubMeetingQueryFacade.retrieveNextMeeting(clubId, memberId));
     }
@@ -63,7 +63,7 @@ public class ClubMeetingController {
     public ApiResponse<MeetingInfo> getMeeting(
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubMeetingQueryFacade.retrieveMeetingInfo(clubId, meetingId, memberId));
     }
@@ -86,7 +86,7 @@ public class ClubMeetingController {
     public ApiResponse<MeetingResponseDTO.MeetingMemberList> getMeetingMembers(
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(
                 clubMeetingQueryFacade.retrieveMeetingMemberList(clubId, meetingId, memberId));
@@ -109,7 +109,7 @@ public class ClubMeetingController {
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
             @RequestBody @Valid MeetingRequestDTO.TeamManage request,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubMeetingCommandService.manageTeam(clubId, meetingId, memberId, request);
         return ApiResponse.onSuccess(null);
@@ -133,7 +133,7 @@ public class ClubMeetingController {
             @PathVariable Long clubId,
             @PathVariable Long meetingId,
             @PathVariable Long teamId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubMeetingQueryFacade.retrieveSelectableTopics(clubId, meetingId, teamId, memberId));
     }

--- a/src/main/java/checkmo/clubNotice/ClubNoticeAPI.java
+++ b/src/main/java/checkmo/clubNotice/ClubNoticeAPI.java
@@ -6,5 +6,5 @@ public interface ClubNoticeAPI {
 
     ClubNoticeExternalDTO.NoticeCommentReportInfo fetchNoticeCommentReportInfo(Long noticeCommentId);
 
-    String fetchNoticeCommentAuthorId(Long noticeCommentId);
+    Long fetchNoticeCommentAuthorId(Long noticeCommentId);
 }

--- a/src/main/java/checkmo/clubNotice/internal/ClubNoticeAPIImpl.java
+++ b/src/main/java/checkmo/clubNotice/internal/ClubNoticeAPIImpl.java
@@ -49,6 +49,7 @@ public class ClubNoticeAPIImpl implements ClubNoticeAPI {
 
         return clubManagementAPI.fetchMembershipInfoByClubMemberIds(Set.of(noticeComment.getClubMemberId()))
                 .get(noticeComment.getClubMemberId())
-                .getMemberId();
+                .getMemberId()
+                .toString();
     }
 }

--- a/src/main/java/checkmo/clubNotice/internal/ClubNoticeAPIImpl.java
+++ b/src/main/java/checkmo/clubNotice/internal/ClubNoticeAPIImpl.java
@@ -44,12 +44,11 @@ public class ClubNoticeAPIImpl implements ClubNoticeAPI {
     }
 
     @Override
-    public String fetchNoticeCommentAuthorId(Long noticeCommentId) {
+    public Long fetchNoticeCommentAuthorId(Long noticeCommentId) {
         NoticeComment noticeComment = noticeCommentQueryService.validateNoticeComment(noticeCommentId);
 
         return clubManagementAPI.fetchMembershipInfoByClubMemberIds(Set.of(noticeComment.getClubMemberId()))
                 .get(noticeComment.getClubMemberId())
-                .getMemberId()
-                .toString();
+                .getMemberId();
     }
 }

--- a/src/main/java/checkmo/clubNotice/internal/service/ClubNoticeQueryFacade.java
+++ b/src/main/java/checkmo/clubNotice/internal/service/ClubNoticeQueryFacade.java
@@ -65,7 +65,7 @@ public class ClubNoticeQueryFacade {
 
     public ClubNoticePreviewPage retrieveClubNoticeList(
             Long clubId,
-            String memberId,
+            Long memberId,
             int page
     ) {
         clubManagementAPI.validateClub(clubId);
@@ -103,7 +103,7 @@ public class ClubNoticeQueryFacade {
     public ClubNoticeResponseDTO.ClubNoticeDetail retrieveClubNoticeDetail(
             Long clubId,
             Long noticeId,
-            String memberId
+            Long memberId
     ) {
         clubManagementAPI.validateClub(clubId);
         MembershipInfo clubMembershipInfo = clubManagementAPI.fetchMembershipInfo(clubId, memberId);
@@ -124,7 +124,7 @@ public class ClubNoticeQueryFacade {
         return ClubNoticeConverter.toClubNoticeDetail(notice, meetingDetail, voteDetail);
     }
 
-    public NoticeCommentList retrieveNoticeComments(Long clubId, Long noticeId, String memberId, Long cursorId) {
+    public NoticeCommentList retrieveNoticeComments(Long clubId, Long noticeId, Long memberId, Long cursorId) {
         clubManagementAPI.validateClub(clubId);
         clubManagementAPI.fetchMembershipInfo(clubId, memberId);
         clubNoticeQueryService.validateNotice(clubId, noticeId);
@@ -293,15 +293,15 @@ public class ClubNoticeQueryFacade {
         }
         Map<Long, MembershipInfo> membershipMap =
                 clubManagementAPI.fetchMembershipInfoByClubMemberIds(clubMemberIds);
-        List<String> memberIds = ExtractHelper.extractDistinctList(
+        List<Long> memberIds = ExtractHelper.extractDistinctList(
                 membershipMap.values(),
                 MembershipInfo::getMemberId
         );
         if (memberIds.isEmpty()) {
             return Map.of();
         }
-        Map<String, MemberExternalDTO.BasicInfo> memberBasicInfoMap =
-                memberAPI.fetchMemberBasicInfoByMemberIds(memberIds);
+        Map<Long, MemberExternalDTO.BasicInfo> memberBasicInfoMap =
+                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(toMemberApiIds(memberIds)));
         if (memberBasicInfoMap == null || memberBasicInfoMap.isEmpty()) {
             return Map.of();
         }
@@ -310,6 +310,20 @@ public class ClubNoticeQueryFacade {
                         MembershipInfo::getClubMemberId,
                         m -> memberBasicInfoMap.get(m.getMemberId()),
                         (a, b) -> a
+                ));
+    }
+
+    private List<String> toMemberApiIds(List<Long> memberIds) {
+        return memberIds.stream()
+                .map(String::valueOf)
+                .toList();
+    }
+
+    private <T> Map<Long, T> toLongKeyMap(Map<String, T> source) {
+        return source.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> Long.valueOf(entry.getKey()),
+                        Map.Entry::getValue
                 ));
     }
 }

--- a/src/main/java/checkmo/clubNotice/internal/service/ClubNoticeQueryFacade.java
+++ b/src/main/java/checkmo/clubNotice/internal/service/ClubNoticeQueryFacade.java
@@ -301,7 +301,7 @@ public class ClubNoticeQueryFacade {
             return Map.of();
         }
         Map<Long, MemberExternalDTO.BasicInfo> memberBasicInfoMap =
-                toLongKeyMap(memberAPI.fetchMemberBasicInfoByMemberIds(toMemberApiIds(memberIds)));
+                memberAPI.fetchMemberBasicInfoByMemberIds(memberIds);
         if (memberBasicInfoMap == null || memberBasicInfoMap.isEmpty()) {
             return Map.of();
         }
@@ -310,20 +310,6 @@ public class ClubNoticeQueryFacade {
                         MembershipInfo::getClubMemberId,
                         m -> memberBasicInfoMap.get(m.getMemberId()),
                         (a, b) -> a
-                ));
-    }
-
-    private List<String> toMemberApiIds(List<Long> memberIds) {
-        return memberIds.stream()
-                .map(String::valueOf)
-                .toList();
-    }
-
-    private <T> Map<Long, T> toLongKeyMap(Map<String, T> source) {
-        return source.entrySet().stream()
-                .collect(Collectors.toMap(
-                        entry -> Long.valueOf(entry.getKey()),
-                        Map.Entry::getValue
                 ));
     }
 }

--- a/src/main/java/checkmo/clubNotice/internal/service/command/ClubNoticeCommandService.java
+++ b/src/main/java/checkmo/clubNotice/internal/service/command/ClubNoticeCommandService.java
@@ -41,7 +41,7 @@ public class ClubNoticeCommandService {
 
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    public Notice createNotice(Long clubId, String memberId, CreateClubNotice request) {
+    public Notice createNotice(Long clubId, Long memberId, CreateClubNotice request) {
         clubManagementAPI.validateClub(clubId);
         clubManagementAPI.validateStaffClubMember(clubId, memberId);
         NoticeTag tag = NoticeTag.decideTag(request.getVote() != null, request.getMeetingId() != null);
@@ -88,7 +88,7 @@ public class ClubNoticeCommandService {
         applicationEventPublisher.publishEvent(event);
     }
 
-    public void updateNotice(Long clubId, Long noticeId, String memberId, UpdateClubNotice request) {
+    public void updateNotice(Long clubId, Long noticeId, Long memberId, UpdateClubNotice request) {
         clubManagementAPI.validateClub(clubId);
         clubManagementAPI.validateStaffClubMember(clubId, memberId);
 
@@ -124,7 +124,7 @@ public class ClubNoticeCommandService {
         }
     }
 
-    public void deleteNotice(Long clubId, String memberId, Long noticeId) {
+    public void deleteNotice(Long clubId, Long memberId, Long noticeId) {
         clubManagementAPI.validateClub(clubId);
         clubManagementAPI.validateStaffClubMember(clubId, memberId);
 
@@ -134,7 +134,7 @@ public class ClubNoticeCommandService {
         noticeRepository.delete(notice);
     }
 
-    public Long haveVote(Long clubId, Long noticeId, Long voteId, String memberId, VoteResult request) {
+    public Long haveVote(Long clubId, Long noticeId, Long voteId, Long memberId, VoteResult request) {
         clubManagementAPI.validateClub(clubId);
         Long clubMemberId = clubManagementAPI.validateAndFetchActiveClubMemberId(clubId, memberId);
 

--- a/src/main/java/checkmo/clubNotice/internal/service/command/NoticeCommentCommandService.java
+++ b/src/main/java/checkmo/clubNotice/internal/service/command/NoticeCommentCommandService.java
@@ -22,7 +22,7 @@ public class NoticeCommentCommandService {
     private final ClubNoticeQueryService clubNoticeQueryService;
     private final NoticeCommentQueryService noticeCommentQueryService;
 
-    public void createNoticeComment(Long clubId, Long noticeId, String memberId, ClubNoticeRequestDTO.CreateClubNoticeComment request) {
+    public void createNoticeComment(Long clubId, Long noticeId, Long memberId, ClubNoticeRequestDTO.CreateClubNoticeComment request) {
         clubManagementAPI.validateClub(clubId);
         Long clubMemberId = clubManagementAPI.validateAndFetchActiveClubMemberId(clubId, memberId);
         Notice notice = clubNoticeQueryService.validateNotice(clubId, noticeId);
@@ -31,7 +31,7 @@ public class NoticeCommentCommandService {
     }
 
     public void updateNoticeComment(
-            Long clubId, Long noticeId, Long commentId, String memberId,
+            Long clubId, Long noticeId, Long commentId, Long memberId,
             ClubNoticeRequestDTO.CreateClubNoticeComment request
     ) {
         clubManagementAPI.validateClub(clubId);
@@ -47,7 +47,7 @@ public class NoticeCommentCommandService {
         noticeComment.updateContent(request.getContent());
     }
 
-    public void deleteNoticeComment(Long clubId, Long noticeId, Long commentId, String memberId) {
+    public void deleteNoticeComment(Long clubId, Long noticeId, Long commentId, Long memberId) {
         clubManagementAPI.validateClub(clubId);
         ClubManagementExternalDTO.MembershipInfo clubMembership = clubManagementAPI.fetchMembershipInfo(clubId, memberId);
         if (!clubMembership.isActive()) {

--- a/src/main/java/checkmo/clubNotice/web/controller/ClubNoticeController.java
+++ b/src/main/java/checkmo/clubNotice/web/controller/ClubNoticeController.java
@@ -56,7 +56,7 @@ public class ClubNoticeController {
     })
     @GetMapping
     public ApiResponse<ClubNoticePreviewPage> getNoticeList(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long clubId,
             @RequestParam(defaultValue = "1") int page
     ) {
@@ -74,7 +74,7 @@ public class ClubNoticeController {
     public ApiResponse<ClubNoticeResponseDTO.ClubNoticeDetail> getNoticeDetail(
             @PathVariable Long clubId,
             @PathVariable Long noticeId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(clubNoticeQueryFacade.retrieveClubNoticeDetail(clubId, noticeId, memberId));
     }
@@ -87,7 +87,7 @@ public class ClubNoticeController {
     })
     @PostMapping
     public ApiResponse<String> createPureVote(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long clubId,
             @RequestBody @Valid ClubNoticeRequestDTO.CreateClubNotice request
     ) {
@@ -106,7 +106,7 @@ public class ClubNoticeController {
     public ApiResponse<String> updateNotice(
             @PathVariable Long clubId,
             @PathVariable Long noticeId,
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestBody @Valid ClubNoticeRequestDTO.UpdateClubNotice request
     ) {
         clubNoticeCommandService.updateNotice(clubId, noticeId, memberId, request);
@@ -124,7 +124,7 @@ public class ClubNoticeController {
     public ApiResponse<String> deletePureNotice(
             @PathVariable Long clubId,
             @PathVariable Long noticeId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         clubNoticeCommandService.deleteNotice(clubId, memberId, noticeId);
         return ApiResponse.onSuccess("공지사항이 삭제되었습니다.");
@@ -141,7 +141,7 @@ public class ClubNoticeController {
             @PathVariable Long clubId,
             @PathVariable Long noticeId,
             @PathVariable Long voteId,
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestBody @Valid ClubNoticeRequestDTO.VoteResult request
     ) {
         Long participatingVoteId = clubNoticeCommandService.haveVote(clubId, noticeId, voteId, memberId, request);
@@ -158,7 +158,7 @@ public class ClubNoticeController {
     public ApiResponse<NoticeCommentList> getNoticeComments(
             @PathVariable Long clubId,
             @PathVariable Long noticeId,
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam(required = false) Long cursorId
     ) {
         return ApiResponse.onSuccess(
@@ -176,7 +176,7 @@ public class ClubNoticeController {
     public ApiResponse<String> createNoticeComment(
             @PathVariable Long clubId,
             @PathVariable Long noticeId,
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestBody @Valid ClubNoticeRequestDTO.CreateClubNoticeComment request
     ) {
         noticeCommentCommandService.createNoticeComment(clubId, noticeId, memberId, request);
@@ -196,7 +196,7 @@ public class ClubNoticeController {
             @PathVariable Long clubId,
             @PathVariable Long noticeId,
             @PathVariable Long commentId,
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestBody @Valid ClubNoticeRequestDTO.CreateClubNoticeComment request
     ) {
         noticeCommentCommandService.updateNoticeComment(clubId, noticeId, commentId, memberId, request);
@@ -216,7 +216,7 @@ public class ClubNoticeController {
             @PathVariable Long clubId,
             @PathVariable Long noticeId,
             @PathVariable Long commentId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         noticeCommentCommandService.deleteNoticeComment(clubId, noticeId, commentId, memberId);
         return ApiResponse.onSuccess("공지사항 댓글이 삭제되었습니다.");

--- a/src/main/java/checkmo/member/MemberAPI.java
+++ b/src/main/java/checkmo/member/MemberAPI.java
@@ -14,21 +14,21 @@ public interface MemberAPI {
      * @param nickname 닉네임
      * @return 회원 ID
      */
-    String fetchMemberId(String nickname);
+    Long fetchMemberId(String nickname);
 
     /**
      * 회원 ID로 회원의 닉네임을 조회합니다.
      *
      * @return 회원의 닉네임
      */
-    String fetchNickname(String memberId);
+    String fetchNickname(Long memberId);
 
     /**
      * 회원 ID 목록으로 회원의 닉네임을 조회합니다.
      *
      * @return 회원 ID와 닉네임의 매핑 정보
      */
-    Map<String, String> fetchNicknameByMemberIds(List<String> memberIds);
+    Map<Long, String> fetchNicknameByMemberIds(List<Long> memberIds);
 
     /**
      * 공유용 기본 회원 정보 조회
@@ -36,7 +36,7 @@ public interface MemberAPI {
      * @param memberId 조회할 회원 ID
      * @return MemberExternalDTO.BasicInfo
      */
-    MemberExternalDTO.BasicInfo fetchMemberBasicInfo(String memberId);
+    MemberExternalDTO.BasicInfo fetchMemberBasicInfo(Long memberId);
 
     /**
      * 회원 ID 목록으로 공유용 기본 회원 정보 조회
@@ -44,7 +44,7 @@ public interface MemberAPI {
      * @param memberIds 조회할 회원 ID 목록
      * @return 회원 ID와 기본 정보 매핑 리스트
      */
-    Map<String, MemberExternalDTO.BasicInfo> fetchMemberBasicInfoByMemberIds(List<String> memberIds);
+    Map<Long, MemberExternalDTO.BasicInfo> fetchMemberBasicInfoByMemberIds(List<Long> memberIds);
 
     /**
      * 회원 ID 목록으로 공유용 디테일 회원 정보 조회
@@ -52,7 +52,7 @@ public interface MemberAPI {
      * @param memberIds 조회할 회원 ID 목록
      * @return 회원 ID와 디테일 정보 매핑 리스트
      */
-    Map<String, MemberExternalDTO.DetailInfo> fetchMemberDetailInfoByMemberIds(List<String> memberIds);
+    Map<Long, MemberExternalDTO.DetailInfo> fetchMemberDetailInfoByMemberIds(List<Long> memberIds);
 
     /**
      * 회원 ID 목록으로 공유용 개인 정보 조회
@@ -60,7 +60,7 @@ public interface MemberAPI {
      * @param memberIds 조회할 회원 ID 목록
      * @return 회원 ID와 개인 정보 매핑 리스트
      */
-    Map<String, MemberExternalDTO.PersonalInfo> fetchMemberPersonalInfoByMemberIds(List<String> memberIds);
+    Map<Long, MemberExternalDTO.PersonalInfo> fetchMemberPersonalInfoByMemberIds(List<Long> memberIds);
 
     /**
      * 팔로우 상태를 포함한 공유용 회원 정보 조회
@@ -69,7 +69,7 @@ public interface MemberAPI {
      * @param currentMemberId 현재 로그인한 회원 ID
      * @return MemberExternalDTO.WithFollowStatus
      */
-    BasicInfoWithFollow fetchMemberBasicInfoWithFollow(String targetMemberId, String currentMemberId);
+    BasicInfoWithFollow fetchMemberBasicInfoWithFollow(Long targetMemberId, Long currentMemberId);
 
     /**
      * 회원 ID 목록으로 팔로우 상태를 포함한 공유용 회원 정보를 조회합니다.
@@ -78,9 +78,9 @@ public interface MemberAPI {
      * @param currentMemberId 현재 로그인한 회원 ID
      * @return 회원 ID와 팔로우 상태 포함 정보 매핑
      */
-    Map<String, BasicInfoWithFollow> fetchMemberBasicInfoWithFollowByMemberId(
-            List<String> targetMemberIds,
-            String currentMemberId
+    Map<Long, BasicInfoWithFollow> fetchMemberBasicInfoWithFollowByMemberId(
+            List<Long> targetMemberIds,
+            Long currentMemberId
     );
 
     /**
@@ -89,7 +89,7 @@ public interface MemberAPI {
      * @param memberId 회원 ID
      * @return 팔로우하는 회원 ID 목록
      */
-    List<String> fetchFollowingIds(String memberId);
+    List<Long> fetchFollowingIds(Long memberId);
 
     /**
      * 특정 회원이 차단한 회원 ID 목록을 조회합니다.
@@ -97,7 +97,7 @@ public interface MemberAPI {
      * @param blockerId 차단 주체 회원 ID
      * @return 차단당한 회원 ID 목록
      */
-    List<String> fetchBlockedMemberIds(String blockerId);
+    List<Long> fetchBlockedMemberIds(Long blockerId);
 
     /**
      * 특정 회원과 차단 관계가 있는 모든 회원 ID 목록을 조회합니다.
@@ -105,7 +105,7 @@ public interface MemberAPI {
      * @param memberId 회원 ID
      * @return 내가 차단했거나 나를 차단한 회원 ID 목록
      */
-    List<String> fetchBlockRelatedMemberIds(String memberId);
+    List<Long> fetchBlockRelatedMemberIds(Long memberId);
 
     /**
      * 두 회원 사이에 어느 방향이든 차단 관계가 있는지 조회합니다.
@@ -114,7 +114,7 @@ public interface MemberAPI {
      * @param memberId2 회원 ID
      * @return 차단 관계 존재 여부
      */
-    boolean hasBlockBetween(String memberId1, String memberId2);
+    boolean hasBlockBetween(Long memberId1, Long memberId2);
 
     /**
      * 차단 주체가 특정 회원을 차단했는지 조회합니다.
@@ -123,7 +123,7 @@ public interface MemberAPI {
      * @param blockedId 피차단 회원 ID
      * @return 차단 여부
      */
-    boolean hasBlocked(String blockerId, String blockedId);
+    boolean hasBlocked(Long blockerId, Long blockedId);
 
     /**
      * 공개 프로필/서재/책이야기 직접 조회 가능 여부를 검증합니다.
@@ -131,7 +131,7 @@ public interface MemberAPI {
      * @param viewerId 조회하는 회원 ID
      * @param targetMemberId 조회 대상 회원 ID
      */
-    void validateProfileAccessible(String viewerId, String targetMemberId);
+    void validateProfileAccessible(Long viewerId, Long targetMemberId);
 
     /**
      * 회원의 관심 카테고리 정보를 조회합니다.
@@ -139,7 +139,7 @@ public interface MemberAPI {
      * @param memberId 회원 ID
      * @return 관심 카테고리 정보
      */
-    InterestCategoryInfo fetchInterestCategory(String memberId);
+    InterestCategoryInfo fetchInterestCategory(Long memberId);
 
     /**
      * 회원 ID로 회원의 이메일을 조회합니다.
@@ -147,5 +147,5 @@ public interface MemberAPI {
      * @param memberId 회원 ID
      * @return 회원 이메일
      */
-    String fetchMemberEmail(String memberId);
+    String fetchMemberEmail(Long memberId);
 }

--- a/src/main/java/checkmo/member/MemberEvent.java
+++ b/src/main/java/checkmo/member/MemberEvent.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 public class MemberEvent {
 
     @Builder
-    public record Follow(Long eventId, String followerId, String followingId) {
+    public record Follow(Long eventId, Long followerId, Long followingId) {
     }
 
     @Builder
@@ -13,6 +13,6 @@ public class MemberEvent {
     }
 
     @Builder
-    public record MemberRegistrationCompleted(String memberId) {
+    public record MemberRegistrationCompleted(Long memberId) {
     }
 }

--- a/src/main/java/checkmo/member/internal/MemberAPIImpl.java
+++ b/src/main/java/checkmo/member/internal/MemberAPIImpl.java
@@ -30,7 +30,7 @@ public class MemberAPIImpl implements MemberAPI {
 
     @Override
     public String fetchMemberId(String nickname) {
-        return memberQueryService.retrieveMemberId(nickname);
+        return String.valueOf(memberQueryService.retrieveMemberId(nickname));
     }
 
     @Override
@@ -39,7 +39,7 @@ public class MemberAPIImpl implements MemberAPI {
             return WITHDRAWN_MEMBER_NICKNAME;
         }
 
-        return memberQueryService.retrieveActiveMemberNickname(memberId)
+        return memberQueryService.retrieveActiveMemberNickname(parseMemberId(memberId))
                 .orElse(WITHDRAWN_MEMBER_NICKNAME);
     }
 
@@ -52,7 +52,8 @@ public class MemberAPIImpl implements MemberAPI {
 
         Map<String, String> result = initializeWithdrawnNicknameMap(distinctMemberIds);
 
-        result.putAll(memberQueryService.retrieveActiveMemberNicknameByMemberIds(distinctMemberIds));
+        memberQueryService.retrieveActiveMemberNicknameByMemberIds(parseMemberIds(distinctMemberIds))
+                .forEach((memberId, nickname) -> result.put(String.valueOf(memberId), nickname));
         return result;
     }
 
@@ -76,9 +77,9 @@ public class MemberAPIImpl implements MemberAPI {
         Map<String, MemberExternalDTO.BasicInfo> result = initializeWithdrawnBasicInfoMap(distinctMemberIds);
 
         List<MemberBasicInfoProjection> activeMembers =
-                memberQueryService.retrieveActiveMemberBasicInfos(distinctMemberIds);
+                memberQueryService.retrieveActiveMemberBasicInfos(parseMemberIds(distinctMemberIds));
 
-        activeMembers.forEach(projection -> result.put(projection.getId(), toBasicInfo(projection)));
+        activeMembers.forEach(projection -> result.put(String.valueOf(projection.getId()), toBasicInfo(projection)));
 
         return result;
     }
@@ -92,8 +93,8 @@ public class MemberAPIImpl implements MemberAPI {
 
         Map<String, DetailInfo> result = initializeWithdrawnDetailInfoMap(distinctMemberIds);
 
-        List<Member> members = memberQueryService.retrieveMemberById(distinctMemberIds);
-        members.forEach(member -> result.put(member.getId(), toDetailInfo(member)));
+        List<Member> members = memberQueryService.retrieveMemberById(parseMemberIds(distinctMemberIds));
+        members.forEach(member -> result.put(String.valueOf(member.getId()), toDetailInfo(member)));
 
         return result;
     }
@@ -107,8 +108,8 @@ public class MemberAPIImpl implements MemberAPI {
 
         Map<String, MemberExternalDTO.PersonalInfo> result = initializeWithdrawnPersonalInfoMap(distinctMemberIds);
 
-        List<Member> members = memberQueryService.retrieveMemberById(distinctMemberIds);
-        members.forEach(member -> result.put(member.getId(), toPersonalInfo(member)));
+        List<Member> members = memberQueryService.retrieveMemberById(parseMemberIds(distinctMemberIds));
+        members.forEach(member -> result.put(String.valueOf(member.getId()), toPersonalInfo(member)));
 
         return result;
     }
@@ -124,7 +125,10 @@ public class MemberAPIImpl implements MemberAPI {
 
         var basicInfoDTO = fetchMemberBasicInfo(targetMemberId);
         boolean isWithdrawn = isWithdrawnBasicInfo(basicInfoDTO);
-        boolean isFollowing = !isWithdrawn && memberFollowQueryService.isFollowing(currentMemberId, targetMemberId);
+        boolean isFollowing = !isWithdrawn && memberFollowQueryService.isFollowing(
+                parseMemberId(currentMemberId),
+                parseMemberId(targetMemberId)
+        );
 
         return MemberExternalDTO.BasicInfoWithFollow.builder()
                 .nickname(basicInfoDTO.getNickname())
@@ -144,8 +148,11 @@ public class MemberAPIImpl implements MemberAPI {
         }
 
         Map<String, MemberExternalDTO.BasicInfo> basicInfoMap = fetchMemberBasicInfoByMemberIds(distinctTargetIds);
-        Map<String, Boolean> followStatusMap =
-                memberFollowQueryService.checkFollowStatusByMemberId(currentMemberId, distinctTargetIds);
+        Map<Long, Boolean> followStatusMap =
+                memberFollowQueryService.checkFollowStatusByMemberId(
+                        parseMemberId(currentMemberId),
+                        parseMemberIds(distinctTargetIds)
+                );
 
         Map<String, MemberExternalDTO.BasicInfoWithFollow> result = new HashMap<>();
         for (String targetId : distinctTargetIds) {
@@ -157,37 +164,43 @@ public class MemberAPIImpl implements MemberAPI {
 
     @Override
     public List<String> fetchFollowingIds(String memberId) {
-        return memberFollowQueryService.retrieveFollowingIds(memberId);
+        return memberFollowQueryService.retrieveFollowingIds(parseMemberId(memberId)).stream()
+                .map(String::valueOf)
+                .toList();
     }
 
     @Override
     public List<String> fetchBlockedMemberIds(String blockerId) {
-        return memberBlockQueryService.retrieveBlockedMemberIds(blockerId);
+        return memberBlockQueryService.retrieveBlockedMemberIds(parseMemberId(blockerId)).stream()
+                .map(String::valueOf)
+                .toList();
     }
 
     @Override
     public List<String> fetchBlockRelatedMemberIds(String memberId) {
-        return memberBlockQueryService.retrieveBlockRelatedMemberIds(memberId);
+        return memberBlockQueryService.retrieveBlockRelatedMemberIds(parseMemberId(memberId)).stream()
+                .map(String::valueOf)
+                .toList();
     }
 
     @Override
     public boolean hasBlockBetween(String memberId1, String memberId2) {
-        return memberBlockQueryService.hasBlockBetween(memberId1, memberId2);
+        return memberBlockQueryService.hasBlockBetween(parseMemberId(memberId1), parseMemberId(memberId2));
     }
 
     @Override
     public boolean hasBlocked(String blockerId, String blockedId) {
-        return memberBlockQueryService.hasBlocked(blockerId, blockedId);
+        return memberBlockQueryService.hasBlocked(parseMemberId(blockerId), parseMemberId(blockedId));
     }
 
     @Override
     public void validateProfileAccessible(String viewerId, String targetMemberId) {
-        memberBlockQueryService.validateProfileAccessible(viewerId, targetMemberId);
+        memberBlockQueryService.validateProfileAccessible(parseMemberId(viewerId), parseMemberId(targetMemberId));
     }
 
     @Override
     public InterestCategoryInfo fetchInterestCategory(String memberId) {
-        Member member = memberQueryService.retrieveMember(memberId);
+        Member member = memberQueryService.retrieveMember(parseMemberId(memberId));
         Set<MemberInterestCategory> interestCategories = member.getInterestCategories();
         List<String> categories = (interestCategories == null)
                 ? List.of()
@@ -203,7 +216,7 @@ public class MemberAPIImpl implements MemberAPI {
 
     @Override
     public String fetchMemberEmail(String memberId) {
-        Member member = memberQueryService.retrieveMember(memberId);
+        Member member = memberQueryService.retrieveMember(parseMemberId(memberId));
         return member.getEmail();
     }
 
@@ -270,7 +283,17 @@ public class MemberAPIImpl implements MemberAPI {
 
         return ids.stream()
                 .filter(Objects::nonNull)
-                .collect(Collectors.collectingAndThen(Collectors.toList(), list -> new java.util.ArrayList<>(new LinkedHashSet<>(list))));
+                .collect(Collectors.collectingAndThen(Collectors.toList(), list -> new ArrayList<>(new LinkedHashSet<>(list))));
+    }
+
+    private List<Long> parseMemberIds(List<String> memberIds) {
+        return memberIds.stream()
+                .map(this::parseMemberId)
+                .toList();
+    }
+
+    private Long parseMemberId(String memberId) {
+        return memberId == null ? null : Long.valueOf(memberId);
     }
 
     private boolean isWithdrawnBasicInfo(MemberExternalDTO.BasicInfo basicInfo) {
@@ -281,11 +304,11 @@ public class MemberAPIImpl implements MemberAPI {
     private MemberExternalDTO.BasicInfoWithFollow toBasicInfoWithFollow(
             String targetId,
             Map<String, MemberExternalDTO.BasicInfo> basicInfoMap,
-            Map<String, Boolean> followStatusMap
+            Map<Long, Boolean> followStatusMap
     ) {
         MemberExternalDTO.BasicInfo basicInfo = basicInfoMap.getOrDefault(targetId, withdrawnBasicInfo());
         boolean isWithdrawn = isWithdrawnBasicInfo(basicInfo);
-        boolean isFollowing = !isWithdrawn && followStatusMap.getOrDefault(targetId, false);
+        boolean isFollowing = !isWithdrawn && followStatusMap.getOrDefault(parseMemberId(targetId), false);
 
         return MemberExternalDTO.BasicInfoWithFollow.builder()
                 .nickname(basicInfo.getNickname())

--- a/src/main/java/checkmo/member/internal/MemberAPIImpl.java
+++ b/src/main/java/checkmo/member/internal/MemberAPIImpl.java
@@ -29,36 +29,36 @@ public class MemberAPIImpl implements MemberAPI {
     private final MemberBlockQueryService memberBlockQueryService;
 
     @Override
-    public String fetchMemberId(String nickname) {
-        return String.valueOf(memberQueryService.retrieveMemberId(nickname));
+    public Long fetchMemberId(String nickname) {
+        return memberQueryService.retrieveMemberId(nickname);
     }
 
     @Override
-    public String fetchNickname(String memberId) {
+    public String fetchNickname(Long memberId) {
         if (memberId == null) {
             return WITHDRAWN_MEMBER_NICKNAME;
         }
 
-        return memberQueryService.retrieveActiveMemberNickname(parseMemberId(memberId))
+        return memberQueryService.retrieveActiveMemberNickname(memberId)
                 .orElse(WITHDRAWN_MEMBER_NICKNAME);
     }
 
     @Override
-    public Map<String, String> fetchNicknameByMemberIds(List<String> memberIds) {
-        List<String> distinctMemberIds = distinctNonNullIds(memberIds);
+    public Map<Long, String> fetchNicknameByMemberIds(List<Long> memberIds) {
+        List<Long> distinctMemberIds = distinctNonNullIds(memberIds);
         if (distinctMemberIds.isEmpty()) {
             return Map.of();
         }
 
-        Map<String, String> result = initializeWithdrawnNicknameMap(distinctMemberIds);
+        Map<Long, String> result = initializeWithdrawnNicknameMap(distinctMemberIds);
 
-        memberQueryService.retrieveActiveMemberNicknameByMemberIds(parseMemberIds(distinctMemberIds))
-                .forEach((memberId, nickname) -> result.put(String.valueOf(memberId), nickname));
+        memberQueryService.retrieveActiveMemberNicknameByMemberIds(distinctMemberIds)
+                .forEach(result::put);
         return result;
     }
 
     @Override
-    public MemberExternalDTO.BasicInfo fetchMemberBasicInfo(String memberId) {
+    public MemberExternalDTO.BasicInfo fetchMemberBasicInfo(Long memberId) {
         if (memberId == null) {
             return withdrawnBasicInfo();
         }
@@ -68,56 +68,56 @@ public class MemberAPIImpl implements MemberAPI {
     }
 
     @Override
-    public Map<String, MemberExternalDTO.BasicInfo> fetchMemberBasicInfoByMemberIds(List<String> memberIds) {
-        List<String> distinctMemberIds = distinctNonNullIds(memberIds);
+    public Map<Long, MemberExternalDTO.BasicInfo> fetchMemberBasicInfoByMemberIds(List<Long> memberIds) {
+        List<Long> distinctMemberIds = distinctNonNullIds(memberIds);
         if (distinctMemberIds.isEmpty()) {
             return Map.of();
         }
 
-        Map<String, MemberExternalDTO.BasicInfo> result = initializeWithdrawnBasicInfoMap(distinctMemberIds);
+        Map<Long, MemberExternalDTO.BasicInfo> result = initializeWithdrawnBasicInfoMap(distinctMemberIds);
 
         List<MemberBasicInfoProjection> activeMembers =
-                memberQueryService.retrieveActiveMemberBasicInfos(parseMemberIds(distinctMemberIds));
+                memberQueryService.retrieveActiveMemberBasicInfos(distinctMemberIds);
 
-        activeMembers.forEach(projection -> result.put(String.valueOf(projection.getId()), toBasicInfo(projection)));
-
-        return result;
-    }
-
-    @Override
-    public Map<String, DetailInfo> fetchMemberDetailInfoByMemberIds(List<String> memberIds) {
-        List<String> distinctMemberIds = distinctNonNullIds(memberIds);
-        if (distinctMemberIds.isEmpty()) {
-            return Map.of();
-        }
-
-        Map<String, DetailInfo> result = initializeWithdrawnDetailInfoMap(distinctMemberIds);
-
-        List<Member> members = memberQueryService.retrieveMemberById(parseMemberIds(distinctMemberIds));
-        members.forEach(member -> result.put(String.valueOf(member.getId()), toDetailInfo(member)));
+        activeMembers.forEach(projection -> result.put(projection.getId(), toBasicInfo(projection)));
 
         return result;
     }
 
     @Override
-    public Map<String, MemberExternalDTO.PersonalInfo> fetchMemberPersonalInfoByMemberIds(List<String> memberIds) {
-        List<String> distinctMemberIds = distinctNonNullIds(memberIds);
+    public Map<Long, DetailInfo> fetchMemberDetailInfoByMemberIds(List<Long> memberIds) {
+        List<Long> distinctMemberIds = distinctNonNullIds(memberIds);
         if (distinctMemberIds.isEmpty()) {
             return Map.of();
         }
 
-        Map<String, MemberExternalDTO.PersonalInfo> result = initializeWithdrawnPersonalInfoMap(distinctMemberIds);
+        Map<Long, DetailInfo> result = initializeWithdrawnDetailInfoMap(distinctMemberIds);
 
-        List<Member> members = memberQueryService.retrieveMemberById(parseMemberIds(distinctMemberIds));
-        members.forEach(member -> result.put(String.valueOf(member.getId()), toPersonalInfo(member)));
+        List<Member> members = memberQueryService.retrieveMemberById(distinctMemberIds);
+        members.forEach(member -> result.put(member.getId(), toDetailInfo(member)));
+
+        return result;
+    }
+
+    @Override
+    public Map<Long, MemberExternalDTO.PersonalInfo> fetchMemberPersonalInfoByMemberIds(List<Long> memberIds) {
+        List<Long> distinctMemberIds = distinctNonNullIds(memberIds);
+        if (distinctMemberIds.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<Long, MemberExternalDTO.PersonalInfo> result = initializeWithdrawnPersonalInfoMap(distinctMemberIds);
+
+        List<Member> members = memberQueryService.retrieveMemberById(distinctMemberIds);
+        members.forEach(member -> result.put(member.getId(), toPersonalInfo(member)));
 
         return result;
     }
 
     @Override
     public MemberExternalDTO.BasicInfoWithFollow fetchMemberBasicInfoWithFollow(
-            String targetMemberId,
-            String currentMemberId
+            Long targetMemberId,
+            Long currentMemberId
     ) {
         if (targetMemberId == null) {
             return withdrawnBasicInfoWithFollow();
@@ -126,8 +126,8 @@ public class MemberAPIImpl implements MemberAPI {
         var basicInfoDTO = fetchMemberBasicInfo(targetMemberId);
         boolean isWithdrawn = isWithdrawnBasicInfo(basicInfoDTO);
         boolean isFollowing = !isWithdrawn && memberFollowQueryService.isFollowing(
-                parseMemberId(currentMemberId),
-                parseMemberId(targetMemberId)
+                currentMemberId,
+                targetMemberId
         );
 
         return MemberExternalDTO.BasicInfoWithFollow.builder()
@@ -138,24 +138,24 @@ public class MemberAPIImpl implements MemberAPI {
     }
 
     @Override
-    public Map<String, MemberExternalDTO.BasicInfoWithFollow> fetchMemberBasicInfoWithFollowByMemberId(
-            List<String> targetMemberIds,
-            String currentMemberId
+    public Map<Long, MemberExternalDTO.BasicInfoWithFollow> fetchMemberBasicInfoWithFollowByMemberId(
+            List<Long> targetMemberIds,
+            Long currentMemberId
     ) {
-        List<String> distinctTargetIds = distinctNonNullIds(targetMemberIds);
+        List<Long> distinctTargetIds = distinctNonNullIds(targetMemberIds);
         if (distinctTargetIds.isEmpty()) {
             return Map.of();
         }
 
-        Map<String, MemberExternalDTO.BasicInfo> basicInfoMap = fetchMemberBasicInfoByMemberIds(distinctTargetIds);
+        Map<Long, MemberExternalDTO.BasicInfo> basicInfoMap = fetchMemberBasicInfoByMemberIds(distinctTargetIds);
         Map<Long, Boolean> followStatusMap =
                 memberFollowQueryService.checkFollowStatusByMemberId(
-                        parseMemberId(currentMemberId),
-                        parseMemberIds(distinctTargetIds)
+                        currentMemberId,
+                        distinctTargetIds
                 );
 
-        Map<String, MemberExternalDTO.BasicInfoWithFollow> result = new HashMap<>();
-        for (String targetId : distinctTargetIds) {
+        Map<Long, MemberExternalDTO.BasicInfoWithFollow> result = new HashMap<>();
+        for (Long targetId : distinctTargetIds) {
             result.put(targetId, toBasicInfoWithFollow(targetId, basicInfoMap, followStatusMap));
         }
 
@@ -163,44 +163,38 @@ public class MemberAPIImpl implements MemberAPI {
     }
 
     @Override
-    public List<String> fetchFollowingIds(String memberId) {
-        return memberFollowQueryService.retrieveFollowingIds(parseMemberId(memberId)).stream()
-                .map(String::valueOf)
-                .toList();
+    public List<Long> fetchFollowingIds(Long memberId) {
+        return memberFollowQueryService.retrieveFollowingIds(memberId);
     }
 
     @Override
-    public List<String> fetchBlockedMemberIds(String blockerId) {
-        return memberBlockQueryService.retrieveBlockedMemberIds(parseMemberId(blockerId)).stream()
-                .map(String::valueOf)
-                .toList();
+    public List<Long> fetchBlockedMemberIds(Long blockerId) {
+        return memberBlockQueryService.retrieveBlockedMemberIds(blockerId);
     }
 
     @Override
-    public List<String> fetchBlockRelatedMemberIds(String memberId) {
-        return memberBlockQueryService.retrieveBlockRelatedMemberIds(parseMemberId(memberId)).stream()
-                .map(String::valueOf)
-                .toList();
+    public List<Long> fetchBlockRelatedMemberIds(Long memberId) {
+        return memberBlockQueryService.retrieveBlockRelatedMemberIds(memberId);
     }
 
     @Override
-    public boolean hasBlockBetween(String memberId1, String memberId2) {
-        return memberBlockQueryService.hasBlockBetween(parseMemberId(memberId1), parseMemberId(memberId2));
+    public boolean hasBlockBetween(Long memberId1, Long memberId2) {
+        return memberBlockQueryService.hasBlockBetween(memberId1, memberId2);
     }
 
     @Override
-    public boolean hasBlocked(String blockerId, String blockedId) {
-        return memberBlockQueryService.hasBlocked(parseMemberId(blockerId), parseMemberId(blockedId));
+    public boolean hasBlocked(Long blockerId, Long blockedId) {
+        return memberBlockQueryService.hasBlocked(blockerId, blockedId);
     }
 
     @Override
-    public void validateProfileAccessible(String viewerId, String targetMemberId) {
-        memberBlockQueryService.validateProfileAccessible(parseMemberId(viewerId), parseMemberId(targetMemberId));
+    public void validateProfileAccessible(Long viewerId, Long targetMemberId) {
+        memberBlockQueryService.validateProfileAccessible(viewerId, targetMemberId);
     }
 
     @Override
-    public InterestCategoryInfo fetchInterestCategory(String memberId) {
-        Member member = memberQueryService.retrieveMember(parseMemberId(memberId));
+    public InterestCategoryInfo fetchInterestCategory(Long memberId) {
+        Member member = memberQueryService.retrieveMember(memberId);
         Set<MemberInterestCategory> interestCategories = member.getInterestCategories();
         List<String> categories = (interestCategories == null)
                 ? List.of()
@@ -215,8 +209,8 @@ public class MemberAPIImpl implements MemberAPI {
     }
 
     @Override
-    public String fetchMemberEmail(String memberId) {
-        Member member = memberQueryService.retrieveMember(parseMemberId(memberId));
+    public String fetchMemberEmail(Long memberId) {
+        Member member = memberQueryService.retrieveMember(memberId);
         return member.getEmail();
     }
 
@@ -227,26 +221,26 @@ public class MemberAPIImpl implements MemberAPI {
                 .build();
     }
 
-    private Map<String, String> initializeWithdrawnNicknameMap(List<String> memberIds) {
-        Map<String, String> result = new HashMap<>();
+    private Map<Long, String> initializeWithdrawnNicknameMap(List<Long> memberIds) {
+        Map<Long, String> result = new HashMap<>();
         memberIds.forEach(memberId -> result.put(memberId, WITHDRAWN_MEMBER_NICKNAME));
         return result;
     }
 
-    private Map<String, MemberExternalDTO.PersonalInfo> initializeWithdrawnPersonalInfoMap(List<String> memberIds) {
-        Map<String, MemberExternalDTO.PersonalInfo> result = new HashMap<>();
+    private Map<Long, MemberExternalDTO.PersonalInfo> initializeWithdrawnPersonalInfoMap(List<Long> memberIds) {
+        Map<Long, MemberExternalDTO.PersonalInfo> result = new HashMap<>();
         memberIds.forEach(memberId -> result.put(memberId, withdrawnPersonalInfo()));
         return result;
     }
 
-    private Map<String, MemberExternalDTO.BasicInfo> initializeWithdrawnBasicInfoMap(List<String> memberIds) {
-        Map<String, MemberExternalDTO.BasicInfo> result = new HashMap<>();
+    private Map<Long, MemberExternalDTO.BasicInfo> initializeWithdrawnBasicInfoMap(List<Long> memberIds) {
+        Map<Long, MemberExternalDTO.BasicInfo> result = new HashMap<>();
         memberIds.forEach(memberId -> result.put(memberId, withdrawnBasicInfo()));
         return result;
     }
 
-    private Map<String, MemberExternalDTO.DetailInfo> initializeWithdrawnDetailInfoMap(List<String> memberIds) {
-        Map<String, MemberExternalDTO.DetailInfo> result = new HashMap<>();
+    private Map<Long, MemberExternalDTO.DetailInfo> initializeWithdrawnDetailInfoMap(List<Long> memberIds) {
+        Map<Long, MemberExternalDTO.DetailInfo> result = new HashMap<>();
         memberIds.forEach(memberId -> result.put(memberId, withdrawnDetailInfo()));
         return result;
     }
@@ -276,7 +270,7 @@ public class MemberAPIImpl implements MemberAPI {
                 .build();
     }
 
-    private List<String> distinctNonNullIds(List<String> ids) {
+    private List<Long> distinctNonNullIds(List<Long> ids) {
         if (ids == null || ids.isEmpty()) {
             return List.of();
         }
@@ -286,29 +280,19 @@ public class MemberAPIImpl implements MemberAPI {
                 .collect(Collectors.collectingAndThen(Collectors.toList(), list -> new ArrayList<>(new LinkedHashSet<>(list))));
     }
 
-    private List<Long> parseMemberIds(List<String> memberIds) {
-        return memberIds.stream()
-                .map(this::parseMemberId)
-                .toList();
-    }
-
-    private Long parseMemberId(String memberId) {
-        return memberId == null ? null : Long.valueOf(memberId);
-    }
-
     private boolean isWithdrawnBasicInfo(MemberExternalDTO.BasicInfo basicInfo) {
         return WITHDRAWN_MEMBER_NICKNAME.equals(basicInfo.getNickname())
                 && basicInfo.getProfileImageUrl() == null;
     }
 
     private MemberExternalDTO.BasicInfoWithFollow toBasicInfoWithFollow(
-            String targetId,
-            Map<String, MemberExternalDTO.BasicInfo> basicInfoMap,
+            Long targetId,
+            Map<Long, MemberExternalDTO.BasicInfo> basicInfoMap,
             Map<Long, Boolean> followStatusMap
     ) {
         MemberExternalDTO.BasicInfo basicInfo = basicInfoMap.getOrDefault(targetId, withdrawnBasicInfo());
         boolean isWithdrawn = isWithdrawnBasicInfo(basicInfo);
-        boolean isFollowing = !isWithdrawn && followStatusMap.getOrDefault(parseMemberId(targetId), false);
+        boolean isFollowing = !isWithdrawn && followStatusMap.getOrDefault(targetId, false);
 
         return MemberExternalDTO.BasicInfoWithFollow.builder()
                 .nickname(basicInfo.getNickname())

--- a/src/main/java/checkmo/member/internal/converter/MemberConverter.java
+++ b/src/main/java/checkmo/member/internal/converter/MemberConverter.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberConverter {
 
-    public static DetailInfo toMemberProfileWithCategory(Member member) {
+    public static DetailInfo toMemberProfileWithCategory(Member member, boolean social) {
         return DetailInfo.builder()
                 .nickname(member.getNickName())
                 .name(member.getName())
@@ -17,7 +17,7 @@ public class MemberConverter {
                 .profileImageUrl(member.getImgUrl())
                 .phoneNumber(member.getPhoneNumber())
                 .categories(member.getInterestCategories())
-                .social(member.isSocial())
+                .social(social)
                 .build();
     }
 
@@ -47,7 +47,7 @@ public class MemberConverter {
     public static BlockedMember toBlockedMember(MemberBlock memberBlock) {
         Member blocked = memberBlock.getBlocked();
         return BlockedMember.builder()
-                .memberId(blocked.getId())
+                .memberId(String.valueOf(blocked.getId()))
                 .nickname(blocked.getNickName())
                 .profileImageUrl(blocked.getImgUrl())
                 .build();

--- a/src/main/java/checkmo/member/internal/converter/MemberConverter.java
+++ b/src/main/java/checkmo/member/internal/converter/MemberConverter.java
@@ -47,7 +47,7 @@ public class MemberConverter {
     public static BlockedMember toBlockedMember(MemberBlock memberBlock) {
         Member blocked = memberBlock.getBlocked();
         return BlockedMember.builder()
-                .memberId(String.valueOf(blocked.getId()))
+                .memberId(blocked.getId())
                 .nickname(blocked.getNickName())
                 .profileImageUrl(blocked.getImgUrl())
                 .build();

--- a/src/main/java/checkmo/member/internal/entity/Member.java
+++ b/src/main/java/checkmo/member/internal/entity/Member.java
@@ -41,7 +41,10 @@ public class Member extends BaseEntity {
 
     @Id
     @Column(nullable = false, unique = true)
-    private String id;
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String legacyId;
 
     @Column(nullable = false)
     private String email;
@@ -119,11 +122,11 @@ public class Member extends BaseEntity {
         }
     }
 
-    public static boolean isSameMember(String memberId1, String memberId2) {
+    public static boolean isSameMember(Long memberId1, Long memberId2) {
         return memberId1.equals(memberId2);
     }
 
-    public void verifyNotSelf(String memberId) {
+    public void verifyNotSelf(Long memberId) {
         if (this.id.equals(memberId)) {
             throw new MemberException(MemberErrorStatus.MEMBER_CANNOT_FOLLOW_SELF);
         }
@@ -149,7 +152,4 @@ public class Member extends BaseEntity {
         return deactivatedAt == null;
     }
 
-    public boolean isSocial() {
-        return !id.startsWith("LOCAL_");
-    }
 }

--- a/src/main/java/checkmo/member/internal/listener/MemberEventListener.java
+++ b/src/main/java/checkmo/member/internal/listener/MemberEventListener.java
@@ -23,6 +23,7 @@ public class MemberEventListener {
     public void createMember(AuthenticationEvent.CreateMember event) {
         memberFacade.createMember(
                 event.id(),
+                event.legacyId(),
                 event.email(),
                 toTermsAgreementCommands(event.agreements())
         );

--- a/src/main/java/checkmo/member/internal/repository/FollowRepository.java
+++ b/src/main/java/checkmo/member/internal/repository/FollowRepository.java
@@ -9,16 +9,16 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRepositoryCustom {
 
-    long countByFollowing_Id(String followingId);
+    long countByFollowing_Id(Long followingId);
 
-    long countByFollower_Id(String followerId);
+    long countByFollower_Id(Long followerId);
 
     @Query("SELECT COUNT(f) > 0 FROM Follow f WHERE f.follower.id = :followerId AND f.following.id = :followingId")
-    boolean existsByFollow(String followerId, String followingId);
+    boolean existsByFollow(Long followerId, Long followingId);
 
     @Modifying
     @Query("DELETE FROM Follow f WHERE f.follower.id = :followerId AND f.following.id = :followingId")
-    void deleteByFollow(String followerId, String followingId);
+    void deleteByFollow(Long followerId, Long followingId);
 
     @Modifying
     @Query("""
@@ -26,15 +26,15 @@ public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRep
             WHERE (f.follower.id = :memberId1 AND f.following.id = :memberId2)
                OR (f.follower.id = :memberId2 AND f.following.id = :memberId1)
             """)
-    void deleteBetweenMembers(String memberId1, String memberId2);
+    void deleteBetweenMembers(Long memberId1, Long memberId2);
 
     @Modifying
     @Query("DELETE FROM Follow f WHERE f.follower.id = :memberId OR f.following.id = :memberId")
-    void deleteAllByMemberId(String memberId);
+    void deleteAllByMemberId(Long memberId);
 
     @Query("SELECT f.following.id FROM Follow f WHERE f.follower.id = :memberId")
-    List<String> getFollowingMemberIds(String memberId);
+    List<Long> getFollowingMemberIds(Long memberId);
 
     @Query("SELECT f.following.id FROM Follow f WHERE f.follower.id = :followerId AND f.following.id IN :memberIds")
-    Set<String> findFollowingIdsByFollowerId(String followerId, List<String> memberIds);
+    Set<Long> findFollowingIdsByFollowerId(Long followerId, List<Long> memberIds);
 }

--- a/src/main/java/checkmo/member/internal/repository/FollowRepositoryCustom.java
+++ b/src/main/java/checkmo/member/internal/repository/FollowRepositoryCustom.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface FollowRepositoryCustom {
 
-    List<Follow> findFollowers(String followingId, Long cursorId, int pageSize, List<String> excludedMemberIds);
+    List<Follow> findFollowers(Long followingId, Long cursorId, int pageSize, List<Long> excludedMemberIds);
 
-    List<Follow> findFollowings(String followerId, Long cursorId, int pageSize, List<String> excludedMemberIds);
+    List<Follow> findFollowings(Long followerId, Long cursorId, int pageSize, List<Long> excludedMemberIds);
 }

--- a/src/main/java/checkmo/member/internal/repository/FollowRepositoryCustomImpl.java
+++ b/src/main/java/checkmo/member/internal/repository/FollowRepositoryCustomImpl.java
@@ -16,7 +16,7 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Follow> findFollowers(String followingId, Long cursorId, int pageSize, List<String> excludedMemberIds) {
+    public List<Follow> findFollowers(Long followingId, Long cursorId, int pageSize, List<Long> excludedMemberIds) {
         return queryFactory
                 .selectFrom(follow)
                 .join(follow.follower).fetchJoin()
@@ -31,7 +31,7 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
     }
 
     @Override
-    public List<Follow> findFollowings(String followerId, Long cursorId, int pageSize, List<String> excludedMemberIds) {
+    public List<Follow> findFollowings(Long followerId, Long cursorId, int pageSize, List<Long> excludedMemberIds) {
         return queryFactory
                 .selectFrom(follow)
                 .join(follow.following).fetchJoin()
@@ -49,11 +49,11 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom {
         return cursorId != null ? follow.id.lt(cursorId) : null;
     }
 
-    private BooleanExpression notInFollowerIds(List<String> excludedMemberIds) {
+    private BooleanExpression notInFollowerIds(List<Long> excludedMemberIds) {
         return excludedMemberIds == null || excludedMemberIds.isEmpty() ? null : follow.follower.id.notIn(excludedMemberIds);
     }
 
-    private BooleanExpression notInFollowingIds(List<String> excludedMemberIds) {
+    private BooleanExpression notInFollowingIds(List<Long> excludedMemberIds) {
         return excludedMemberIds == null || excludedMemberIds.isEmpty() ? null : follow.following.id.notIn(excludedMemberIds);
     }
 }

--- a/src/main/java/checkmo/member/internal/repository/MemberBlockRepository.java
+++ b/src/main/java/checkmo/member/internal/repository/MemberBlockRepository.java
@@ -8,11 +8,11 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface MemberBlockRepository extends JpaRepository<MemberBlock, Long>, MemberBlockRepositoryCustom {
 
-    boolean existsByBlocker_IdAndBlocked_Id(String blockerId, String blockedId);
+    boolean existsByBlocker_IdAndBlocked_Id(Long blockerId, Long blockedId);
 
-    Optional<MemberBlock> findByBlocker_IdAndBlocked_Id(String blockerId, String blockedId);
+    Optional<MemberBlock> findByBlocker_IdAndBlocked_Id(Long blockerId, Long blockedId);
 
     @Modifying
     @Query("DELETE FROM MemberBlock mb WHERE mb.blocker.id = :memberId OR mb.blocked.id = :memberId")
-    void deleteAllByMemberId(String memberId);
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/checkmo/member/internal/repository/MemberBlockRepositoryCustom.java
+++ b/src/main/java/checkmo/member/internal/repository/MemberBlockRepositoryCustom.java
@@ -6,13 +6,13 @@ import java.util.Optional;
 
 public interface MemberBlockRepositoryCustom {
 
-    List<MemberBlock> findBlocks(String blockerId, Long cursorId, int pageSize);
+    List<MemberBlock> findBlocks(Long blockerId, Long cursorId, int pageSize);
 
-    List<String> findBlockedMemberIds(String blockerId);
+    List<Long> findBlockedMemberIds(Long blockerId);
 
-    List<String> findBlockRelatedMemberIds(String memberId);
+    List<Long> findBlockRelatedMemberIds(Long memberId);
 
-    Optional<MemberBlock> findBetween(String memberId1, String memberId2);
+    Optional<MemberBlock> findBetween(Long memberId1, Long memberId2);
 
-    boolean existsBetween(String memberId1, String memberId2);
+    boolean existsBetween(Long memberId1, Long memberId2);
 }

--- a/src/main/java/checkmo/member/internal/repository/MemberBlockRepositoryCustomImpl.java
+++ b/src/main/java/checkmo/member/internal/repository/MemberBlockRepositoryCustomImpl.java
@@ -18,7 +18,7 @@ public class MemberBlockRepositoryCustomImpl implements MemberBlockRepositoryCus
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<MemberBlock> findBlocks(String blockerId, Long cursorId, int pageSize) {
+    public List<MemberBlock> findBlocks(Long blockerId, Long cursorId, int pageSize) {
         return queryFactory
                 .selectFrom(memberBlock)
                 .join(memberBlock.blocked).fetchJoin()
@@ -32,7 +32,7 @@ public class MemberBlockRepositoryCustomImpl implements MemberBlockRepositoryCus
     }
 
     @Override
-    public List<String> findBlockedMemberIds(String blockerId) {
+    public List<Long> findBlockedMemberIds(Long blockerId) {
         return queryFactory
                 .select(memberBlock.blocked.id)
                 .from(memberBlock)
@@ -41,7 +41,7 @@ public class MemberBlockRepositoryCustomImpl implements MemberBlockRepositoryCus
     }
 
     @Override
-    public List<String> findBlockRelatedMemberIds(String memberId) {
+    public List<Long> findBlockRelatedMemberIds(Long memberId) {
         return queryFactory
                 .select(new CaseBuilder()
                         .when(memberBlock.blocker.id.eq(memberId))
@@ -55,7 +55,7 @@ public class MemberBlockRepositoryCustomImpl implements MemberBlockRepositoryCus
     }
 
     @Override
-    public Optional<MemberBlock> findBetween(String memberId1, String memberId2) {
+    public Optional<MemberBlock> findBetween(Long memberId1, Long memberId2) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(memberBlock)
                 .where(between(memberId1, memberId2))
@@ -63,7 +63,7 @@ public class MemberBlockRepositoryCustomImpl implements MemberBlockRepositoryCus
     }
 
     @Override
-    public boolean existsBetween(String memberId1, String memberId2) {
+    public boolean existsBetween(Long memberId1, Long memberId2) {
         Integer result = queryFactory
                 .selectOne()
                 .from(memberBlock)
@@ -73,7 +73,7 @@ public class MemberBlockRepositoryCustomImpl implements MemberBlockRepositoryCus
         return result != null;
     }
 
-    private BooleanExpression between(String memberId1, String memberId2) {
+    private BooleanExpression between(Long memberId1, Long memberId2) {
         return memberBlock.blocker.id.eq(memberId1).and(memberBlock.blocked.id.eq(memberId2))
                 .or(memberBlock.blocker.id.eq(memberId2).and(memberBlock.blocked.id.eq(memberId1)));
     }

--- a/src/main/java/checkmo/member/internal/repository/MemberRepository.java
+++ b/src/main/java/checkmo/member/internal/repository/MemberRepository.java
@@ -59,5 +59,15 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
     boolean existsByEmail(String email);
 
 
-    Page<Member> findByEmailContainingIgnoreCase(String emailKeyword, Pageable pageable);
+    @Query("""
+            select m
+            from Member m
+            where (:memberId is not null and m.id = :memberId)
+               or lower(m.email) like lower(concat('%', :keyword, '%'))
+            """)
+    Page<Member> findByIdOrEmailContainingIgnoreCase(
+            @Param("memberId") Long memberId,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/src/main/java/checkmo/member/internal/repository/MemberRepository.java
+++ b/src/main/java/checkmo/member/internal/repository/MemberRepository.java
@@ -14,30 +14,30 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface MemberRepository extends JpaRepository<Member, String>, MemberRepositoryCustom {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
 
     boolean existsByNickNameAndDeactivatedAtIsNull(String nickName);
-    Optional<Member> findByIdAndDeactivatedAtIsNull(String id);
-    List<Member> findAllByIdInAndDeactivatedAtIsNull(List<String> ids);
+    Optional<Member> findByIdAndDeactivatedAtIsNull(Long id);
+    List<Member> findAllByIdInAndDeactivatedAtIsNull(List<Long> ids);
 
     @Query("select m from Member m where m.nickName = :nickName and m.deactivatedAt is null")
     Optional<Member> findByNickName(@Param("nickName") String nickName);
 
     @Query("select m.id from Member m where m.nickName = :nickName and m.deactivatedAt is null")
-    Optional<String> findIdByNickName(@Param("nickName") String nickName);
+    Optional<Long> findIdByNickName(@Param("nickName") String nickName);
 
     @Query("select m.nickName from Member m where m.id = :memberId and m.deactivatedAt is null")
-    Optional<String> findActiveNicknameById(@Param("memberId") String memberId);
+    Optional<String> findActiveNicknameById(@Param("memberId") Long memberId);
 
     @Query("select m.id as id, m.nickName as nickName from Member m where m.id in :memberIds and m.deactivatedAt is null")
-    List<MemberIdAndNicknameProjection> findActiveIdAndNicknameByIdIn(@Param("memberIds") List<String> memberIds);
+    List<MemberIdAndNicknameProjection> findActiveIdAndNicknameByIdIn(@Param("memberIds") List<Long> memberIds);
 
     @Query("select m.id as id, m.nickName as nickName, m.imgUrl as imgUrl from Member m where m.id in :memberIds and m.deactivatedAt is null")
-    List<MemberBasicInfoProjection> findActiveIdNicknameAndImgUrlByIdIn(@Param("memberIds") List<String> memberIds);
+    List<MemberBasicInfoProjection> findActiveIdNicknameAndImgUrlByIdIn(@Param("memberIds") List<Long> memberIds);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select m from Member m where m.id in :memberIds and m.deactivatedAt is null order by m.id asc")
-    List<Member> lockActiveMembersByIdIn(@Param("memberIds") List<String> memberIds);
+    List<Member> lockActiveMembersByIdIn(@Param("memberIds") List<Long> memberIds);
 
     // 생성일시가 특정 시간 이전이고, 추가정보(nickname)가 아직 입력되지 않은(프로필 미완료) 회원 조회
     @Query("SELECT m FROM Member m WHERE m.createdAt < :threshold AND m.nickName IS NULL")
@@ -59,9 +59,5 @@ public interface MemberRepository extends JpaRepository<Member, String>, MemberR
     boolean existsByEmail(String email);
 
 
-    Page<Member> findByIdContainingIgnoreCaseOrEmailContainingIgnoreCase(
-            String idKeyword,
-            String emailKeyword,
-            Pageable pageable
-    );
+    Page<Member> findByEmailContainingIgnoreCase(String emailKeyword, Pageable pageable);
 }

--- a/src/main/java/checkmo/member/internal/repository/MemberRepositoryCustom.java
+++ b/src/main/java/checkmo/member/internal/repository/MemberRepositoryCustom.java
@@ -6,9 +6,9 @@ import java.util.List;
 
 public interface MemberRepositoryCustom {
     List<Member> findRecommendMembers(
-            String currentMemberId,
+            Long currentMemberId,
             List<MemberInterestCategory> myInterests,
-            List<String> excludedMemberIds,
+            List<Long> excludedMemberIds,
             int limit
     );
 }

--- a/src/main/java/checkmo/member/internal/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/checkmo/member/internal/repository/MemberRepositoryCustomImpl.java
@@ -21,13 +21,12 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 
     @Override
     public List<Member> findRecommendMembers(
-            String currentMemberId,
+            Long currentMemberId,
             List<MemberInterestCategory> myInterests,
-            List<String> excludedMemberIds,
+            List<Long> excludedMemberIds,
             int limit
     ) {
-        // 1. 이미 팔로우한 사람들의 ID 조회
-        List<String> followingIds = queryFactory
+        List<Long> followingIds = queryFactory
                 .select(follow.following.id)
                 .from(follow)
                 .where(follow.follower.id.eq(currentMemberId))
@@ -67,11 +66,11 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
                 .fetch();
     }
 
-    private BooleanExpression notInFollowingIds(List<String> followingIds) {
+    private BooleanExpression notInFollowingIds(List<Long> followingIds) {
         return followingIds.isEmpty() ? null : member.id.notIn(followingIds);
     }
 
-    private BooleanExpression notInExcludedIds(List<String> excludedMemberIds) {
+    private BooleanExpression notInExcludedIds(List<Long> excludedMemberIds) {
         return excludedMemberIds == null || excludedMemberIds.isEmpty() ? null : member.id.notIn(excludedMemberIds);
     }
 }

--- a/src/main/java/checkmo/member/internal/repository/MemberTermsRepository.java
+++ b/src/main/java/checkmo/member/internal/repository/MemberTermsRepository.java
@@ -26,9 +26,9 @@ public interface MemberTermsRepository extends JpaRepository<MemberTerms, Long> 
               )
             """)
     List<MemberTerms> findLatestByMemberIdAndTermsIdIn(
-            @Param("memberId") String memberId,
+            @Param("memberId") Long memberId,
             @Param("termsIds") List<Long> termsIds
     );
 
-    long countByMember_IdAndTerms_Id(String memberId, Long termsId);
+    long countByMember_IdAndTerms_Id(Long memberId, Long termsId);
 }

--- a/src/main/java/checkmo/member/internal/repository/projection/MemberBasicInfoProjection.java
+++ b/src/main/java/checkmo/member/internal/repository/projection/MemberBasicInfoProjection.java
@@ -4,7 +4,7 @@ package checkmo.member.internal.repository.projection;
  * 회원 ID, 닉네임, 프로필 이미지
  */
 public interface MemberBasicInfoProjection {
-    String getId();
+    Long getId();
     String getNickName();
     String getImgUrl();
 }

--- a/src/main/java/checkmo/member/internal/repository/projection/MemberIdAndNicknameProjection.java
+++ b/src/main/java/checkmo/member/internal/repository/projection/MemberIdAndNicknameProjection.java
@@ -4,6 +4,6 @@ package checkmo.member.internal.repository.projection;
  * 회원 ID와 닉네임
  */
 public interface MemberIdAndNicknameProjection {
-    String getId();
+    Long getId();
     String getNickName();
 }

--- a/src/main/java/checkmo/member/internal/scheduler/MemberCleanupScheduler.java
+++ b/src/main/java/checkmo/member/internal/scheduler/MemberCleanupScheduler.java
@@ -39,11 +39,11 @@ public class MemberCleanupScheduler {
         if (!ghostMembers.isEmpty()) {
             log.info("유령 회원 삭제 시작: {}명", ghostMembers.size());
 
-            List<String> ghostMemberIds = ghostMembers.stream()
+            List<Long> ghostMemberIds = ghostMembers.stream()
                                                       .map(Member::getId)
                                                       .toList();
 
-            for (String id : ghostMemberIds) {
+            for (Long id : ghostMemberIds) {
                 authenticationAPI.deleteAuthData(id);
             }
 
@@ -68,12 +68,12 @@ public class MemberCleanupScheduler {
 
         log.info("탈퇴 1년 경과 회원 삭제 시작: {}명", expiredMembers.size());
 
-        List<String> expiredMemberIds = expiredMembers.stream()
+        List<Long> expiredMemberIds = expiredMembers.stream()
                 .map(Member::getId)
                 .toList();
 
         Exception firstFailure = null;
-        for (String memberId : expiredMemberIds) {
+        for (Long memberId : expiredMemberIds) {
             try {
                 memberCommandService.deleteMember(memberId);
             } catch (Exception e) {

--- a/src/main/java/checkmo/member/internal/service/MemberFacade.java
+++ b/src/main/java/checkmo/member/internal/service/MemberFacade.java
@@ -25,8 +25,8 @@ public class MemberFacade {
     @Value("${checkmo.terms.enforcement-enabled:false}")
     private boolean termsEnforcementEnabled;
 
-    public void createMember(String memberId, String email, List<TermsAgreementCommand> termsAgreements) {
-        memberCommandService.createMember(memberId, email);
+    public void createMember(Long memberId, String legacyId, String email, List<TermsAgreementCommand> termsAgreements) {
+        memberCommandService.createMember(memberId, legacyId, email);
         memberTermsCommandService.saveSignupAgreements(
                 memberId,
                 termsAgreements,
@@ -34,12 +34,12 @@ public class MemberFacade {
         );
     }
 
-    public void addAdditionalInfo(String memberId, MemberRequestDTO.AdditionalInfo request) {
+    public void addAdditionalInfo(Long memberId, MemberRequestDTO.AdditionalInfo request) {
         validateRequiredTermsBeforeProfileCompletion(memberId);
         memberCommandService.addAdditionalInfo(memberId, request);
     }
 
-    private void validateRequiredTermsBeforeProfileCompletion(String memberId) {
+    private void validateRequiredTermsBeforeProfileCompletion(Long memberId) {
         if (!termsEnforcementEnabled) {
             return;
         }

--- a/src/main/java/checkmo/member/internal/service/MemberQueryFacade.java
+++ b/src/main/java/checkmo/member/internal/service/MemberQueryFacade.java
@@ -292,7 +292,7 @@ public class MemberQueryFacade {
 
         List<MemberResponseDTO.AdminBasicInfo> memberList = memberPage.getContent().stream()
                 .map(member -> MemberResponseDTO.AdminBasicInfo.builder()
-                        .memberId(String.valueOf(member.getId()))
+                        .memberId(member.getId())
                         .nickname(member.getNickName())
                         .name(member.getName())
                         .email(member.getEmail())
@@ -318,7 +318,7 @@ public class MemberQueryFacade {
         Member member = memberQueryService.retrieveMemberByNickname(memberNickName);
 
         return MemberResponseDTO.AdminMemberDetailInfo.builder()
-                .memberId(String.valueOf(member.getId()))
+                .memberId(member.getId())
                 .nickname(member.getNickName())
                 .name(member.getName())
                 .email(member.getEmail())

--- a/src/main/java/checkmo/member/internal/service/MemberQueryFacade.java
+++ b/src/main/java/checkmo/member/internal/service/MemberQueryFacade.java
@@ -46,13 +46,13 @@ public class MemberQueryFacade {
     private final MemberBlockQueryService memberBlockQueryService;
     private final MemberTermsQueryService memberTermsQueryService;
 
-    public DetailInfo retrieveMemberDetailInfo(String memberId) {
+    public DetailInfo retrieveMemberDetailInfo(Long memberId) {
         Member member = memberQueryService.retrieveMember(memberId);
 
-        return MemberConverter.toMemberProfileWithCategory(member);
+        return MemberConverter.toMemberProfileWithCategory(member, isSocialMember(memberId));
     }
 
-    public MemberTermsStatus retrieveMemberTermsStatus(String memberId) {
+    public MemberTermsStatus retrieveMemberTermsStatus(Long memberId) {
         List<Terms> activeTerms = memberTermsQueryService.retrieveActiveTerms();
 
         return TermsConverter.toMemberTermsStatus(
@@ -66,7 +66,7 @@ public class MemberQueryFacade {
         );
     }
 
-    public MemberResponseDTO.FollowCount retrieveMyFollowCount(String memberId) {
+    public MemberResponseDTO.FollowCount retrieveMyFollowCount(Long memberId) {
         long followerCount = memberFollowQueryService.countFollowers(memberId);
         long followingCount = memberFollowQueryService.countFollowings(memberId);
 
@@ -76,7 +76,7 @@ public class MemberQueryFacade {
                 .build();
     }
 
-    public othersDetailInfo retrieveOthersDetailInfo(String targetMemberNickname, String memberId) {
+    public othersDetailInfo retrieveOthersDetailInfo(String targetMemberNickname, Long memberId) {
         Member targetMember = memberQueryService.retrieveMemberByNickname(targetMemberNickname);
         memberBlockQueryService.validateProfileAccessible(memberId, targetMember.getId());
 
@@ -92,25 +92,25 @@ public class MemberQueryFacade {
         );
     }
 
-    public MemberResponseDTO.FollowList retrieveFollowers(String memberId, Long cursorId) {
+    public MemberResponseDTO.FollowList retrieveFollowers(Long memberId, Long cursorId) {
         return retrieveFollowers(memberId, memberId, cursorId);
     }
 
-    public MemberResponseDTO.FollowList retrieveOtherFollowers(String targetMemberNickname, String currentMemberId, Long cursorId) {
+    public MemberResponseDTO.FollowList retrieveOtherFollowers(String targetMemberNickname, Long currentMemberId, Long cursorId) {
         Member targetMember = memberQueryService.retrieveMemberByNickname(targetMemberNickname);
         memberBlockQueryService.validateProfileAccessible(currentMemberId, targetMember.getId());
         return retrieveFollowers(targetMember.getId(), currentMemberId, cursorId);
     }
 
-    private MemberResponseDTO.FollowList retrieveFollowers(String targetMemberId, String currentMemberId, Long cursorId) {
-        List<String> blockRelatedMemberIds = memberBlockQueryService.retrieveBlockRelatedMemberIds(currentMemberId);
+    private MemberResponseDTO.FollowList retrieveFollowers(Long targetMemberId, Long currentMemberId, Long cursorId) {
+        List<Long> blockRelatedMemberIds = memberBlockQueryService.retrieveBlockRelatedMemberIds(currentMemberId);
         CursorResult<Follow> followCursorResult = CursorPagingHelper.getPage(
                 size -> memberFollowQueryService.retrieveFollowers(targetMemberId, cursorId, size, blockRelatedMemberIds),
                 Follow::getId,
                 DEFAULT_PAGE_SIZE
         );
         List<Follow> followerList = followCursorResult.content();
-        List<String> followerIdList = ExtractHelper.extractDistinctList(followerList, follow -> follow.getFollower().getId());
+        List<Long> followerIdList = ExtractHelper.extractDistinctList(followerList, follow -> follow.getFollower().getId());
 
         // 배치 조회 (내부 DTO)
         List<BasicInfoWithFollow> profiles = retrieveMemberBasicInfoWithFollows(followerIdList, currentMemberId);
@@ -122,18 +122,18 @@ public class MemberQueryFacade {
                 .build();
     }
 
-    public MemberResponseDTO.FollowList retrieveFollowings(String memberId, Long cursorId) {
+    public MemberResponseDTO.FollowList retrieveFollowings(Long memberId, Long cursorId) {
         return retrieveFollowings(memberId, memberId, cursorId);
     }
 
-    public MemberResponseDTO.FollowList retrieveOtherFollowings(String targetMemberNickname, String currentMemberId, Long cursorId) {
+    public MemberResponseDTO.FollowList retrieveOtherFollowings(String targetMemberNickname, Long currentMemberId, Long cursorId) {
         Member targetMember = memberQueryService.retrieveMemberByNickname(targetMemberNickname);
         memberBlockQueryService.validateProfileAccessible(currentMemberId, targetMember.getId());
         return retrieveFollowings(targetMember.getId(), currentMemberId, cursorId);
     }
 
-    private MemberResponseDTO.FollowList retrieveFollowings(String targetMemberId, String currentMemberId, Long cursorId) {
-        List<String> blockRelatedMemberIds = memberBlockQueryService.retrieveBlockRelatedMemberIds(currentMemberId);
+    private MemberResponseDTO.FollowList retrieveFollowings(Long targetMemberId, Long currentMemberId, Long cursorId) {
+        List<Long> blockRelatedMemberIds = memberBlockQueryService.retrieveBlockRelatedMemberIds(currentMemberId);
         CursorResult<Follow> followCursorResult = CursorPagingHelper.getPage(
                 size -> memberFollowQueryService.retrieveFollowingIds(targetMemberId, cursorId, size, blockRelatedMemberIds),
                 Follow::getId,
@@ -141,7 +141,7 @@ public class MemberQueryFacade {
         );
         List<Follow> followingList = followCursorResult.content();
 
-        List<String> followingIdList = ExtractHelper.extractDistinctList(followingList, follow -> follow.getFollowing().getId());
+        List<Long> followingIdList = ExtractHelper.extractDistinctList(followingList, follow -> follow.getFollowing().getId());
 
         // 배치 조회 (내부 DTO)
         List<BasicInfoWithFollow> profiles = retrieveMemberBasicInfoWithFollows(followingIdList, currentMemberId);
@@ -161,8 +161,8 @@ public class MemberQueryFacade {
      * @return 회원 프로필 목록 (내부 DTO)
      */
     public List<BasicInfoWithFollow> retrieveMemberBasicInfoWithFollows(
-            List<String> targetMemberIds,
-            String currentMemberId
+            List<Long> targetMemberIds,
+            Long currentMemberId
     ) {
 
         if (targetMemberIds == null || targetMemberIds.isEmpty()) {
@@ -174,15 +174,15 @@ public class MemberQueryFacade {
                 targetMemberIds);
 
         // 2. 팔로우 상태 배치 조회
-        Map<String, Boolean> followStatusMap = memberFollowQueryService
+        Map<Long, Boolean> followStatusMap = memberFollowQueryService
                 .checkFollowStatusByMemberId(currentMemberId, targetMemberIds);
 
         // 3. 내부 DTO로 변환
-        Map<String, BasicInfoWithFollow> profileMap = memberInfoList.stream()
+        Map<Long, BasicInfoWithFollow> profileMap = memberInfoList.stream()
                 .collect(Collectors.toMap(
                         MemberBasicInfoProjection::getId,
                         projection -> {
-                            String memberId = projection.getId();
+                            Long memberId = projection.getId();
                             boolean isFollowing = followStatusMap.getOrDefault(memberId, false);
                             return BasicInfoWithFollow.builder()
                                     .nickname(projection.getNickName())
@@ -216,10 +216,10 @@ public class MemberQueryFacade {
         return id.substring(0, id.length() - 4) + "****" + domain;
     }
 
-    public RecommendedMemberList retrieveRecommendedMembers(String memberId) {
+    public RecommendedMemberList retrieveRecommendedMembers(Long memberId) {
         Member member = memberQueryService.retrieveMember(memberId);
         List<MemberInterestCategory> myInterests = List.copyOf(member.getInterestCategories());
-        List<String> blockRelatedMemberIds = memberBlockQueryService.retrieveBlockRelatedMemberIds(memberId);
+        List<Long> blockRelatedMemberIds = memberBlockQueryService.retrieveBlockRelatedMemberIds(memberId);
 
         List<Member> recommendedMembers = memberQueryService.retrieveRecommendedMembers(
                 memberId, myInterests, blockRelatedMemberIds, RECOMMENDED_MEMBER_LIMIT
@@ -234,7 +234,7 @@ public class MemberQueryFacade {
                 .build();
     }
 
-    public BlockedMemberList retrieveBlockedMembers(String memberId, Long cursorId) {
+    public BlockedMemberList retrieveBlockedMembers(Long memberId, Long cursorId) {
         CursorResult<MemberBlock> blockCursorResult = CursorPagingHelper.getPage(
                 size -> memberBlockQueryService.retrieveBlocks(memberId, cursorId, size),
                 MemberBlock::getId,
@@ -252,12 +252,12 @@ public class MemberQueryFacade {
                 .build();
     }
 
-    public MemberResponseDTO.LoginStatus retrieveLoginStatus(String memberId) {
+    public MemberResponseDTO.LoginStatus retrieveLoginStatus(Long memberId) {
         Member member = memberQueryService.retrieveMember(memberId);
 
-        String prefix = member.getId().split("_")[0];
-        String provider = switch (prefix) {
-            case "LOCAL", "KAKAO", "GOOGLE", "NAVER" -> prefix;
+        String authProvider = authenticationAPI.fetchProvider(memberId);
+        String provider = switch (authProvider) {
+            case "LOCAL", "KAKAO", "GOOGLE", "NAVER", "APPLE" -> authProvider;
             default -> "SOCIAL";
         };
 
@@ -292,7 +292,7 @@ public class MemberQueryFacade {
 
         List<MemberResponseDTO.AdminBasicInfo> memberList = memberPage.getContent().stream()
                 .map(member -> MemberResponseDTO.AdminBasicInfo.builder()
-                        .memberId(member.getId())
+                        .memberId(String.valueOf(member.getId()))
                         .nickname(member.getNickName())
                         .name(member.getName())
                         .email(member.getEmail())
@@ -318,7 +318,7 @@ public class MemberQueryFacade {
         Member member = memberQueryService.retrieveMemberByNickname(memberNickName);
 
         return MemberResponseDTO.AdminMemberDetailInfo.builder()
-                .memberId(member.getId())
+                .memberId(String.valueOf(member.getId()))
                 .nickname(member.getNickName())
                 .name(member.getName())
                 .email(member.getEmail())
@@ -328,5 +328,9 @@ public class MemberQueryFacade {
                 .categories(member.getInterestCategories())
                 .active(member.isActive())
                 .build();
+    }
+
+    private boolean isSocialMember(Long memberId) {
+        return !"LOCAL".equals(authenticationAPI.fetchProvider(memberId));
     }
 }

--- a/src/main/java/checkmo/member/internal/service/command/MemberBlockCommandService.java
+++ b/src/main/java/checkmo/member/internal/service/command/MemberBlockCommandService.java
@@ -22,7 +22,7 @@ public class MemberBlockCommandService {
     private final MemberBlockRepository memberBlockRepository;
     private final FollowRepository followRepository;
 
-    public void block(String blockerId, String blockedNickname) {
+    public void block(Long blockerId, String blockedNickname) {
         Member blocker = memberRepository.findByIdAndDeactivatedAtIsNull(blockerId)
                 .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
         Member blocked = memberRepository.findByNickName(blockedNickname)
@@ -49,8 +49,8 @@ public class MemberBlockCommandService {
         followRepository.deleteBetweenMembers(blocker.getId(), blocked.getId());
     }
 
-    public void unblock(String blockerId, String blockedNickname) {
-        String blockedId = memberRepository.findIdByNickName(blockedNickname)
+    public void unblock(Long blockerId, String blockedNickname) {
+        Long blockedId = memberRepository.findIdByNickName(blockedNickname)
                 .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
 
         MemberBlock memberBlock = memberBlockRepository.findByBlocker_IdAndBlocked_Id(blockerId, blockedId)
@@ -59,8 +59,8 @@ public class MemberBlockCommandService {
         memberBlockRepository.delete(memberBlock);
     }
 
-    private void lockMemberPair(String memberId1, String memberId2) {
-        List<String> memberIds = List.of(memberId1, memberId2).stream()
+    private void lockMemberPair(Long memberId1, Long memberId2) {
+        List<Long> memberIds = List.of(memberId1, memberId2).stream()
                 .sorted()
                 .toList();
         memberRepository.lockActiveMembersByIdIn(memberIds);

--- a/src/main/java/checkmo/member/internal/service/command/MemberCommandService.java
+++ b/src/main/java/checkmo/member/internal/service/command/MemberCommandService.java
@@ -80,7 +80,7 @@ public class MemberCommandService {
         // 회원 등록 완료 이벤트 발행
         eventPublisher.publishEvent(
                 MemberEvent.MemberRegistrationCompleted.builder()
-                        .memberId(String.valueOf(memberId))
+                        .memberId(memberId)
                         .build());
     }
 

--- a/src/main/java/checkmo/member/internal/service/command/MemberCommandService.java
+++ b/src/main/java/checkmo/member/internal/service/command/MemberCommandService.java
@@ -33,9 +33,10 @@ public class MemberCommandService {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    public void createMember(String memberId, String email) {
+    public void createMember(Long memberId, String legacyId, String email) {
         Member member = Member.builder()
                 .id(memberId)
+                .legacyId(legacyId)
                 .email(email)
                 .name("")
                 .phoneNumber("")
@@ -52,7 +53,7 @@ public class MemberCommandService {
      * @param request 추가 정보 DTO (닉네임, 프로필 이미지, 관심 카테고리)
      * @return void -> 어차피 회원 프로필 정보 완료 후에는 메인 화면에 로그인된 상태로 리다이렉트
      */
-    public void addAdditionalInfo(String memberId, MemberRequestDTO.AdditionalInfo request) {
+    public void addAdditionalInfo(Long memberId, MemberRequestDTO.AdditionalInfo request) {
         Member member = findActiveMember(memberId);
 
         if (!StringUtils.hasText(request.getNickname())) {
@@ -79,7 +80,7 @@ public class MemberCommandService {
         // 회원 등록 완료 이벤트 발행
         eventPublisher.publishEvent(
                 MemberEvent.MemberRegistrationCompleted.builder()
-                        .memberId(memberId)
+                        .memberId(String.valueOf(memberId))
                         .build());
     }
 
@@ -92,7 +93,7 @@ public class MemberCommandService {
      * @return 수정된 회원 프로필 정보 엔티티 - 이때는 관심 카테고리 정보 DTO에 포함 X , -> 반드시 CategoryQueryFacade를 통해 조회해야 함
      */
     public DetailInfo updateProfile(
-            String memberId,
+            Long memberId,
             MemberRequestDTO.MemberProfileUpdate request
     ) {
         // 회원 조회
@@ -126,7 +127,7 @@ public class MemberCommandService {
             member.updateInterestCategories(new HashSet<>(request.getCategories()));
         }
 
-        return MemberConverter.toMemberProfileWithCategory(member);
+        return MemberConverter.toMemberProfileWithCategory(member, isSocialMember(memberId));
     }
 
     /**
@@ -135,7 +136,7 @@ public class MemberCommandService {
      * @param memberId 비밀번호를 변경할 회원의 ID
      * @param request  비밀번호 변경 정보 DTO (현재 비밀번호, 새 비밀번호, 새 비밀번호 확인)
      */
-    public void updatePassword(String memberId, MemberRequestDTO.UpdatePassword request) {
+    public void updatePassword(Long memberId, MemberRequestDTO.UpdatePassword request) {
         if (!request.getNewPassword().equals(request.getConfirmPassword())) {
             throw new MemberException(MemberErrorStatus.PASSWORD_MISMATCH);
         }
@@ -152,7 +153,7 @@ public class MemberCommandService {
      *
      * @param memberId 비활성화할 회원의 ID
      */
-    public void deactivateMember(String memberId, HttpServletRequest request, HttpServletResponse response) {
+    public void deactivateMember(Long memberId, HttpServletRequest request, HttpServletResponse response) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
 
@@ -164,7 +165,7 @@ public class MemberCommandService {
         authenticationAPI.deactivateMember(memberId, request, response);
     }
 
-    public void reactivateIfDeactivated(String memberId) {
+    public void reactivateIfDeactivated(Long memberId) {
         memberRepository.findById(memberId)
                 .filter(Member::isDeactivated)
                 .ifPresent(Member::reactivate);
@@ -175,7 +176,7 @@ public class MemberCommandService {
      *
      * @param memberId 삭제할 회원의 ID
      */
-    public void deleteMember(String memberId) {
+    public void deleteMember(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElse(null);
 
@@ -196,7 +197,7 @@ public class MemberCommandService {
      * @param memberId
      * @param request
      */
-    public void updateEmail(String memberId, MemberRequestDTO.UpdateEmail request) {
+    public void updateEmail(Long memberId, MemberRequestDTO.UpdateEmail request) {
         // 새 이메일 중복 체크
         if (memberRepository.existsByEmail(request.getNewEmail())) {
             throw new MemberException(MemberErrorStatus.EMAIL_ALREADY_EXISTS);
@@ -210,8 +211,12 @@ public class MemberCommandService {
         member.updateEmail(request.getNewEmail());
     }
 
-    private Member findActiveMember(String memberId) {
+    private Member findActiveMember(Long memberId) {
         return memberRepository.findByIdAndDeactivatedAtIsNull(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    private boolean isSocialMember(Long memberId) {
+        return !"LOCAL".equals(authenticationAPI.fetchProvider(memberId));
     }
 }

--- a/src/main/java/checkmo/member/internal/service/command/MemberFollowCommandService.java
+++ b/src/main/java/checkmo/member/internal/service/command/MemberFollowCommandService.java
@@ -66,8 +66,8 @@ public class MemberFollowCommandService {
         // 팔로잉 이벤트 발행
         eventPublisher.publishEvent(new MemberEvent.Follow(
                 follow.getId(),
-                String.valueOf(memberId),
-                String.valueOf(following.getId())
+                memberId,
+                following.getId()
         ));
     }
 

--- a/src/main/java/checkmo/member/internal/service/command/MemberFollowCommandService.java
+++ b/src/main/java/checkmo/member/internal/service/command/MemberFollowCommandService.java
@@ -33,7 +33,7 @@ public class MemberFollowCommandService {
      * @param memberId          팔로우할 회원의 ID
      * @param followingNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로잉 처리
      */
-    public void following(String memberId, String followingNickname) {
+    public void following(Long memberId, String followingNickname) {
         // 닉네임으로 팔로잉 대상 조회
         Member following = memberRepository.findByNickName(followingNickname)
                 .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
@@ -64,11 +64,15 @@ public class MemberFollowCommandService {
         followRepository.save(follow);
 
         // 팔로잉 이벤트 발행
-        eventPublisher.publishEvent(new MemberEvent.Follow(follow.getId(), memberId, following.getId()));
+        eventPublisher.publishEvent(new MemberEvent.Follow(
+                follow.getId(),
+                String.valueOf(memberId),
+                String.valueOf(following.getId())
+        ));
     }
 
-    private void lockMemberPair(String memberId1, String memberId2) {
-        List<String> memberIds = List.of(memberId1, memberId2).stream()
+    private void lockMemberPair(Long memberId1, Long memberId2) {
+        List<Long> memberIds = List.of(memberId1, memberId2).stream()
                 .sorted()
                 .toList();
         memberRepository.lockActiveMembersByIdIn(memberIds);
@@ -80,9 +84,9 @@ public class MemberFollowCommandService {
      * @param memberId          언팔로잉할 회원의 ID
      * @param followingNickname 팔로우 대상 회원의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 언팔로잉 처리
      */
-    public void unfollowing(String memberId, String followingNickname) {
+    public void unfollowing(Long memberId, String followingNickname) {
         // 닉네임으로 팔로잉 대상의 Id 조회
-        String followingId = memberRepository.findIdByNickName(followingNickname)
+        Long followingId = memberRepository.findIdByNickName(followingNickname)
                 .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
 
         // 팔로잉 하고 있는지 여부 확인
@@ -100,9 +104,9 @@ public class MemberFollowCommandService {
      * @param memberId         제거할 회원 ID
      * @param followerNickname 팔로워의 nickname -> 서비스 로직에서 닉네임으로 회원의 ID를 조회하여 팔로워 삭제 처리
      */
-    public void deleteFollower(String memberId, String followerNickname) {
+    public void deleteFollower(Long memberId, String followerNickname) {
         // 닉네임으로 팔로워의 Id 조회
-        String followerId = memberRepository.findIdByNickName(followerNickname)
+        Long followerId = memberRepository.findIdByNickName(followerNickname)
                 .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
 
         // 팔로워가 존재하는지 확인

--- a/src/main/java/checkmo/member/internal/service/command/MemberTermsCommandService.java
+++ b/src/main/java/checkmo/member/internal/service/command/MemberTermsCommandService.java
@@ -29,12 +29,12 @@ public class MemberTermsCommandService {
 
     private final MemberTermsQueryService memberTermsQueryService;
 
-    public void updateAgreements(String memberId, List<TermsAgreementCommand> commands) {
+    public void updateAgreements(Long memberId, List<TermsAgreementCommand> commands) {
         saveAgreements(memberId, commands, false);
     }
 
     public void saveSignupAgreements(
-            String memberId,
+            Long memberId,
             List<TermsAgreementCommand> commands,
             boolean requireRequiredAgreement
     ) {
@@ -47,7 +47,7 @@ public class MemberTermsCommandService {
     }
 
     private void saveAgreements(
-            String memberId,
+            Long memberId,
             List<TermsAgreementCommand> commands,
             boolean requireRequiredAgreement
     ) {
@@ -114,7 +114,7 @@ public class MemberTermsCommandService {
         }
     }
 
-    private Map<Long, MemberTerms> retrieveLatestMemberTermsByTermsId(String memberId, List<Long> termsIds) {
+    private Map<Long, MemberTerms> retrieveLatestMemberTermsByTermsId(Long memberId, List<Long> termsIds) {
         if (termsIds == null || termsIds.isEmpty()) {
             return Map.of();
         }

--- a/src/main/java/checkmo/member/internal/service/query/MemberBlockQueryService.java
+++ b/src/main/java/checkmo/member/internal/service/query/MemberBlockQueryService.java
@@ -16,7 +16,7 @@ public class MemberBlockQueryService {
 
     private final MemberBlockRepository memberBlockRepository;
 
-    public List<MemberBlock> retrieveBlocks(String blockerId, Long cursorId, int pageSize) {
+    public List<MemberBlock> retrieveBlocks(Long blockerId, Long cursorId, int pageSize) {
         if (blockerId == null) {
             return List.of();
         }
@@ -24,7 +24,7 @@ public class MemberBlockQueryService {
         return memberBlockRepository.findBlocks(blockerId, cursorId, pageSize);
     }
 
-    public List<String> retrieveBlockedMemberIds(String blockerId) {
+    public List<Long> retrieveBlockedMemberIds(Long blockerId) {
         if (blockerId == null) {
             return List.of();
         }
@@ -32,7 +32,7 @@ public class MemberBlockQueryService {
         return memberBlockRepository.findBlockedMemberIds(blockerId);
     }
 
-    public List<String> retrieveBlockRelatedMemberIds(String memberId) {
+    public List<Long> retrieveBlockRelatedMemberIds(Long memberId) {
         if (memberId == null) {
             return List.of();
         }
@@ -40,7 +40,7 @@ public class MemberBlockQueryService {
         return memberBlockRepository.findBlockRelatedMemberIds(memberId);
     }
 
-    public boolean hasBlockBetween(String memberId1, String memberId2) {
+    public boolean hasBlockBetween(Long memberId1, Long memberId2) {
         if (memberId1 == null || memberId2 == null) {
             return false;
         }
@@ -48,7 +48,7 @@ public class MemberBlockQueryService {
         return memberBlockRepository.existsBetween(memberId1, memberId2);
     }
 
-    public boolean hasBlocked(String blockerId, String blockedId) {
+    public boolean hasBlocked(Long blockerId, Long blockedId) {
         if (blockerId == null || blockedId == null) {
             return false;
         }
@@ -56,7 +56,7 @@ public class MemberBlockQueryService {
         return memberBlockRepository.existsByBlocker_IdAndBlocked_Id(blockerId, blockedId);
     }
 
-    public void validateProfileAccessible(String viewerId, String targetMemberId) {
+    public void validateProfileAccessible(Long viewerId, Long targetMemberId) {
         if (viewerId == null || targetMemberId == null || viewerId.equals(targetMemberId)) {
             return;
         }

--- a/src/main/java/checkmo/member/internal/service/query/MemberFollowQueryService.java
+++ b/src/main/java/checkmo/member/internal/service/query/MemberFollowQueryService.java
@@ -26,7 +26,7 @@ public class MemberFollowQueryService {
      * @param pageSize 페이지 크기
      * @return 팔로워 목록
      */
-    public List<Follow> retrieveFollowers(String memberId, Long cursorId, int pageSize, List<String> excludedMemberIds) {
+    public List<Follow> retrieveFollowers(Long memberId, Long cursorId, int pageSize, List<Long> excludedMemberIds) {
         return followRepository.findFollowers(memberId, cursorId, pageSize, excludedMemberIds);
     }
 
@@ -38,14 +38,14 @@ public class MemberFollowQueryService {
      * @param pageSize 페이지 크기
      * @return 팔로잉 목록
      */
-    public List<Follow> retrieveFollowingIds(String memberId, Long cursorId, int pageSize, List<String> excludedMemberIds) {
+    public List<Follow> retrieveFollowingIds(Long memberId, Long cursorId, int pageSize, List<Long> excludedMemberIds) {
         return followRepository.findFollowings(memberId, cursorId, pageSize, excludedMemberIds);
     }
 
     /**
      * 특정 회원의 팔로우 여부 확인
      */
-    public boolean isFollowing(String memberId, String targetMemberId) {
+    public boolean isFollowing(Long memberId, Long targetMemberId) {
         if (memberId == null || targetMemberId == null) {
             return false;
         }
@@ -65,7 +65,7 @@ public class MemberFollowQueryService {
      * @param targetMemberIds 확인할 대상 회원 ID 목록
      * @return 대상 회원 ID별 팔로우 여부 매핑
      */
-    public Map<String, Boolean> checkFollowStatusByMemberId(String currentMemberId, List<String> targetMemberIds) {
+    public Map<Long, Boolean> checkFollowStatusByMemberId(Long currentMemberId, List<Long> targetMemberIds) {
         if (targetMemberIds == null || targetMemberIds.isEmpty()) {
             return Map.of();
         }
@@ -80,7 +80,7 @@ public class MemberFollowQueryService {
         }
 
         // 실제로 팔로우하고 있는 대상들을 배치로 조회
-        Set<String> followingIds = followRepository.findFollowingIdsByFollowerId(currentMemberId, targetMemberIds);
+        Set<Long> followingIds = followRepository.findFollowingIdsByFollowerId(currentMemberId, targetMemberIds);
 
         // 모든 대상에 대해 팔로우 상태를 설정 (자기 자신은 항상 true)
         return targetMemberIds.stream()
@@ -97,7 +97,7 @@ public class MemberFollowQueryService {
      * @param memberId 회원 ID
      * @return 팔로우하는 회원 ID 목록
      */
-    public List<String> retrieveFollowingIds(String memberId) {
+    public List<Long> retrieveFollowingIds(Long memberId) {
         return followRepository.getFollowingMemberIds(memberId);
     }
 
@@ -107,7 +107,7 @@ public class MemberFollowQueryService {
      * @param memberId 회원 ID
      * @return 팔로워 수
      */
-    public long countFollowers(String memberId) {
+    public long countFollowers(Long memberId) {
         return followRepository.countByFollowing_Id(memberId);
     }
 
@@ -117,7 +117,7 @@ public class MemberFollowQueryService {
      * @param memberId 회원 ID
      * @return 팔로잉 수
      */
-    public long countFollowings(String memberId) {
+    public long countFollowings(Long memberId) {
         return followRepository.countByFollower_Id(memberId);
     }
 }

--- a/src/main/java/checkmo/member/internal/service/query/MemberQueryService.java
+++ b/src/main/java/checkmo/member/internal/service/query/MemberQueryService.java
@@ -140,7 +140,20 @@ public class MemberQueryService {
             return memberRepository.findAll(pageable);
         }
 
-        return memberRepository.findByEmailContainingIgnoreCase(keyword, pageable);
+        String normalizedKeyword = keyword.trim();
+        return memberRepository.findByIdOrEmailContainingIgnoreCase(
+                parseMemberIdKeyword(normalizedKeyword),
+                normalizedKeyword,
+                pageable
+        );
+    }
+
+    private Long parseMemberIdKeyword(String keyword) {
+        try {
+            return Long.valueOf(keyword);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
 }

--- a/src/main/java/checkmo/member/internal/service/query/MemberQueryService.java
+++ b/src/main/java/checkmo/member/internal/service/query/MemberQueryService.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
@@ -44,7 +43,7 @@ public class MemberQueryService {
      * @param memberId 회원 ID
      * @return 회원 엔티티
      */
-    public Member retrieveMember(String memberId) {
+    public Member retrieveMember(Long memberId) {
         return memberRepository.findByIdAndDeactivatedAtIsNull(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
     }
@@ -55,7 +54,7 @@ public class MemberQueryService {
      * @param memberIds 회원 ID 목록
      * @return 회원 엔티티 리스트
      */
-    public List<Member> retrieveMemberById(List<String> memberIds) {
+    public List<Member> retrieveMemberById(List<Long> memberIds) {
         return memberRepository.findAllByIdInAndDeactivatedAtIsNull(memberIds);
     }
 
@@ -70,7 +69,7 @@ public class MemberQueryService {
                 .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
     }
 
-    public List<MemberBasicInfoProjection> retrieveActiveMemberBasicInfos(List<String> memberIds) {
+    public List<MemberBasicInfoProjection> retrieveActiveMemberBasicInfos(List<Long> memberIds) {
         return memberRepository.findActiveIdNicknameAndImgUrlByIdIn(memberIds);
     }
 
@@ -80,16 +79,16 @@ public class MemberQueryService {
      * @param nickname 닉네임
      * @return 회원 ID
      */
-    public String retrieveMemberId(String nickname) {
+    public Long retrieveMemberId(String nickname) {
         return memberRepository.findIdByNickName(nickname)
                 .orElseThrow(() -> new MemberException(MemberErrorStatus.MEMBER_NOT_FOUND));
     }
 
-    public Optional<String> retrieveActiveMemberNickname(String memberId) {
+    public Optional<String> retrieveActiveMemberNickname(Long memberId) {
         return memberRepository.findActiveNicknameById(memberId);
     }
 
-    public Map<String, String> retrieveActiveMemberNicknameByMemberIds(List<String> memberIds) {
+    public Map<Long, String> retrieveActiveMemberNicknameByMemberIds(List<Long> memberIds) {
         List<MemberIdAndNicknameProjection> results = memberRepository.findActiveIdAndNicknameByIdIn(memberIds);
         return results.stream()
                 .collect(Collectors.toMap(
@@ -120,9 +119,9 @@ public class MemberQueryService {
     }
 
     public List<Member> retrieveRecommendedMembers(
-            String memberId,
+            Long memberId,
             List<MemberInterestCategory> myInterests,
-            List<String> excludedMemberIds,
+            List<Long> excludedMemberIds,
             int limit
     ) {
         return memberRepository.findRecommendMembers(memberId, myInterests, excludedMemberIds, limit);
@@ -141,11 +140,7 @@ public class MemberQueryService {
             return memberRepository.findAll(pageable);
         }
 
-        return memberRepository.findByIdContainingIgnoreCaseOrEmailContainingIgnoreCase(
-                keyword,
-                keyword,
-                pageable
-        );
+        return memberRepository.findByEmailContainingIgnoreCase(keyword, pageable);
     }
 
 }

--- a/src/main/java/checkmo/member/internal/service/query/MemberTermsQueryService.java
+++ b/src/main/java/checkmo/member/internal/service/query/MemberTermsQueryService.java
@@ -33,7 +33,7 @@ public class MemberTermsQueryService {
                 .toList();
     }
 
-    public Map<Long, MemberTerms> retrieveLatestMemberTermsByTermsId(String memberId, List<Long> termsIds) {
+    public Map<Long, MemberTerms> retrieveLatestMemberTermsByTermsId(Long memberId, List<Long> termsIds) {
         if (termsIds == null || termsIds.isEmpty()) {
             return Map.of();
         }
@@ -47,7 +47,7 @@ public class MemberTermsQueryService {
         return latestTermsByTermsId;
     }
 
-    public boolean hasAgreedAllRequiredActiveTerms(String memberId) {
+    public boolean hasAgreedAllRequiredActiveTerms(Long memberId) {
         List<Terms> requiredTerms = retrieveActiveTerms().stream()
                 .filter(Terms::isRequired)
                 .toList();

--- a/src/main/java/checkmo/member/web/controller/MemberController.java
+++ b/src/main/java/checkmo/member/web/controller/MemberController.java
@@ -61,7 +61,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
     })
     public ApiResponse<Void> addAdditionalInfo(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @Valid @RequestBody MemberRequestDTO.AdditionalInfo request
     ) {
         memberFacade.addAdditionalInfo(memberId, request);
@@ -93,7 +93,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다."),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "활성 약관 종류 중복 시 TERMS_500")
     })
-    public ApiResponse<MemberTermsStatus> getMyTermsStatus(@CurrentId String memberId) {
+    public ApiResponse<MemberTermsStatus> getMyTermsStatus(@CurrentId Long memberId) {
         return ApiResponse.onSuccess(memberQueryFacade.retrieveMemberTermsStatus(memberId));
     }
 
@@ -106,7 +106,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
     })
     public ApiResponse<Void> updateMyTermsAgreements(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @Valid @RequestBody TermsRequestDTO.UpdateAgreements request
     ) {
         memberTermsCommandService.updateAgreements(
@@ -130,7 +130,7 @@ public class MemberController {
     })
     @PostMapping("/{memberNickname}/following")
     public ApiResponse<String> following(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String memberNickname
     ) {
         memberFollowCommandService.following(memberId, memberNickname);
@@ -149,7 +149,7 @@ public class MemberController {
     })
     @DeleteMapping("/{memberNickname}/following")
     public ApiResponse<String> unfollowing(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String memberNickname
     ) {
         memberFollowCommandService.unfollowing(memberId, memberNickname);
@@ -168,7 +168,7 @@ public class MemberController {
     })
     @DeleteMapping("/{memberNickname}/follower")
     public ApiResponse<String> deleteFollower(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String memberNickname
     ) {
         memberFollowCommandService.deleteFollower(memberId, memberNickname);
@@ -178,7 +178,7 @@ public class MemberController {
     @Operation(summary = "회원 차단 API", description = "특정 회원을 차단합니다. 기존 양방향 팔로우 관계는 모두 삭제됩니다.")
     @PostMapping("/{memberNickname}/block")
     public ApiResponse<String> blockMember(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String memberNickname
     ) {
         memberBlockCommandService.block(memberId, memberNickname);
@@ -188,7 +188,7 @@ public class MemberController {
     @Operation(summary = "회원 차단 해제 API", description = "특정 회원에 대한 차단을 해제합니다.")
     @DeleteMapping("/{memberNickname}/block")
     public ApiResponse<String> unblockMember(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String memberNickname
     ) {
         memberBlockCommandService.unblock(memberId, memberNickname);
@@ -204,7 +204,7 @@ public class MemberController {
     })
     @GetMapping("/me/following")
     public ApiResponse<MemberResponseDTO.FollowList> getFollowingList(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam(required = false) Long cursorId
     ) {
         var followingList = memberQueryFacade.retrieveFollowings(memberId, cursorId);
@@ -220,7 +220,7 @@ public class MemberController {
     })
     @GetMapping("/me/follower")
     public ApiResponse<MemberResponseDTO.FollowList> getFollowerList(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam(required = false) Long cursorId
     ) {
         var followerList = memberQueryFacade.retrieveFollowers(memberId, cursorId);
@@ -231,7 +231,7 @@ public class MemberController {
     @Parameter(name = "cursorId", description = "커서 ID (페이징을 위한 커서, 처음에는 null)", required = false, example = "10")
     @GetMapping("/me/blocks")
     public ApiResponse<MemberResponseDTO.BlockedMemberList> getBlockedMemberList(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam(required = false) Long cursorId
     ) {
         return ApiResponse.onSuccess(memberQueryFacade.retrieveBlockedMembers(memberId, cursorId));
@@ -246,7 +246,7 @@ public class MemberController {
     })
     @GetMapping("/{memberNickname}/followings")
     public ApiResponse<MemberResponseDTO.FollowList> getOtherFollowingList(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String memberNickname,
             @RequestParam(required = false) Long cursorId
     ) {
@@ -263,7 +263,7 @@ public class MemberController {
     })
     @GetMapping("/{memberNickname}/followers")
     public ApiResponse<MemberResponseDTO.FollowList> getOtherFollowerList(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String memberNickname,
             @RequestParam(required = false) Long cursorId
     ) {
@@ -281,7 +281,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
     })
     public ApiResponse<DetailInfo> updateMemberProfile(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @Valid @RequestBody MemberRequestDTO.MemberProfileUpdate request
     ) {
         return ApiResponse.onSuccess(memberCommandService.updateProfile(memberId, request));
@@ -296,7 +296,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
     })
     public ApiResponse<DetailInfo> getMemberProfile(
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(memberQueryFacade.retrieveMemberDetailInfo(memberId));
     }
@@ -304,7 +304,7 @@ public class MemberController {
     @Operation(summary = "내 팔로워/팔로잉 수 조회 API", description = "현재 로그인한 회원의 팔로워 수와 팔로잉 수를 조회합니다.")
     @GetMapping("/me/follow-count")
     public ApiResponse<MemberResponseDTO.FollowCount> getMyFollowCount(
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(memberQueryFacade.retrieveMyFollowCount(memberId));
     }
@@ -315,7 +315,7 @@ public class MemberController {
                     "모임 목록은 별도 API(GET /api/v1/clubs?memberNickname={닉네임})를 통해 조회해야 합니다.")
     @GetMapping("/{memberNickname}")
     public ApiResponse<othersDetailInfo> getOtherProfile(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String memberNickname
     ) {
         return ApiResponse.onSuccess(memberQueryFacade.retrieveOthersDetailInfo(memberNickname, memberId));
@@ -337,7 +337,7 @@ public class MemberController {
     @Operation(summary = "비밀번호 변경 API", description = "기존 비밀번호 확인 후 새로운 비밀번호로 변경합니다.")
     @PatchMapping("/me/update-password")
     public ApiResponse<String> updatePassword(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @Valid @RequestBody MemberRequestDTO.UpdatePassword request
     ) {
         memberCommandService.updatePassword(memberId, request);
@@ -352,7 +352,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "로그인이 필요한 서비스입니다.")
     })
     public ApiResponse<String> updateEmail(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @Valid @RequestBody MemberRequestDTO.UpdateEmail request
     ) {
         memberCommandService.updateEmail(memberId, request);
@@ -362,7 +362,7 @@ public class MemberController {
     @Operation(summary = "소셜 로그인 연동 관리", description = "현재 로그인된 계정의 가입 수단과 이메일 정보를 조회합니다.")
     @GetMapping("/me/login-status")
     public ApiResponse<MemberResponseDTO.LoginStatus> getLoginStatus(
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(memberQueryFacade.retrieveLoginStatus(memberId));
     }
@@ -375,7 +375,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
     })
     public ApiResponse<RecommendedMemberList> getRecommendedFriends(
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         return ApiResponse.onSuccess(memberQueryFacade.retrieveRecommendedMembers(memberId));
     }
@@ -389,7 +389,7 @@ public class MemberController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 회원을 찾을 수 없습니다.")
     })
     public ApiResponse<Void> withdrawMember(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             HttpServletRequest request,
             HttpServletResponse response
     ) {

--- a/src/main/java/checkmo/member/web/dto/MemberResponseDTO.java
+++ b/src/main/java/checkmo/member/web/dto/MemberResponseDTO.java
@@ -43,16 +43,6 @@ public class MemberResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
-    public static class BasicInfoWithDescription {
-        private String nickname;
-        private String description;
-        private String profileImageUrl;
-    }
-
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
     public static class DetailInfo {
         private String nickname;
         private String name;
@@ -106,7 +96,7 @@ public class MemberResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class BlockedMember {
-        private String memberId;
+        private Long memberId;
         private String nickname;
         private String profileImageUrl;
     }
@@ -157,7 +147,7 @@ public class MemberResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class AdminBasicInfo {
-        private String memberId;
+        private Long memberId;
         private String nickname;
         private String name;
         private String email;
@@ -169,7 +159,7 @@ public class MemberResponseDTO {
     @AllArgsConstructor
     @Builder
     public static class AdminMemberDetailInfo {
-        private String memberId;
+        private Long memberId;
         private String nickname;
         private String name;
         private String email;

--- a/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
+++ b/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
@@ -62,7 +62,7 @@ public class NewsQueryFacade {
     }
 
     public NewsResponseDTO.NewsList fetchMyNewsList(Long memberId, Long cursorId) {
-        String requesterEmail = memberAPI.fetchMemberEmail(String.valueOf(memberId));
+        String requesterEmail = memberAPI.fetchMemberEmail(memberId);
 
         CursorResult<News> newsCursorResult = CursorPagingHelper.getPage(
                 (pageSize) -> newsQueryService.retrieveMyNewsList(requesterEmail, cursorId, pageSize),
@@ -138,7 +138,7 @@ public class NewsQueryFacade {
     }
 
     public NewsResponseDTO.NewsList fetchMemberNewsListForAdmin(String memberNickname, Long cursorId) {
-        Long memberId = Long.valueOf(memberAPI.fetchMemberId(memberNickname));
+        Long memberId = memberAPI.fetchMemberId(memberNickname);
         return fetchMyNewsList(memberId, cursorId);
     }
 }

--- a/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
+++ b/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
@@ -61,8 +61,8 @@ public class NewsQueryFacade {
         return NewsConverter.toDetailInfo(news);
     }
 
-    public NewsResponseDTO.NewsList fetchMyNewsList(String memberId, Long cursorId) {
-        String requesterEmail = memberAPI.fetchMemberEmail(memberId);
+    public NewsResponseDTO.NewsList fetchMyNewsList(Long memberId, Long cursorId) {
+        String requesterEmail = memberAPI.fetchMemberEmail(String.valueOf(memberId));
 
         CursorResult<News> newsCursorResult = CursorPagingHelper.getPage(
                 (pageSize) -> newsQueryService.retrieveMyNewsList(requesterEmail, cursorId, pageSize),
@@ -138,7 +138,7 @@ public class NewsQueryFacade {
     }
 
     public NewsResponseDTO.NewsList fetchMemberNewsListForAdmin(String memberNickname, Long cursorId) {
-        String memberId = memberAPI.fetchMemberId(memberNickname);
+        Long memberId = Long.valueOf(memberAPI.fetchMemberId(memberNickname));
         return fetchMyNewsList(memberId, cursorId);
     }
 }

--- a/src/main/java/checkmo/news/web/controller/NewsController.java
+++ b/src/main/java/checkmo/news/web/controller/NewsController.java
@@ -49,7 +49,7 @@ public class NewsController {
     })
     @GetMapping("/me")
     public ApiResponse<NewsResponseDTO.NewsList> getMyNewsList(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam(required = false) Long cursorId
     ) {
         NewsResponseDTO.NewsList newsList = newsQueryFacade.fetchMyNewsList(memberId, cursorId);

--- a/src/main/java/checkmo/notification/internal/PushMessageFactory.java
+++ b/src/main/java/checkmo/notification/internal/PushMessageFactory.java
@@ -75,7 +75,7 @@ public class PushMessageFactory {
 
     private String fetchNickname(Long memberId) {
         try {
-            return memberAPI.fetchNickname(String.valueOf(memberId));
+            return memberAPI.fetchNickname(memberId);
         } catch (Exception e) {
             log.debug("닉네임 조회 실패 (탈퇴한 회원): memberId={}", memberId);
             return "탈퇴한 회원";

--- a/src/main/java/checkmo/notification/internal/PushMessageFactory.java
+++ b/src/main/java/checkmo/notification/internal/PushMessageFactory.java
@@ -73,9 +73,9 @@ public class PushMessageFactory {
         return data;
     }
 
-    private String fetchNickname(String memberId) {
+    private String fetchNickname(Long memberId) {
         try {
-            return memberAPI.fetchNickname(memberId);
+            return memberAPI.fetchNickname(String.valueOf(memberId));
         } catch (Exception e) {
             log.debug("닉네임 조회 실패 (탈퇴한 회원): memberId={}", memberId);
             return "탈퇴한 회원";

--- a/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
+++ b/src/main/java/checkmo/notification/internal/converter/NotificationConverter.java
@@ -15,7 +15,7 @@ public class NotificationConverter {
 
     public static BasicInfoPreviewList toPreviewListDTO(
             List<Notification> notifications,
-            Map<String, String> senderNicknameMap,
+            Map<Long, String> senderNicknameMap,
             Map<Long, String> clubNameMap
     ) {
         List<BasicInfo> previewList = notifications.stream()
@@ -29,7 +29,7 @@ public class NotificationConverter {
 
     public static BasicInfoList toNotificationListDTO(
             List<Notification> notifications,
-            Map<String, String> senderNicknameMap,
+            Map<Long, String> senderNicknameMap,
             Map<Long, String> clubNameMap,
             CursorResult<Notification> cursorResult,
             int pageSize
@@ -48,7 +48,7 @@ public class NotificationConverter {
 
     private static BasicInfo toBasicInfo(
             Notification notification,
-            Map<String, String> senderNicknameMap,
+            Map<Long, String> senderNicknameMap,
             Map<Long, String> clubNameMap
     ) {
         // 클럽 알림: clubName 사용,

--- a/src/main/java/checkmo/notification/internal/entity/Notification.java
+++ b/src/main/java/checkmo/notification/internal/entity/Notification.java
@@ -46,10 +46,10 @@ public class Notification extends BaseEntity {
     private Long domainId; // 알림 대상 도메인의 ID (bookStoryId, clubId 등). FOLLOW의 경우 null
 
     @Column(name = "receiver_id", nullable = false)
-    private String receiverId;
+    private Long receiverId;
 
-    @Column(name = "sender_id", nullable = false)
-    private String senderId;
+    @Column(name = "sender_id")
+    private Long senderId;
 
     public void markAsRead() {
         this.isRead = true;

--- a/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
+++ b/src/main/java/checkmo/notification/internal/entity/NotificationSetting.java
@@ -30,7 +30,7 @@ public class NotificationSetting extends BaseEntity {
     private Long id;
 
     @Column(name = "member_id", nullable = false)
-    private String memberId;
+    private Long memberId;
 
     @Column(name = "book_story_liked", nullable = false)
     @Builder.Default

--- a/src/main/java/checkmo/notification/internal/entity/PushDevice.java
+++ b/src/main/java/checkmo/notification/internal/entity/PushDevice.java
@@ -22,7 +22,7 @@ public class PushDevice extends BaseEntity {
     private Long id;
 
     @Column(name = "member_id", nullable = false)
-    private String memberId;
+    private Long memberId;
 
     @Column(name = "installation_id", nullable = false, length = 36)
     private String installationId;
@@ -51,7 +51,7 @@ public class PushDevice extends BaseEntity {
     @Column(name = "deactivated_at")
     private LocalDateTime deactivatedAt;
 
-    public void update(String expoPushToken, String memberId, PushPlatform platform, String appVersion, String buildNumber) {
+    public void update(String expoPushToken, Long memberId, PushPlatform platform, String appVersion, String buildNumber) {
         this.expoPushToken = expoPushToken;
         this.memberId = memberId;
         this.platform = platform;

--- a/src/main/java/checkmo/notification/internal/listener/event/NotificationCreatedForPush.java
+++ b/src/main/java/checkmo/notification/internal/listener/event/NotificationCreatedForPush.java
@@ -1,4 +1,4 @@
 package checkmo.notification.internal.listener.event;
 
-public record NotificationCreatedForPush(Long notificationId, String receiverId) {
+public record NotificationCreatedForPush(Long notificationId, Long receiverId) {
 }

--- a/src/main/java/checkmo/notification/internal/repository/NotificationRepository.java
+++ b/src/main/java/checkmo/notification/internal/repository/NotificationRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
 
-    Optional<Notification> findByIdAndReceiverId(Long notificationId, String receiverId);
+    Optional<Notification> findByIdAndReceiverId(Long notificationId, Long receiverId);
 }

--- a/src/main/java/checkmo/notification/internal/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/checkmo/notification/internal/repository/NotificationRepositoryCustom.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface NotificationRepositoryCustom {
 
-    List<Notification> findNotificationPreviews(String receiverId, int pageSize);
+    List<Notification> findNotificationPreviews(Long receiverId, int pageSize);
 
-    List<Notification> findNotifications(String receiverId, Long cursorId, int pageSize);
+    List<Notification> findNotifications(Long receiverId, Long cursorId, int pageSize);
 }

--- a/src/main/java/checkmo/notification/internal/repository/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/checkmo/notification/internal/repository/NotificationRepositoryCustomImpl.java
@@ -16,7 +16,7 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Notification> findNotificationPreviews(String receiverId, int pageSize) {
+    public List<Notification> findNotificationPreviews(Long receiverId, int pageSize) {
         return queryFactory
                 .selectFrom(notification)
                 .where(
@@ -29,7 +29,7 @@ public class NotificationRepositoryCustomImpl implements NotificationRepositoryC
     }
 
     @Override
-    public List<Notification> findNotifications(String receiverId, Long cursorId, int pageSize) {
+    public List<Notification> findNotifications(Long receiverId, Long cursorId, int pageSize) {
         return queryFactory
                 .selectFrom(notification)
                 .where(

--- a/src/main/java/checkmo/notification/internal/repository/NotificationSettingRepository.java
+++ b/src/main/java/checkmo/notification/internal/repository/NotificationSettingRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
 
-    Optional<NotificationSetting> findByMemberId(String memberId);
+    Optional<NotificationSetting> findByMemberId(Long memberId);
 
-    boolean existsByMemberId(String memberId);
+    boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/checkmo/notification/internal/repository/PushDeviceRepository.java
+++ b/src/main/java/checkmo/notification/internal/repository/PushDeviceRepository.java
@@ -11,11 +11,11 @@ public interface PushDeviceRepository extends JpaRepository<PushDevice, Long> {
 
     Optional<PushDevice> findByInstallationId(String installationId);
 
-    Optional<PushDevice> findByInstallationIdAndMemberId(String installationId, String memberId);
+    Optional<PushDevice> findByInstallationIdAndMemberId(String installationId, Long memberId);
 
     Optional<PushDevice> findByExpoPushToken(String expoPushToken);
 
-    List<PushDevice> findAllByMemberIdAndActiveTrue(String memberId);
+    List<PushDevice> findAllByMemberIdAndActiveTrue(Long memberId);
 
     List<PushDevice> findAllByActiveFalseAndDeactivatedAtBefore(LocalDateTime threshold, Pageable pageable);
 }

--- a/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
+++ b/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
@@ -14,7 +14,6 @@ import checkmo.notification.web.dto.NotificationResponseDTO.SettingInfo;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -76,7 +75,7 @@ public class NotificationQueryFacade {
                 .filter(Objects::nonNull)
                 .distinct()
                 .toList();
-        return toLongKeyMap(memberAPI.fetchNicknameByMemberIds(toMemberApiIds(senderIds)));
+        return memberAPI.fetchNicknameByMemberIds(senderIds);
     }
 
     private Map<Long, String> fetchClubNameMap(List<Notification> notifications) {
@@ -86,19 +85,5 @@ public class NotificationQueryFacade {
                 .distinct()
                 .toList();
         return clubManagementAPI.fetchClubNamesByClubIds(clubIds);
-    }
-
-    private List<String> toMemberApiIds(List<Long> memberIds) {
-        return memberIds.stream()
-                .map(String::valueOf)
-                .toList();
-    }
-
-    private Map<Long, String> toLongKeyMap(Map<String, String> source) {
-        return source.entrySet().stream()
-                .collect(Collectors.toMap(
-                        entry -> Long.valueOf(entry.getKey()),
-                        Map.Entry::getValue
-                ));
     }
 }

--- a/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
+++ b/src/main/java/checkmo/notification/internal/service/NotificationQueryFacade.java
@@ -13,6 +13,8 @@ import checkmo.notification.web.dto.NotificationResponseDTO.BasicInfoPreviewList
 import checkmo.notification.web.dto.NotificationResponseDTO.SettingInfo;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -34,16 +36,16 @@ public class NotificationQueryFacade {
     private final NotificationSettingQueryService notificationSettingQueryService;
 
     @Cacheable(value = "notifications", key = "#memberId")
-    public BasicInfoPreviewList retrieveNotificationPreviews(String memberId) {
+    public BasicInfoPreviewList retrieveNotificationPreviews(Long memberId) {
         List<Notification> notifications = notificationQueryService.retrieveUnreadNotifications(memberId, DEFAULT_PREVIEW_SIZE);
 
-        Map<String, String> senderNicknameMap = fetchSenderNicknameMap(notifications);
+        Map<Long, String> senderNicknameMap = fetchSenderNicknameMap(notifications);
         Map<Long, String> clubNameMap = fetchClubNameMap(notifications);
 
         return NotificationConverter.toPreviewListDTO(notifications, senderNicknameMap, clubNameMap);
     }
 
-    public BasicInfoList retrieveNotifications(String memberId, Long cursorId) {
+    public BasicInfoList retrieveNotifications(Long memberId, Long cursorId) {
         CursorResult<Notification> notificationCursorResult = CursorPagingHelper.getPage(
                 size -> notificationQueryService.retrieveNotifications(memberId, cursorId, size),
                 Notification::getId,
@@ -51,7 +53,7 @@ public class NotificationQueryFacade {
         );
         List<Notification> notifications = notificationCursorResult.content();
 
-        Map<String, String> senderNicknameMap = fetchSenderNicknameMap(notifications);
+        Map<Long, String> senderNicknameMap = fetchSenderNicknameMap(notifications);
         Map<Long, String> clubNameMap = fetchClubNameMap(notifications);
 
         return NotificationConverter.toNotificationListDTO(
@@ -63,17 +65,18 @@ public class NotificationQueryFacade {
         );
     }
 
-    public SettingInfo retrieveNotificationSetting(String memberId) {
+    public SettingInfo retrieveNotificationSetting(Long memberId) {
         return notificationSettingQueryService.getNotificationSetting(memberId);
     }
 
-    private Map<String, String> fetchSenderNicknameMap(List<Notification> notifications) {
-        List<String> senderIds = notifications.stream()
+    private Map<Long, String> fetchSenderNicknameMap(List<Notification> notifications) {
+        List<Long> senderIds = notifications.stream()
                 .filter(n -> !n.getNotificationType().isClubNotification())
                 .map(Notification::getSenderId)
+                .filter(Objects::nonNull)
                 .distinct()
                 .toList();
-        return memberAPI.fetchNicknameByMemberIds(senderIds);
+        return toLongKeyMap(memberAPI.fetchNicknameByMemberIds(toMemberApiIds(senderIds)));
     }
 
     private Map<Long, String> fetchClubNameMap(List<Notification> notifications) {
@@ -83,5 +86,19 @@ public class NotificationQueryFacade {
                 .distinct()
                 .toList();
         return clubManagementAPI.fetchClubNamesByClubIds(clubIds);
+    }
+
+    private List<String> toMemberApiIds(List<Long> memberIds) {
+        return memberIds.stream()
+                .map(String::valueOf)
+                .toList();
+    }
+
+    private Map<Long, String> toLongKeyMap(Map<String, String> source) {
+        return source.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> Long.valueOf(entry.getKey()),
+                        Map.Entry::getValue
+                ));
     }
 }

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
@@ -126,7 +126,8 @@ public class NotificationCommandService {
      */
     public void createNotification(JoinClubEvent event) {
         Notification.NotificationType type = Notification.NotificationType.JOIN_CLUB;
-        if (!isNotificationEnabled(event.memberId(), type)) {
+        String receiverId = String.valueOf(event.memberId());
+        if (!isNotificationEnabled(receiverId, type)) {
             return;
         }
 
@@ -135,12 +136,12 @@ public class NotificationCommandService {
                 .sourceId(event.eventId())
                 .domainId(event.clubId())
                 .senderId("SYSTEM")
-                .receiverId(event.memberId())
+                .receiverId(receiverId)
                 .build();
         try {
             Notification saved = notificationRepository.save(notification);
-            eventPublisher.publishEvent(new NotificationCreatedForPush(saved.getId(), event.memberId()));
-            evictNotificationCache(event.memberId());
+            eventPublisher.publishEvent(new NotificationCreatedForPush(saved.getId(), receiverId));
+            evictNotificationCache(receiverId);
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
         }
@@ -155,9 +156,9 @@ public class NotificationCommandService {
         NotificationType type = NotificationType.CLUB_MEETING_CREATED;
         Long sourceId = event.eventId();
 
-        List<String> memberIds = clubManagementAPI.fetchActiveMemberIds(event.clubId());
-        for (String memberId : memberIds) {
-            createClubNotification(type, sourceId, event.clubId(), memberId);
+        List<Long> memberIds = clubManagementAPI.fetchActiveMemberIds(event.clubId());
+        for (Long memberId : memberIds) {
+            createClubNotification(type, sourceId, event.clubId(), String.valueOf(memberId));
         }
     }
 
@@ -170,9 +171,9 @@ public class NotificationCommandService {
         NotificationType type = NotificationType.CLUB_NOTICE_CREATED;
         Long sourceId = event.eventId();
 
-        List<String> memberIds = clubManagementAPI.fetchActiveMemberIds(event.clubId());
-        for (String memberId : memberIds) {
-            createClubNotification(type, sourceId, event.clubId(), memberId);
+        List<Long> memberIds = clubManagementAPI.fetchActiveMemberIds(event.clubId());
+        for (Long memberId : memberIds) {
+            createClubNotification(type, sourceId, event.clubId(), String.valueOf(memberId));
         }
     }
 

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
@@ -44,8 +44,8 @@ public class NotificationCommandService {
      */
     public void createNotification(BookStoryEvent.BookStoryLiked event) {
         NotificationType type = NotificationType.LIKE;
-        String senderId = String.valueOf(event.senderId());
-        String receiverId = String.valueOf(event.receiverId());
+        Long senderId = event.senderId();
+        Long receiverId = event.receiverId();
         if (!isNotificationEnabled(receiverId, type)) {
             return;
         }
@@ -73,8 +73,8 @@ public class NotificationCommandService {
      */
     public void createNotification(BookStoryEvent.BookStoryComment event) {
         NotificationType type = NotificationType.COMMENT;
-        String senderId = String.valueOf(event.senderId());
-        String receiverId = String.valueOf(event.receiverId());
+        Long senderId = event.senderId();
+        Long receiverId = event.receiverId();
         if (!isNotificationEnabled(receiverId, type)) {
             return;
         }
@@ -130,7 +130,7 @@ public class NotificationCommandService {
      */
     public void createNotification(JoinClubEvent event) {
         Notification.NotificationType type = Notification.NotificationType.JOIN_CLUB;
-        String receiverId = String.valueOf(event.memberId());
+        Long receiverId = event.memberId();
         if (!isNotificationEnabled(receiverId, type)) {
             return;
         }
@@ -139,7 +139,7 @@ public class NotificationCommandService {
                 .notificationType(type)
                 .sourceId(event.eventId())
                 .domainId(event.clubId())
-                .senderId("SYSTEM")
+                .senderId(null)
                 .receiverId(receiverId)
                 .build();
         try {
@@ -162,7 +162,7 @@ public class NotificationCommandService {
 
         List<Long> memberIds = clubManagementAPI.fetchActiveMemberIds(event.clubId());
         for (Long memberId : memberIds) {
-            createClubNotification(type, sourceId, event.clubId(), String.valueOf(memberId));
+            createClubNotification(type, sourceId, event.clubId(), memberId);
         }
     }
 
@@ -177,12 +177,12 @@ public class NotificationCommandService {
 
         List<Long> memberIds = clubManagementAPI.fetchActiveMemberIds(event.clubId());
         for (Long memberId : memberIds) {
-            createClubNotification(type, sourceId, event.clubId(), String.valueOf(memberId));
+            createClubNotification(type, sourceId, event.clubId(), memberId);
         }
     }
 
     private void createClubNotification(NotificationType type, Long sourceId, Long clubId,
-                                        String receiverId) {
+                                        Long receiverId) {
         if (!isNotificationEnabled(receiverId, type)) {
             return;
         }
@@ -191,7 +191,7 @@ public class NotificationCommandService {
                 .notificationType(type)
                 .sourceId(sourceId)
                 .domainId(clubId)
-                .senderId("SYSTEM")
+                .senderId(null)
                 .receiverId(receiverId)
                 .build();
         try {
@@ -203,14 +203,14 @@ public class NotificationCommandService {
         }
     }
 
-    private void evictNotificationCache(String memberId) {
+    private void evictNotificationCache(Long memberId) {
         Cache cache = cacheManager.getCache("notifications");
         if (cache != null) {
             cache.evict(memberId);
         }
     }
 
-    private boolean isNotificationEnabled(String receiverId, NotificationType type) {
+    private boolean isNotificationEnabled(Long receiverId, NotificationType type) {
         return notificationSettingRepository.findByMemberId(receiverId)
                 .map(setting -> setting.isEnabled(type))
                 .orElse(true);
@@ -223,7 +223,7 @@ public class NotificationCommandService {
      * @param memberId       읽음 처리할 회원 ID (receiverId)
      */
     @CacheEvict(value = "notifications", key = "#memberId")
-    public void markNotificationAsRead(Long notificationId, String memberId) {
+    public void markNotificationAsRead(Long notificationId, Long memberId) {
         Notification notification = notificationRepository.findByIdAndReceiverId(notificationId, memberId)
                 .orElseThrow(() -> new NotificationException(NotificationErrorStatus.NOTIFICATION_NOT_FOUND));
 

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationCommandService.java
@@ -44,7 +44,9 @@ public class NotificationCommandService {
      */
     public void createNotification(BookStoryEvent.BookStoryLiked event) {
         NotificationType type = NotificationType.LIKE;
-        if (!isNotificationEnabled(event.receiverId(), type)) {
+        String senderId = String.valueOf(event.senderId());
+        String receiverId = String.valueOf(event.receiverId());
+        if (!isNotificationEnabled(receiverId, type)) {
             return;
         }
 
@@ -52,13 +54,13 @@ public class NotificationCommandService {
                 .notificationType(type)
                 .sourceId(event.eventId())
                 .domainId(event.bookStoryId())
-                .senderId(event.senderId())
-                .receiverId(event.receiverId())
+                .senderId(senderId)
+                .receiverId(receiverId)
                 .build();
         try {
             Notification saved = notificationRepository.save(notification);
-            eventPublisher.publishEvent(new NotificationCreatedForPush(saved.getId(), event.receiverId()));
-            evictNotificationCache(event.receiverId());
+            eventPublisher.publishEvent(new NotificationCreatedForPush(saved.getId(), receiverId));
+            evictNotificationCache(receiverId);
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
         }
@@ -71,7 +73,9 @@ public class NotificationCommandService {
      */
     public void createNotification(BookStoryEvent.BookStoryComment event) {
         NotificationType type = NotificationType.COMMENT;
-        if (!isNotificationEnabled(event.receiverId(), type)) {
+        String senderId = String.valueOf(event.senderId());
+        String receiverId = String.valueOf(event.receiverId());
+        if (!isNotificationEnabled(receiverId, type)) {
             return;
         }
 
@@ -79,13 +83,13 @@ public class NotificationCommandService {
                 .notificationType(type)
                 .sourceId(event.eventId())
                 .domainId(event.bookStoryId())
-                .senderId(event.senderId())
-                .receiverId(event.receiverId())
+                .senderId(senderId)
+                .receiverId(receiverId)
                 .build();
         try {
             Notification saved = notificationRepository.save(notification);
-            eventPublisher.publishEvent(new NotificationCreatedForPush(saved.getId(), event.receiverId()));
-            evictNotificationCache(event.receiverId());
+            eventPublisher.publishEvent(new NotificationCreatedForPush(saved.getId(), receiverId));
+            evictNotificationCache(receiverId);
         } catch (DataIntegrityViolationException e) {
             // 다른 인스턴스가 동일 알람을 저장한 경우 -> 무시
         }

--- a/src/main/java/checkmo/notification/internal/service/command/NotificationSettingCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/NotificationSettingCommandService.java
@@ -16,7 +16,7 @@ public class NotificationSettingCommandService {
 
     private final NotificationSettingRepository notificationSettingRepository;
 
-    public void createNotificationSetting(String memberId) {
+    public void createNotificationSetting(Long memberId) {
         if (notificationSettingRepository.existsByMemberId(memberId)) {
             return;
         }
@@ -28,7 +28,7 @@ public class NotificationSettingCommandService {
         notificationSettingRepository.save(notificationSetting);
     }
 
-    public void toggleNotificationSetting(String memberId, NotificationSettingType settingType) {
+    public void toggleNotificationSetting(Long memberId, NotificationSettingType settingType) {
         NotificationSetting setting = notificationSettingRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new NotificationException(NotificationErrorStatus.NOTIFICATION_SETTING_NOT_FOUND));
 

--- a/src/main/java/checkmo/notification/internal/service/command/PushDeviceCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/PushDeviceCommandService.java
@@ -18,7 +18,7 @@ public class PushDeviceCommandService {
 
     private final PushDeviceRepository pushDeviceRepository;
 
-    public PushDevice upsert(String memberId, PushDeviceRequestDTO request) {
+    public PushDevice upsert(Long memberId, PushDeviceRequestDTO request) {
         String installationId = (request.getInstallationId() != null)
                 ? request.getInstallationId()
                 : UUID.randomUUID().toString();
@@ -59,7 +59,7 @@ public class PushDeviceCommandService {
         return device;
     }
 
-    public void deactivate(String memberId, String installationId) {
+    public void deactivate(Long memberId, String installationId) {
         // 미존재·이미 비활성·타인 소유 모두 성공으로 처리한다
         pushDeviceRepository.findByInstallationId(installationId)
                 .filter(d -> memberId.equals(d.getMemberId()) && d.isActive())

--- a/src/main/java/checkmo/notification/internal/service/query/NotificationQueryService.java
+++ b/src/main/java/checkmo/notification/internal/service/query/NotificationQueryService.java
@@ -22,7 +22,7 @@ public class NotificationQueryService {
      * @param size       페이지 크기
      * @return 조회된 알림 엔티티 목록
      */
-    public List<Notification> retrieveNotifications(String receiverId, Long cursorId, int size) {
+    public List<Notification> retrieveNotifications(Long receiverId, Long cursorId, int size) {
         return notificationRepository.findNotifications(receiverId, cursorId, size);
     }
 
@@ -33,7 +33,7 @@ public class NotificationQueryService {
      * @param size       조회할 알림 개수
      * @return 읽지 않은 알림 엔티티 목록
      */
-    public List<Notification> retrieveUnreadNotifications(String receiverId, int size) {
+    public List<Notification> retrieveUnreadNotifications(Long receiverId, int size) {
         return notificationRepository.findNotificationPreviews(receiverId, size);
     }
 }

--- a/src/main/java/checkmo/notification/internal/service/query/NotificationSettingQueryService.java
+++ b/src/main/java/checkmo/notification/internal/service/query/NotificationSettingQueryService.java
@@ -16,7 +16,7 @@ public class NotificationSettingQueryService {
 
     private final NotificationSettingRepository notificationSettingRepository;
 
-    public SettingInfo getNotificationSetting(String memberId) {
+    public SettingInfo getNotificationSetting(Long memberId) {
         NotificationSetting setting = notificationSettingRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new NotificationException(NotificationErrorStatus.NOTIFICATION_SETTING_NOT_FOUND));
 

--- a/src/main/java/checkmo/notification/web/controller/NotificationController.java
+++ b/src/main/java/checkmo/notification/web/controller/NotificationController.java
@@ -49,7 +49,7 @@ public class NotificationController {
     })
     @PutMapping("/push-devices")
     public ApiResponse<PushDeviceResponseDTO> registerPushDevice(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestBody @Valid PushDeviceRequestDTO request
     ) {
         var device = pushDeviceCommandService.upsert(memberId, request);
@@ -64,7 +64,7 @@ public class NotificationController {
     })
     @DeleteMapping("/push-devices/{installationId}")
     public ApiResponse<Void> deregisterPushDevice(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable String installationId
     ) {
         pushDeviceCommandService.deactivate(memberId, installationId);
@@ -81,7 +81,7 @@ public class NotificationController {
     })
     @GetMapping()
     public ApiResponse<BasicInfoList> getNotifications(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam(required = false) Long cursorId
     ) {
         var notifications = notificationQueryFacade.retrieveNotifications(memberId, cursorId);
@@ -97,7 +97,7 @@ public class NotificationController {
     })
     @GetMapping("/preview")
     public ApiResponse<BasicInfoPreviewList> getUnreadNotifications(
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         // Facade를 통해 QueryService의 캐시된 메서드 호출
         var notifications = notificationQueryFacade.retrieveNotificationPreviews(memberId);
@@ -114,7 +114,7 @@ public class NotificationController {
     })
     @PatchMapping("/{notificationId}/read")
     public ApiResponse<Long> markNotificationAsRead(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable Long notificationId
     ) {
         notificationCommandService.markNotificationAsRead(notificationId, memberId);
@@ -129,7 +129,7 @@ public class NotificationController {
     })
     @GetMapping("/settings")
     public ApiResponse<SettingInfo> getNotificationSetting(
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         var setting = notificationQueryFacade.retrieveNotificationSetting(memberId);
         return ApiResponse.onSuccess(setting);
@@ -144,7 +144,7 @@ public class NotificationController {
     })
     @PatchMapping("/settings/{settingType}")
     public ApiResponse<Void> toggleNotificationSetting(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @PathVariable NotificationSettingType settingType
     ) {
         notificationSettingCommandService.toggleNotificationSetting(memberId, settingType);

--- a/src/main/java/checkmo/realtime/RealtimeAPI.java
+++ b/src/main/java/checkmo/realtime/RealtimeAPI.java
@@ -4,5 +4,5 @@ public interface RealtimeAPI {
 
     RealtimeExternalDTO.TeamChatReportInfo fetchTeamChatReportInfo(Long chatMessageId);
 
-    String fetchChatSenderMemberId(Long chatMessageId);
+    Long fetchChatSenderMemberId(Long chatMessageId);
 }

--- a/src/main/java/checkmo/realtime/internal/RealtimeAPIImpl.java
+++ b/src/main/java/checkmo/realtime/internal/RealtimeAPIImpl.java
@@ -35,6 +35,6 @@ public class RealtimeAPIImpl implements RealtimeAPI {
         TeamChatMessage message = teamChatMessageRepository.findById(chatMessageId)
                 .orElseThrow(() -> new RealtimeGeneralException(RealtimeGeneralErrorStatus.MESSAGE_NOT_FOUND));
 
-        return message.getSenderMemberId();
+        return String.valueOf(message.getSenderMemberId());
     }
 }

--- a/src/main/java/checkmo/realtime/internal/RealtimeAPIImpl.java
+++ b/src/main/java/checkmo/realtime/internal/RealtimeAPIImpl.java
@@ -31,10 +31,10 @@ public class RealtimeAPIImpl implements RealtimeAPI {
     }
 
     @Override
-    public String fetchChatSenderMemberId(Long chatMessageId) {
+    public Long fetchChatSenderMemberId(Long chatMessageId) {
         TeamChatMessage message = teamChatMessageRepository.findById(chatMessageId)
                 .orElseThrow(() -> new RealtimeGeneralException(RealtimeGeneralErrorStatus.MESSAGE_NOT_FOUND));
 
-        return String.valueOf(message.getSenderMemberId());
+        return message.getSenderMemberId();
     }
 }

--- a/src/main/java/checkmo/realtime/internal/entity/TeamChatMessage.java
+++ b/src/main/java/checkmo/realtime/internal/entity/TeamChatMessage.java
@@ -26,7 +26,7 @@ public class TeamChatMessage extends BaseEntity {
     private Long teamId;
 
     @Column(nullable = false)
-    private String senderMemberId;
+    private Long senderMemberId;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;

--- a/src/main/java/checkmo/realtime/internal/listener/RealtimeMessagePublisher.java
+++ b/src/main/java/checkmo/realtime/internal/listener/RealtimeMessagePublisher.java
@@ -29,7 +29,7 @@ public class RealtimeMessagePublisher {
     public void publishChatAfterCommit(RealtimeEvent.TeamChatSavedEvent event) {
         TeamChatMessage teamChatMessage = teamChatMessageRepository.findById(event.meessageId())
                 .orElseThrow(() -> new RealtimeException(RealtimeErrorStatus.MESSAGE_NOT_FOUND));
-        MemberExternalDTO.BasicInfo basicInfo = memberAPI.fetchMemberBasicInfo(String.valueOf(teamChatMessage.getSenderMemberId()));
+        MemberExternalDTO.BasicInfo basicInfo = memberAPI.fetchMemberBasicInfo(teamChatMessage.getSenderMemberId());
         String dest = String.format(TEAM_CHAT_MESSAGE_DEST_TEMPLATE, event.clubId(), event.meetingId(), event.teamId());
         ChatResponseMessage message = ChatResponseMessage.builder()
                 .clubId(event.clubId())

--- a/src/main/java/checkmo/realtime/internal/listener/RealtimeMessagePublisher.java
+++ b/src/main/java/checkmo/realtime/internal/listener/RealtimeMessagePublisher.java
@@ -29,13 +29,13 @@ public class RealtimeMessagePublisher {
     public void publishChatAfterCommit(RealtimeEvent.TeamChatSavedEvent event) {
         TeamChatMessage teamChatMessage = teamChatMessageRepository.findById(event.meessageId())
                 .orElseThrow(() -> new RealtimeException(RealtimeErrorStatus.MESSAGE_NOT_FOUND));
-        MemberExternalDTO.BasicInfo basicInfo = memberAPI.fetchMemberBasicInfo(teamChatMessage.getSenderMemberId());
+        MemberExternalDTO.BasicInfo basicInfo = memberAPI.fetchMemberBasicInfo(String.valueOf(teamChatMessage.getSenderMemberId()));
         String dest = String.format(TEAM_CHAT_MESSAGE_DEST_TEMPLATE, event.clubId(), event.meetingId(), event.teamId());
         ChatResponseMessage message = ChatResponseMessage.builder()
                 .clubId(event.clubId())
                 .meetingId(event.meetingId())
                 .teamId(event.teamId())
-                .senderMemberId(teamChatMessage.getSenderMemberId())
+                .senderMemberId(String.valueOf(teamChatMessage.getSenderMemberId()))
                 .senderNickname(basicInfo.getNickname())
                 .senderProfileImageUrl(basicInfo.getProfileImageUrl())
                 .messageId(teamChatMessage.getId())

--- a/src/main/java/checkmo/realtime/internal/service/AuthorizationService.java
+++ b/src/main/java/checkmo/realtime/internal/service/AuthorizationService.java
@@ -14,6 +14,7 @@ public class AuthorizationService {
     private final ClubMeetingAPI clubMeetingAPI;
 
     public void authorizeTeamAccess(Long clubId, Long meetingId, Long teamId, String memberId) {
+        Long memberLongId = Long.valueOf(memberId);
         if (clubMeetingAPI.isNotMeetingBelongsToClub(clubId, meetingId)) {
             throw new RealtimeException(RealtimeErrorStatus.MEETING_NOT_IN_CLUB);
         }
@@ -22,12 +23,13 @@ public class AuthorizationService {
             throw new RealtimeException(RealtimeErrorStatus.TEAM_NOT_IN_ClUB);
         }
 
-        Long clubMemberId = clubManagementAPI.fetchActiveClubMemberId(clubId, memberId);
+        Long clubMemberId = clubManagementAPI.fetchActiveClubMemberId(clubId, memberLongId);
         if (clubMemberId == null) {
             throw new RealtimeException(RealtimeErrorStatus.NOT_ACTIVE_CLUB_MEMBER);
         }
 
-        if (!clubManagementAPI.isStaffClubMember(clubId, memberId) && clubMeetingAPI.isNotTeamMember(teamId, clubMemberId)) {
+        if (!clubManagementAPI.isStaffClubMember(clubId, memberLongId)
+                && clubMeetingAPI.isNotTeamMember(teamId, clubMemberId)) {
             throw new RealtimeException(RealtimeErrorStatus.NOT_TEAM_MEMBER_OR_STAFF);
         }
     }

--- a/src/main/java/checkmo/realtime/internal/service/AuthorizationService.java
+++ b/src/main/java/checkmo/realtime/internal/service/AuthorizationService.java
@@ -13,8 +13,7 @@ public class AuthorizationService {
     private final ClubManagementAPI clubManagementAPI;
     private final ClubMeetingAPI clubMeetingAPI;
 
-    public void authorizeTeamAccess(Long clubId, Long meetingId, Long teamId, String memberId) {
-        Long memberLongId = Long.valueOf(memberId);
+    public void authorizeTeamAccess(Long clubId, Long meetingId, Long teamId, Long memberId) {
         if (clubMeetingAPI.isNotMeetingBelongsToClub(clubId, meetingId)) {
             throw new RealtimeException(RealtimeErrorStatus.MEETING_NOT_IN_CLUB);
         }
@@ -23,12 +22,12 @@ public class AuthorizationService {
             throw new RealtimeException(RealtimeErrorStatus.TEAM_NOT_IN_ClUB);
         }
 
-        Long clubMemberId = clubManagementAPI.fetchActiveClubMemberId(clubId, memberLongId);
+        Long clubMemberId = clubManagementAPI.fetchActiveClubMemberId(clubId, memberId);
         if (clubMemberId == null) {
             throw new RealtimeException(RealtimeErrorStatus.NOT_ACTIVE_CLUB_MEMBER);
         }
 
-        if (!clubManagementAPI.isStaffClubMember(clubId, memberLongId)
+        if (!clubManagementAPI.isStaffClubMember(clubId, memberId)
                 && clubMeetingAPI.isNotTeamMember(teamId, clubMemberId)) {
             throw new RealtimeException(RealtimeErrorStatus.NOT_TEAM_MEMBER_OR_STAFF);
         }

--- a/src/main/java/checkmo/realtime/internal/service/ChatCommandService.java
+++ b/src/main/java/checkmo/realtime/internal/service/ChatCommandService.java
@@ -23,7 +23,7 @@ public class ChatCommandService {
     @Transactional
     public void saveTeamChatMessage(
             Long clubId, Long meetingId, Long teamId,
-            String senderMemberId, String content
+            Long senderMemberId, String content
     ) {
         if (clubMeetingAPI.isChatDisabled(meetingId)) {
             throw new RealtimeException(RealtimeErrorStatus.CHAT_DISABLED);

--- a/src/main/java/checkmo/realtime/internal/service/ChatQueryService.java
+++ b/src/main/java/checkmo/realtime/internal/service/ChatQueryService.java
@@ -2,7 +2,6 @@ package checkmo.realtime.internal.service;
 
 import checkmo.common.template.CursorPagingHelper;
 import checkmo.common.template.CursorResult;
-import checkmo.common.template.ExtractHelper;
 import checkmo.member.MemberAPI;
 import checkmo.member.MemberExternalDTO.BasicInfo;
 import checkmo.realtime.internal.entity.TeamChatMessage;
@@ -17,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -41,7 +41,7 @@ public class ChatQueryService {
         List<TeamChatMessage> ascContent = new ArrayList<>(descContent);
         Collections.reverse(ascContent); // 과거 -> 최신으로 reverse
 
-        Map<String, BasicInfo> memberInfoMap = getMemberInfoMap(ascContent);
+        Map<Long, BasicInfo> memberInfoMap = getMemberInfoMap(ascContent);
 
         List<ChatResponseDTO.Chat> chats = ascContent.stream()
                 .map(m -> {
@@ -72,8 +72,21 @@ public class ChatQueryService {
         return teamChatMessageRepository.findByClubIdAndMeetingIdAndTeamIdAndIdLessThanOrderByIdDesc(clubId, meetingId, teamId, cursorId, pageable);
     }
 
-    private Map<String, BasicInfo> getMemberInfoMap(List<TeamChatMessage> teamChatMessages) {
-        List<String> memberIds = ExtractHelper.extractDistinctList(teamChatMessages, TeamChatMessage::getSenderMemberId);
-        return memberAPI.fetchMemberBasicInfoByMemberIds(memberIds);
+    private Map<Long, BasicInfo> getMemberInfoMap(List<TeamChatMessage> teamChatMessages) {
+        List<Long> memberIds = teamChatMessages.stream()
+                .map(TeamChatMessage::getSenderMemberId)
+                .distinct()
+                .toList();
+        return memberAPI.fetchMemberBasicInfoByMemberIds(toMemberApiIds(memberIds)).entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> Long.valueOf(entry.getKey()),
+                        Map.Entry::getValue
+                ));
+    }
+
+    private List<String> toMemberApiIds(List<Long> memberIds) {
+        return memberIds.stream()
+                .map(String::valueOf)
+                .toList();
     }
 }

--- a/src/main/java/checkmo/realtime/internal/service/ChatQueryService.java
+++ b/src/main/java/checkmo/realtime/internal/service/ChatQueryService.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -77,16 +76,6 @@ public class ChatQueryService {
                 .map(TeamChatMessage::getSenderMemberId)
                 .distinct()
                 .toList();
-        return memberAPI.fetchMemberBasicInfoByMemberIds(toMemberApiIds(memberIds)).entrySet().stream()
-                .collect(Collectors.toMap(
-                        entry -> Long.valueOf(entry.getKey()),
-                        Map.Entry::getValue
-                ));
-    }
-
-    private List<String> toMemberApiIds(List<Long> memberIds) {
-        return memberIds.stream()
-                .map(String::valueOf)
-                .toList();
+        return memberAPI.fetchMemberBasicInfoByMemberIds(memberIds);
     }
 }

--- a/src/main/java/checkmo/realtime/web/controller/ChatHistoryController.java
+++ b/src/main/java/checkmo/realtime/web/controller/ChatHistoryController.java
@@ -29,7 +29,7 @@ public class ChatHistoryController {
             @PathVariable Long meetingId,
             @PathVariable Long teamId,
             @RequestParam(required = false) Long cursorId,
-            @CurrentId String memberId
+            @CurrentId Long memberId
     ) {
         authorizationService.authorizeTeamAccess(clubId, meetingId, teamId, memberId);
         return ApiResponse.onSuccess(chatQueryService.fetchHistory(clubId, meetingId, teamId, cursorId));

--- a/src/main/java/checkmo/realtime/web/websocket/controller/ChatController.java
+++ b/src/main/java/checkmo/realtime/web/websocket/controller/ChatController.java
@@ -30,6 +30,6 @@ public class ChatController {
         if (principal == null) {
             throw new RealtimeException(RealtimeErrorStatus.UNAUTHENTICATED);
         }
-        chatCommandService.saveTeamChatMessage(clubId, meetingId, teamId, principal.getName(), payload.getContent());
+        chatCommandService.saveTeamChatMessage(clubId, meetingId, teamId, Long.valueOf(principal.getName()), payload.getContent());
     }
 }

--- a/src/main/java/checkmo/realtime/web/websocket/interceptor/TeamAuthorizationInterceptor.java
+++ b/src/main/java/checkmo/realtime/web/websocket/interceptor/TeamAuthorizationInterceptor.java
@@ -69,7 +69,7 @@ public class TeamAuthorizationInterceptor implements ChannelInterceptor {
 
         DestinationVariables vars = extractVariables(destination);
 
-        authorizationService.authorizeTeamAccess(vars.clubId, vars.meetingId, vars.teamId, auth.getName());
+        authorizationService.authorizeTeamAccess(vars.clubId, vars.meetingId, vars.teamId, Long.valueOf(auth.getName()));
         return message;
     }
 

--- a/src/main/java/checkmo/report/internal/entity/Report.java
+++ b/src/main/java/checkmo/report/internal/entity/Report.java
@@ -16,7 +16,7 @@ public class Report extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String reporterId;
+    private Long reporterId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/checkmo/report/internal/repository/ReportRepositoryCustom.java
+++ b/src/main/java/checkmo/report/internal/repository/ReportRepositoryCustom.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface ReportRepositoryCustom {
 
-    List<Report> findMyReports(String reporterId, Long cursorId, int pageSize);
+    List<Report> findMyReports(Long reporterId, Long cursorId, int pageSize);
 }

--- a/src/main/java/checkmo/report/internal/repository/ReportRepositoryCustomImpl.java
+++ b/src/main/java/checkmo/report/internal/repository/ReportRepositoryCustomImpl.java
@@ -17,7 +17,7 @@ public class ReportRepositoryCustomImpl implements ReportRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Report> findMyReports(String reporterId, Long cursorId, int pageSize) {
+    public List<Report> findMyReports(Long reporterId, Long cursorId, int pageSize) {
         return queryFactory
                 .selectFrom(report)
                 .where(

--- a/src/main/java/checkmo/report/internal/service/command/ReportCommandService.java
+++ b/src/main/java/checkmo/report/internal/service/command/ReportCommandService.java
@@ -77,7 +77,7 @@ public class ReportCommandService {
     }
 
     private String resolveMember(Long reporterId, String memberNickname) {
-        Long reportedMemberId = Long.valueOf(memberAPI.fetchMemberId(memberNickname));
+        Long reportedMemberId = memberAPI.fetchMemberId(memberNickname);
 
         if (reporterId.equals(reportedMemberId)) {
             throw new ReportException(ReportErrorStatus.CANNOT_REPORT_SELF);

--- a/src/main/java/checkmo/report/internal/service/command/ReportCommandService.java
+++ b/src/main/java/checkmo/report/internal/service/command/ReportCommandService.java
@@ -32,7 +32,7 @@ public class ReportCommandService {
 
     private final ReportRepository reportRepository;
 
-    public Long createReport(String reporterId, ReportRequestDTO.Create request) {
+    public Long createReport(Long reporterId, ReportRequestDTO.Create request) {
         String redirectUrl = resolveRedirectUrl(
                 reporterId,
                 request.getTargetType(),
@@ -52,7 +52,7 @@ public class ReportCommandService {
     }
 
     public String resolveRedirectUrl(
-            String reporterId,
+            Long reporterId,
             ReportTargetType targetType,
             String targetId
     ) {
@@ -76,8 +76,8 @@ public class ReportCommandService {
         }
     }
 
-    private String resolveMember(String reporterId, String memberNickname) {
-        String reportedMemberId = memberAPI.fetchMemberId(memberNickname);
+    private String resolveMember(Long reporterId, String memberNickname) {
+        Long reportedMemberId = Long.valueOf(memberAPI.fetchMemberId(memberNickname));
 
         if (reporterId.equals(reportedMemberId)) {
             throw new ReportException(ReportErrorStatus.CANNOT_REPORT_SELF);

--- a/src/main/java/checkmo/report/internal/service/query/ReportQueryService.java
+++ b/src/main/java/checkmo/report/internal/service/query/ReportQueryService.java
@@ -39,7 +39,7 @@ public class ReportQueryService {
     private final ClubMeetingAPI clubMeetingAPI;
     private final RealtimeAPI realtimeAPI;
 
-    public ReportResponseDTO.MyReportList retrieveMyReports(String memberId, Long cursorId) {
+    public ReportResponseDTO.MyReportList retrieveMyReports(Long memberId, Long cursorId) {
         CursorResult<Report> reportCursorResult = CursorPagingHelper.getPage(
                 size -> reportRepository.findMyReports(memberId, cursorId, size),
                 Report::getId,
@@ -73,7 +73,7 @@ public class ReportQueryService {
             String memberNickname,
             Long cursorId
     ) {
-        String reporterId = memberAPI.fetchMemberId(memberNickname);
+        Long reporterId = Long.valueOf(memberAPI.fetchMemberId(memberNickname));
 
         CursorResult<Report> reportCursorResult = CursorPagingHelper.getPage(
                 size -> reportRepository.findMyReports(reporterId, cursorId, size),

--- a/src/main/java/checkmo/report/internal/service/query/ReportQueryService.java
+++ b/src/main/java/checkmo/report/internal/service/query/ReportQueryService.java
@@ -73,7 +73,7 @@ public class ReportQueryService {
             String memberNickname,
             Long cursorId
     ) {
-        Long reporterId = Long.valueOf(memberAPI.fetchMemberId(memberNickname));
+        Long reporterId = memberAPI.fetchMemberId(memberNickname);
 
         CursorResult<Report> reportCursorResult = CursorPagingHelper.getPage(
                 size -> reportRepository.findMyReports(reporterId, cursorId, size),
@@ -269,12 +269,12 @@ public class ReportQueryService {
     }
 
     private DisplayInfo resolveMemberDisplayInfoByNickname(String nickname) {
-        String memberId = memberAPI.fetchMemberId(nickname);
+        Long memberId = memberAPI.fetchMemberId(nickname);
 
         return resolveMemberDisplayInfo(memberId);
     }
 
-    private DisplayInfo resolveMemberDisplayInfo(String memberId) {
+    private DisplayInfo resolveMemberDisplayInfo(Long memberId) {
         var memberInfo = memberAPI.fetchMemberBasicInfo(memberId);
 
         return new DisplayInfo(

--- a/src/main/java/checkmo/report/web/controller/ReportController.java
+++ b/src/main/java/checkmo/report/web/controller/ReportController.java
@@ -22,7 +22,7 @@ public class ReportController {
 
     @PostMapping
     public ApiResponse<Long> createReport(
-            @CurrentId String reporterId,
+            @CurrentId Long reporterId,
             @Valid @RequestBody ReportRequestDTO.Create request
     ) {
         return ApiResponse.onSuccess(reportCommandService.createReport(reporterId, request));
@@ -30,7 +30,7 @@ public class ReportController {
 
     @GetMapping("/me")
     public ApiResponse<ReportResponseDTO.MyReportList> getMyReports(
-            @CurrentId String memberId,
+            @CurrentId Long memberId,
             @RequestParam(required = false) Long cursorId
     ) {
         return ApiResponse.onSuccess(reportQueryService.retrieveMyReports(memberId, cursorId));

--- a/src/main/resources/db/migration/V20260706_2__convert_member_auth_identity_to_bigint.sql
+++ b/src/main/resources/db/migration/V20260706_2__convert_member_auth_identity_to_bigint.sql
@@ -22,11 +22,11 @@ LEFT JOIN auth_user au ON au.id = m.id
 WHERE au.id IS NULL;
 
 INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
-SELECT 'invalid_auth_legacy_id', au.id, 'expected LOCAL, GOOGLE, APPLE, or KAKAO provider prefix, underscore, and provider user id'
+SELECT 'invalid_auth_legacy_id', au.id, 'expected LOCAL, GOOGLE, APPLE, KAKAO, or NAVER provider prefix, underscore, and provider user id'
 FROM auth_user au
 WHERE LOCATE('_', au.id) <= 1
    OR LOCATE('_', au.id) = CHAR_LENGTH(au.id)
-   OR UPPER(SUBSTRING_INDEX(au.id, '_', 1)) NOT IN ('LOCAL', 'GOOGLE', 'APPLE', 'KAKAO');
+   OR UPPER(SUBSTRING_INDEX(au.id, '_', 1)) NOT IN ('LOCAL', 'GOOGLE', 'APPLE', 'KAKAO', 'NAVER');
 
 INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
 SELECT 'duplicate_provider_identity', MIN(parsed.legacy_id),

--- a/src/main/resources/db/migration/V20260706_2__convert_member_auth_identity_to_bigint.sql
+++ b/src/main/resources/db/migration/V20260706_2__convert_member_auth_identity_to_bigint.sql
@@ -110,7 +110,9 @@ INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
 SELECT 'notification.sender_id_orphan', r.sender_id, NULL
 FROM notification r
 LEFT JOIN member m ON m.id = r.sender_id
-WHERE r.sender_id IS NOT NULL AND m.id IS NULL
+WHERE r.sender_id IS NOT NULL
+  AND r.sender_id <> 'SYSTEM'
+  AND m.id IS NULL
 LIMIT 1;
 
 INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
@@ -299,10 +301,17 @@ UPDATE notification r
 JOIN member_identity_map mim ON mim.old_member_identity = r.receiver_id
 SET r.receiver_id = CAST(mim.new_member_id AS CHAR);
 
+ALTER TABLE notification MODIFY COLUMN sender_id VARCHAR(255) NULL;
+
 UPDATE notification r
 JOIN member_identity_map mim ON mim.old_member_identity = r.sender_id
 SET r.sender_id = CAST(mim.new_member_id AS CHAR)
-WHERE r.sender_id IS NOT NULL;
+WHERE r.sender_id IS NOT NULL
+  AND r.sender_id <> 'SYSTEM';
+
+UPDATE notification
+SET sender_id = NULL
+WHERE sender_id = 'SYSTEM';
 
 UPDATE topic r
 JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
@@ -368,7 +377,7 @@ ALTER TABLE comment MODIFY COLUMN member_id BIGINT NULL;
 ALTER TABLE follow MODIFY COLUMN follower_id BIGINT NULL;
 ALTER TABLE follow MODIFY COLUMN following_id BIGINT NULL;
 ALTER TABLE notification MODIFY COLUMN receiver_id BIGINT NOT NULL;
-ALTER TABLE notification MODIFY COLUMN sender_id BIGINT NOT NULL;
+ALTER TABLE notification MODIFY COLUMN sender_id BIGINT NULL;
 ALTER TABLE topic MODIFY COLUMN member_id BIGINT NOT NULL;
 ALTER TABLE notification_setting MODIFY COLUMN member_id BIGINT NOT NULL;
 ALTER TABLE member_terms MODIFY COLUMN member_id BIGINT NOT NULL;

--- a/src/main/resources/db/migration/V20260706_2__convert_member_auth_identity_to_bigint.sql
+++ b/src/main/resources/db/migration/V20260706_2__convert_member_auth_identity_to_bigint.sql
@@ -43,6 +43,17 @@ FROM (
 GROUP BY parsed.provider, parsed.provider_user_id
 HAVING COUNT(*) > 1;
 
+CREATE TEMPORARY TABLE notification_sender_identity_candidates (
+    sender_id VARCHAR(255) NOT NULL,
+    PRIMARY KEY (sender_id)
+) ENGINE=InnoDB;
+
+INSERT INTO notification_sender_identity_candidates (sender_id)
+SELECT DISTINCT sender_id
+FROM notification
+WHERE sender_id IS NOT NULL
+  AND sender_id <> 'SYSTEM';
+
 INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
 SELECT 'member_interest_categories.member_id_orphan', r.member_id, NULL
 FROM member_interest_categories r
@@ -108,11 +119,9 @@ LIMIT 1;
 
 INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
 SELECT 'notification.sender_id_orphan', r.sender_id, NULL
-FROM notification r
+FROM notification_sender_identity_candidates r
 LEFT JOIN member m ON m.id = r.sender_id
-WHERE r.sender_id IS NOT NULL
-  AND r.sender_id <> 'SYSTEM'
-  AND m.id IS NULL
+WHERE m.id IS NULL
 LIMIT 1;
 
 INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
@@ -303,15 +312,14 @@ SET r.receiver_id = CAST(mim.new_member_id AS CHAR);
 
 ALTER TABLE notification MODIFY COLUMN sender_id VARCHAR(255) NULL;
 
-UPDATE notification r
-JOIN member_identity_map mim ON mim.old_member_identity = r.sender_id
-SET r.sender_id = CAST(mim.new_member_id AS CHAR)
-WHERE r.sender_id IS NOT NULL
-  AND r.sender_id <> 'SYSTEM';
-
 UPDATE notification
 SET sender_id = NULL
 WHERE sender_id = 'SYSTEM';
+
+UPDATE notification r
+JOIN member_identity_map mim ON mim.old_member_identity = r.sender_id
+SET r.sender_id = CAST(mim.new_member_id AS CHAR)
+WHERE r.sender_id IS NOT NULL;
 
 UPDATE topic r
 JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
@@ -364,6 +372,7 @@ ALTER TABLE member DROP PRIMARY KEY;
 UPDATE member SET id = CAST(new_id AS CHAR);
 ALTER TABLE member MODIFY COLUMN id BIGINT NOT NULL;
 ALTER TABLE member ADD PRIMARY KEY (id);
+ALTER TABLE member MODIFY COLUMN id BIGINT NOT NULL AUTO_INCREMENT;
 ALTER TABLE member
     MODIFY COLUMN legacy_id VARCHAR(255) NOT NULL,
     DROP COLUMN new_id;

--- a/src/main/resources/db/migration/V20260706__convert_member_auth_identity_to_bigint.sql
+++ b/src/main/resources/db/migration/V20260706__convert_member_auth_identity_to_bigint.sql
@@ -1,0 +1,502 @@
+-- Convert provider-shaped member/auth identities to a shared BIGINT identity.
+-- This migration intentionally keeps member_identity_map for rollback diagnostics:
+-- it records the old member/auth ids and the deterministic numeric id assigned
+-- from the old member.id ordering.
+
+CREATE TEMPORARY TABLE identity_migration_failures (
+    check_name VARCHAR(128) NOT NULL,
+    legacy_id VARCHAR(255),
+    detail VARCHAR(500)
+) ENGINE=InnoDB;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'auth_without_member', au.id, au.email
+FROM auth_user au
+LEFT JOIN member m ON m.id = au.id
+WHERE m.id IS NULL;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'member_without_auth', m.id, m.email
+FROM member m
+LEFT JOIN auth_user au ON au.id = m.id
+WHERE au.id IS NULL;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'invalid_auth_legacy_id', au.id, 'expected LOCAL, GOOGLE, APPLE, or KAKAO provider prefix, underscore, and provider user id'
+FROM auth_user au
+WHERE LOCATE('_', au.id) <= 1
+   OR LOCATE('_', au.id) = CHAR_LENGTH(au.id)
+   OR UPPER(SUBSTRING_INDEX(au.id, '_', 1)) NOT IN ('LOCAL', 'GOOGLE', 'APPLE', 'KAKAO');
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'duplicate_provider_identity', MIN(parsed.legacy_id),
+       CONCAT(parsed.provider, ':', parsed.provider_user_id, ':', COUNT(*))
+FROM (
+    SELECT
+        id AS legacy_id,
+        UPPER(SUBSTRING_INDEX(id, '_', 1)) AS provider,
+        SUBSTRING(id, LOCATE('_', id) + 1) AS provider_user_id
+    FROM auth_user
+    WHERE LOCATE('_', id) > 1
+      AND LOCATE('_', id) < CHAR_LENGTH(id)
+) parsed
+GROUP BY parsed.provider, parsed.provider_user_id
+HAVING COUNT(*) > 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'member_interest_categories.member_id_orphan', r.member_id, NULL
+FROM member_interest_categories r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'book_review.member_id_orphan', r.member_id, NULL
+FROM book_review r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'book_story.member_id_orphan', r.member_id, NULL
+FROM book_story r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'book_story_liked.member_id_orphan', r.member_id, NULL
+FROM book_story_liked r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'club_member.member_id_orphan', r.member_id, NULL
+FROM club_member r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'comment.member_id_orphan', r.member_id, NULL
+FROM comment r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'follow.follower_id_orphan', r.follower_id, NULL
+FROM follow r
+LEFT JOIN member m ON m.id = r.follower_id
+WHERE r.follower_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'follow.following_id_orphan', r.following_id, NULL
+FROM follow r
+LEFT JOIN member m ON m.id = r.following_id
+WHERE r.following_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'notification.receiver_id_orphan', r.receiver_id, NULL
+FROM notification r
+LEFT JOIN member m ON m.id = r.receiver_id
+WHERE r.receiver_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'notification.sender_id_orphan', r.sender_id, NULL
+FROM notification r
+LEFT JOIN member m ON m.id = r.sender_id
+WHERE r.sender_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'topic.member_id_orphan', r.member_id, NULL
+FROM topic r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'notification_setting.member_id_orphan', r.member_id, NULL
+FROM notification_setting r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'member_terms.member_id_orphan', r.member_id, NULL
+FROM member_terms r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'book_liked.member_id_orphan', r.member_id, NULL
+FROM book_liked r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'member_block.blocker_id_orphan', r.blocker_id, NULL
+FROM member_block r
+LEFT JOIN member m ON m.id = r.blocker_id
+WHERE r.blocker_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'member_block.blocked_id_orphan', r.blocked_id, NULL
+FROM member_block r
+LEFT JOIN member m ON m.id = r.blocked_id
+WHERE r.blocked_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'report.reporter_id_orphan', r.reporter_id, NULL
+FROM report r
+LEFT JOIN member m ON m.id = r.reporter_id
+WHERE r.reporter_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'team_chat_message.sender_member_id_orphan', r.sender_member_id, NULL
+FROM team_chat_message r
+LEFT JOIN member m ON m.id = r.sender_member_id
+WHERE r.sender_member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'push_device.member_id_orphan', r.member_id, NULL
+FROM push_device r
+LEFT JOIN member m ON m.id = r.member_id
+WHERE r.member_id IS NOT NULL AND m.id IS NULL
+LIMIT 1;
+
+CREATE TEMPORARY TABLE identity_migration_guard (
+    id INT NOT NULL,
+    check_name VARCHAR(128) NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
+
+INSERT INTO identity_migration_guard (id, check_name)
+VALUES (1, 'no_precondition_failures');
+
+-- If any precondition row exists, this duplicate-key insert aborts Flyway.
+INSERT INTO identity_migration_guard (id, check_name)
+SELECT 1, check_name
+FROM identity_migration_failures
+LIMIT 1;
+
+CREATE TABLE member_identity_map (
+    old_member_identity VARCHAR(255) NOT NULL,
+    old_auth_user_id VARCHAR(255) NOT NULL,
+    new_member_id BIGINT NOT NULL,
+    provider VARCHAR(50) NOT NULL,
+    provider_user_id VARCHAR(255) NOT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (old_member_identity),
+    CONSTRAINT UK_member_identity_map_old_auth_user UNIQUE (old_auth_user_id),
+    CONSTRAINT UK_member_identity_map_new_member UNIQUE (new_member_id),
+    CONSTRAINT UK_member_identity_map_provider_user UNIQUE (provider, provider_user_id)
+) ENGINE=InnoDB;
+
+INSERT INTO member_identity_map (
+    old_member_identity,
+    old_auth_user_id,
+    new_member_id,
+    provider,
+    provider_user_id
+)
+SELECT
+    m.id,
+    au.id,
+    ROW_NUMBER() OVER (ORDER BY m.id),
+    UPPER(SUBSTRING_INDEX(au.id, '_', 1)),
+    SUBSTRING(au.id, LOCATE('_', au.id) + 1)
+FROM member m
+JOIN auth_user au ON au.id = m.id
+ORDER BY m.id;
+
+ALTER TABLE follow DROP FOREIGN KEY FK_follow_follower;
+ALTER TABLE follow DROP FOREIGN KEY FK_follow_following;
+ALTER TABLE member_interest_categories DROP FOREIGN KEY FK_member_interest_categories_member;
+ALTER TABLE member_terms DROP FOREIGN KEY FK_member_terms_member;
+ALTER TABLE member_block DROP FOREIGN KEY FK_member_block_blocker;
+ALTER TABLE member_block DROP FOREIGN KEY FK_member_block_blocked;
+
+ALTER TABLE member_interest_categories DROP PRIMARY KEY;
+ALTER TABLE `book_story_liked` DROP INDEX UK_book_story_liked_member_book_story;
+ALTER TABLE follow DROP INDEX UK_follow_follower_following;
+ALTER TABLE notification_setting DROP INDEX UK_notification_setting_member;
+ALTER TABLE `book_liked` DROP INDEX uk_book_liked_member_book;
+ALTER TABLE member_block DROP INDEX UK_member_block_blocker_blocked;
+ALTER TABLE member_block DROP INDEX IDX_member_block_blocked_id;
+DROP INDEX idx_push_device_member_id ON push_device;
+
+ALTER TABLE auth_user
+    ADD COLUMN legacy_id VARCHAR(255) NULL,
+    ADD COLUMN provider VARCHAR(50) NULL,
+    ADD COLUMN provider_user_id VARCHAR(255) NULL,
+    ADD COLUMN new_id BIGINT NULL;
+
+ALTER TABLE member
+    ADD COLUMN legacy_id VARCHAR(255) NULL,
+    ADD COLUMN new_id BIGINT NULL;
+
+UPDATE auth_user au
+JOIN member_identity_map mim ON mim.old_auth_user_id = au.id
+SET au.legacy_id = au.id,
+    au.provider = mim.provider,
+    au.provider_user_id = mim.provider_user_id,
+    au.new_id = mim.new_member_id;
+
+UPDATE member m
+JOIN member_identity_map mim ON mim.old_member_identity = m.id
+SET m.legacy_id = m.id,
+    m.new_id = mim.new_member_id;
+
+UPDATE member_interest_categories r
+JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
+SET r.member_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE `book_review` r
+JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
+SET r.member_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE `book_story` r
+JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
+SET r.member_id = CAST(mim.new_member_id AS CHAR)
+WHERE r.member_id IS NOT NULL;
+
+UPDATE `book_story_liked` r
+JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
+SET r.member_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE club_member r
+JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
+SET r.member_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE comment r
+JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
+SET r.member_id = CAST(mim.new_member_id AS CHAR)
+WHERE r.member_id IS NOT NULL;
+
+UPDATE follow r
+JOIN member_identity_map mim ON mim.old_member_identity = r.follower_id
+SET r.follower_id = CAST(mim.new_member_id AS CHAR)
+WHERE r.follower_id IS NOT NULL;
+
+UPDATE follow r
+JOIN member_identity_map mim ON mim.old_member_identity = r.following_id
+SET r.following_id = CAST(mim.new_member_id AS CHAR)
+WHERE r.following_id IS NOT NULL;
+
+UPDATE notification r
+JOIN member_identity_map mim ON mim.old_member_identity = r.receiver_id
+SET r.receiver_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE notification r
+JOIN member_identity_map mim ON mim.old_member_identity = r.sender_id
+SET r.sender_id = CAST(mim.new_member_id AS CHAR)
+WHERE r.sender_id IS NOT NULL;
+
+UPDATE topic r
+JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
+SET r.member_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE notification_setting r
+JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
+SET r.member_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE member_terms r
+JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
+SET r.member_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE `book_liked` r
+JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
+SET r.member_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE member_block r
+JOIN member_identity_map mim ON mim.old_member_identity = r.blocker_id
+SET r.blocker_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE member_block r
+JOIN member_identity_map mim ON mim.old_member_identity = r.blocked_id
+SET r.blocked_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE report r
+JOIN member_identity_map mim ON mim.old_member_identity = r.reporter_id
+SET r.reporter_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE team_chat_message r
+JOIN member_identity_map mim ON mim.old_member_identity = r.sender_member_id
+SET r.sender_member_id = CAST(mim.new_member_id AS CHAR);
+
+UPDATE push_device r
+JOIN member_identity_map mim ON mim.old_member_identity = r.member_id
+SET r.member_id = CAST(mim.new_member_id AS CHAR);
+
+ALTER TABLE auth_user DROP PRIMARY KEY;
+UPDATE auth_user SET id = CAST(new_id AS CHAR);
+ALTER TABLE auth_user MODIFY COLUMN id BIGINT NOT NULL;
+ALTER TABLE auth_user ADD PRIMARY KEY (id);
+ALTER TABLE auth_user MODIFY COLUMN id BIGINT NOT NULL AUTO_INCREMENT;
+ALTER TABLE auth_user
+    MODIFY COLUMN legacy_id VARCHAR(255) NOT NULL,
+    MODIFY COLUMN provider VARCHAR(50) NOT NULL,
+    MODIFY COLUMN provider_user_id VARCHAR(255) NOT NULL,
+    DROP COLUMN new_id;
+
+ALTER TABLE member DROP PRIMARY KEY;
+UPDATE member SET id = CAST(new_id AS CHAR);
+ALTER TABLE member MODIFY COLUMN id BIGINT NOT NULL;
+ALTER TABLE member ADD PRIMARY KEY (id);
+ALTER TABLE member
+    MODIFY COLUMN legacy_id VARCHAR(255) NOT NULL,
+    DROP COLUMN new_id;
+
+ALTER TABLE member_interest_categories MODIFY COLUMN member_id BIGINT NOT NULL;
+ALTER TABLE `book_review` MODIFY COLUMN member_id BIGINT NOT NULL;
+ALTER TABLE `book_story` MODIFY COLUMN member_id BIGINT NULL;
+ALTER TABLE `book_story_liked` MODIFY COLUMN member_id BIGINT NOT NULL;
+ALTER TABLE club_member MODIFY COLUMN member_id BIGINT NOT NULL;
+ALTER TABLE comment MODIFY COLUMN member_id BIGINT NULL;
+ALTER TABLE follow MODIFY COLUMN follower_id BIGINT NULL;
+ALTER TABLE follow MODIFY COLUMN following_id BIGINT NULL;
+ALTER TABLE notification MODIFY COLUMN receiver_id BIGINT NOT NULL;
+ALTER TABLE notification MODIFY COLUMN sender_id BIGINT NOT NULL;
+ALTER TABLE topic MODIFY COLUMN member_id BIGINT NOT NULL;
+ALTER TABLE notification_setting MODIFY COLUMN member_id BIGINT NOT NULL;
+ALTER TABLE member_terms MODIFY COLUMN member_id BIGINT NOT NULL;
+ALTER TABLE `book_liked` MODIFY COLUMN member_id BIGINT NOT NULL;
+ALTER TABLE member_block MODIFY COLUMN blocker_id BIGINT NOT NULL;
+ALTER TABLE member_block MODIFY COLUMN blocked_id BIGINT NOT NULL;
+ALTER TABLE report MODIFY COLUMN reporter_id BIGINT NOT NULL;
+ALTER TABLE team_chat_message MODIFY COLUMN sender_member_id BIGINT NOT NULL;
+ALTER TABLE push_device MODIFY COLUMN member_id BIGINT NOT NULL;
+
+ALTER TABLE auth_user
+    ADD CONSTRAINT UK_auth_user_legacy_id UNIQUE (legacy_id),
+    ADD CONSTRAINT UK_auth_user_provider_user UNIQUE (provider, provider_user_id);
+
+ALTER TABLE member
+    ADD CONSTRAINT UK_member_legacy_id UNIQUE (legacy_id);
+
+ALTER TABLE member_interest_categories
+    ADD PRIMARY KEY (member_id, category);
+
+ALTER TABLE `book_story_liked`
+    ADD CONSTRAINT UK_book_story_liked_member_book_story UNIQUE (member_id, book_story_id);
+
+ALTER TABLE follow
+    ADD CONSTRAINT UK_follow_follower_following UNIQUE (follower_id, following_id);
+
+ALTER TABLE notification_setting
+    ADD CONSTRAINT UK_notification_setting_member UNIQUE (member_id);
+
+ALTER TABLE `book_liked`
+    ADD CONSTRAINT uk_book_liked_member_book UNIQUE (member_id, book_id);
+
+ALTER TABLE member_block
+    ADD CONSTRAINT UK_member_block_blocker_blocked UNIQUE (blocker_id, blocked_id),
+    ADD INDEX IDX_member_block_blocked_id (blocked_id);
+
+CREATE INDEX idx_push_device_member_id ON push_device (member_id);
+
+ALTER TABLE member_interest_categories
+    ADD CONSTRAINT FK_member_interest_categories_member
+        FOREIGN KEY (member_id) REFERENCES member (id);
+
+ALTER TABLE `book_review`
+    ADD CONSTRAINT FK_book_review_member
+        FOREIGN KEY (member_id) REFERENCES member (id);
+
+ALTER TABLE `book_story`
+    ADD CONSTRAINT FK_book_story_member
+        FOREIGN KEY (member_id) REFERENCES member (id);
+
+ALTER TABLE `book_story_liked`
+    ADD CONSTRAINT FK_book_story_liked_member
+        FOREIGN KEY (member_id) REFERENCES member (id);
+
+ALTER TABLE club_member
+    ADD CONSTRAINT FK_club_member_member
+        FOREIGN KEY (member_id) REFERENCES member (id);
+
+ALTER TABLE comment
+    ADD CONSTRAINT FK_comment_member
+        FOREIGN KEY (member_id) REFERENCES member (id);
+
+ALTER TABLE follow
+    ADD CONSTRAINT FK_follow_follower
+        FOREIGN KEY (follower_id) REFERENCES member (id),
+    ADD CONSTRAINT FK_follow_following
+        FOREIGN KEY (following_id) REFERENCES member (id);
+
+ALTER TABLE notification
+    ADD CONSTRAINT FK_notification_receiver
+        FOREIGN KEY (receiver_id) REFERENCES member (id),
+    ADD CONSTRAINT FK_notification_sender
+        FOREIGN KEY (sender_id) REFERENCES member (id);
+
+ALTER TABLE topic
+    ADD CONSTRAINT FK_topic_member
+        FOREIGN KEY (member_id) REFERENCES member (id);
+
+ALTER TABLE notification_setting
+    ADD CONSTRAINT FK_notification_setting_member
+        FOREIGN KEY (member_id) REFERENCES member (id);
+
+ALTER TABLE member_terms
+    ADD CONSTRAINT FK_member_terms_member
+        FOREIGN KEY (member_id) REFERENCES member (id)
+            ON DELETE CASCADE;
+
+ALTER TABLE `book_liked`
+    ADD CONSTRAINT FK_book_liked_member
+        FOREIGN KEY (member_id) REFERENCES member (id);
+
+ALTER TABLE member_block
+    ADD CONSTRAINT FK_member_block_blocker
+        FOREIGN KEY (blocker_id) REFERENCES member (id),
+    ADD CONSTRAINT FK_member_block_blocked
+        FOREIGN KEY (blocked_id) REFERENCES member (id);
+
+ALTER TABLE report
+    ADD CONSTRAINT FK_report_reporter
+        FOREIGN KEY (reporter_id) REFERENCES member (id);
+
+ALTER TABLE team_chat_message
+    ADD CONSTRAINT FK_team_chat_message_sender_member
+        FOREIGN KEY (sender_member_id) REFERENCES member (id);
+
+ALTER TABLE push_device
+    ADD CONSTRAINT FK_push_device_member
+        FOREIGN KEY (member_id) REFERENCES member (id);
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'post_auth_member_id_mismatch', CAST(au.id AS CHAR), CAST(m.id AS CHAR)
+FROM auth_user au
+LEFT JOIN member m ON m.id = au.id
+WHERE m.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_failures (check_name, legacy_id, detail)
+SELECT 'post_member_auth_id_mismatch', CAST(m.id AS CHAR), CAST(au.id AS CHAR)
+FROM member m
+LEFT JOIN auth_user au ON au.id = m.id
+WHERE au.id IS NULL
+LIMIT 1;
+
+INSERT INTO identity_migration_guard (id, check_name)
+SELECT 1, check_name
+FROM identity_migration_failures
+WHERE check_name LIKE 'post_%'
+LIMIT 1;
+
+DROP TABLE identity_migration_guard;
+DROP TABLE identity_migration_failures;

--- a/src/main/resources/db/seed/local/V20260706_1__normalize_local_seed_member_identity.sql
+++ b/src/main/resources/db/seed/local/V20260706_1__normalize_local_seed_member_identity.sql
@@ -1,0 +1,88 @@
+SET @old_foreign_key_checks := @@FOREIGN_KEY_CHECKS;
+SET FOREIGN_KEY_CHECKS = 0;
+
+UPDATE auth_user
+SET id = CONCAT('LOCAL_', id)
+WHERE id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE member
+SET id = CONCAT('LOCAL_', id)
+WHERE id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE member_interest_categories
+SET member_id = CONCAT('LOCAL_', member_id)
+WHERE member_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE book_review
+SET member_id = CONCAT('LOCAL_', member_id)
+WHERE member_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE book_story
+SET member_id = CONCAT('LOCAL_', member_id)
+WHERE member_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE book_story_liked
+SET member_id = CONCAT('LOCAL_', member_id)
+WHERE member_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE club_member
+SET member_id = CONCAT('LOCAL_', member_id)
+WHERE member_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE comment
+SET member_id = CONCAT('LOCAL_', member_id)
+WHERE member_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE follow
+SET follower_id = CONCAT('LOCAL_', follower_id)
+WHERE follower_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE follow
+SET following_id = CONCAT('LOCAL_', following_id)
+WHERE following_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE notification
+SET receiver_id = CONCAT('LOCAL_', receiver_id)
+WHERE receiver_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE notification
+SET sender_id = CONCAT('LOCAL_', sender_id)
+WHERE sender_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE topic
+SET member_id = CONCAT('LOCAL_', member_id)
+WHERE member_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE notification_setting
+SET member_id = CONCAT('LOCAL_', member_id)
+WHERE member_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE member_terms
+SET member_id = CONCAT('LOCAL_', member_id)
+WHERE member_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE book_liked
+SET member_id = CONCAT('LOCAL_', member_id)
+WHERE member_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE member_block
+SET blocker_id = CONCAT('LOCAL_', blocker_id)
+WHERE blocker_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE member_block
+SET blocked_id = CONCAT('LOCAL_', blocked_id)
+WHERE blocked_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE report
+SET reporter_id = CONCAT('LOCAL_', reporter_id)
+WHERE reporter_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE team_chat_message
+SET sender_member_id = CONCAT('LOCAL_', sender_member_id)
+WHERE sender_member_id REGEXP '^mem-[0-9]{3}$';
+
+UPDATE push_device
+SET member_id = CONCAT('LOCAL_', member_id)
+WHERE member_id REGEXP '^mem-[0-9]{3}$';
+
+SET FOREIGN_KEY_CHECKS = @old_foreign_key_checks;

--- a/src/test/java/checkmo/admin/AdminApiTest.java
+++ b/src/test/java/checkmo/admin/AdminApiTest.java
@@ -78,6 +78,13 @@ class AdminApiTest extends ApiTestSupport {
                 .body("result.memberList.size()", greaterThanOrEqualTo(1));
 
         given().cookie(accessTokenCookie(admin))
+                .queryParam("keyword", user.id())
+                .when().get("/api/v1/admin/members")
+                .then().statusCode(200)
+                .body("result.memberList.size()", equalTo(1))
+                .body("result.memberList[0].memberId", equalTo(user.memberId().intValue()));
+
+        given().cookie(accessTokenCookie(admin))
                 .when().get("/api/v1/admin/members/{memberNickName}", user.nickName())
                 .then().statusCode(200)
                 .body("result.email", equalTo(user.email()));

--- a/src/test/java/checkmo/admin/AdminApiTest.java
+++ b/src/test/java/checkmo/admin/AdminApiTest.java
@@ -186,7 +186,7 @@ class AdminApiTest extends ApiTestSupport {
         TestUser admin = createAdmin();
         TestUser owner = createUser();
         TestUser nonAdmin = createUser();
-        Club club = createClub(owner, "admin-club-" + owner.id().substring(owner.id().length() - 4).toLowerCase());
+        Club club = createClub(owner, "admin-club-" + owner.legacyId().substring(owner.legacyId().length() - 4).toLowerCase());
 
         given().cookie(accessTokenCookie(admin))
                 .queryParam("keyword", "admin-club")

--- a/src/test/java/checkmo/admin/AdminApiTest.java
+++ b/src/test/java/checkmo/admin/AdminApiTest.java
@@ -299,14 +299,14 @@ class AdminApiTest extends ApiTestSupport {
         TestUser author = createUser();
         TestUser nonAdmin = createUser();
         BookStory story = bookStoryRepository.save(BookStory.builder()
-                .memberId(author.id())
+                .memberId(Long.valueOf(author.id()))
                 .bookId(ISBN)
                 .title("관리자 책 이야기")
                 .description("관리자 테스트용 책 이야기입니다.")
                 .status(BookStoryStatus.PUBLISHED)
                 .build());
         Comment comment = commentRepository.save(Comment.builder()
-                .memberId(author.id())
+                .memberId(Long.valueOf(author.id()))
                 .bookStory(story)
                 .content("관리자 삭제 대상 댓글")
                 .build());

--- a/src/test/java/checkmo/admin/AdminApiTest.java
+++ b/src/test/java/checkmo/admin/AdminApiTest.java
@@ -365,7 +365,7 @@ class AdminApiTest extends ApiTestSupport {
                         .build())))
                 .build();
         Club saved = clubRepository.save(club);
-        ClubMember clubOwner = saved.createOwnerMember(owner.id(), LocalDateTime.now());
+        ClubMember clubOwner = saved.createOwnerMember(Long.valueOf(owner.id()), LocalDateTime.now());
         clubMemberRepository.save(clubOwner);
         return saved;
     }

--- a/src/test/java/checkmo/admin/AdminApiTest.java
+++ b/src/test/java/checkmo/admin/AdminApiTest.java
@@ -104,7 +104,7 @@ class AdminApiTest extends ApiTestSupport {
 
         for (int index = 0; index < 21; index++) {
             reportRepository.save(Report.builder()
-                    .reporterId(reporter.id())
+                    .reporterId(Long.valueOf(reporter.id()))
                     .reportTargetType(ReportTargetType.MEMBER)
                     .targetId(target.nickName())
                     .reportReason(ReportReason.GENERAL)
@@ -113,7 +113,7 @@ class AdminApiTest extends ApiTestSupport {
                     .build());
         }
         reportRepository.save(Report.builder()
-                .reporterId(otherReporter.id())
+                .reporterId(Long.valueOf(otherReporter.id()))
                 .reportTargetType(ReportTargetType.MEMBER)
                 .targetId(target.nickName())
                 .reportReason(ReportReason.SPAM)
@@ -161,7 +161,7 @@ class AdminApiTest extends ApiTestSupport {
         TestUser reporter = createUser();
 
         reportRepository.save(Report.builder()
-                .reporterId(reporter.id())
+                .reporterId(Long.valueOf(reporter.id()))
                 .reportTargetType(ReportTargetType.BOOK_STORY)
                 .targetId("999999")
                 .reportReason(ReportReason.INSULT)

--- a/src/test/java/checkmo/authentication/AppleAppLoginApiTest.java
+++ b/src/test/java/checkmo/authentication/AppleAppLoginApiTest.java
@@ -44,7 +44,7 @@ class AppleAppLoginApiTest extends ApiTestSupport {
             softly.assertThat(refreshToken).isNotBlank();
             softly.assertThat(response.cookie("refreshToken")).isEqualTo(refreshToken);
             softly.assertThat(response.cookie("accessToken")).isNotBlank();
-            softly.assertThat(authRepository.findById("APPLE_apple-sub")).isPresent();
+            softly.assertThat(authRepository.findByProviderAndProviderUserId("APPLE", "apple-sub")).isPresent();
         });
     }
 
@@ -73,7 +73,7 @@ class AppleAppLoginApiTest extends ApiTestSupport {
 
         assertSoftly(softly -> {
             softly.assertThat(response.jsonPath().getString("result.refreshToken")).isNotBlank();
-            softly.assertThat(authRepository.findById("APPLE_repeat-sub")).isPresent();
+            softly.assertThat(authRepository.findByProviderAndProviderUserId("APPLE", "repeat-sub")).isPresent();
             softly.assertThat(authRepository.findByEmail("repeat-apple-user@example.com")).isPresent();
         });
     }
@@ -94,7 +94,7 @@ class AppleAppLoginApiTest extends ApiTestSupport {
                 .body("isSuccess", equalTo(false))
                 .body("code", equalTo("AUTH_414"));
 
-        assertThat(authRepository.findById("APPLE_new-apple-sub")).isEmpty();
+        assertThat(authRepository.findByProviderAndProviderUserId("APPLE", "new-apple-sub")).isEmpty();
     }
 
     @Test

--- a/src/test/java/checkmo/authentication/AuthApiTest.java
+++ b/src/test/java/checkmo/authentication/AuthApiTest.java
@@ -456,6 +456,42 @@ class AuthApiTest extends ApiTestSupport {
     }
 
     @Test
+    void protectedRouteRejectsLegacyStringSubjectAccessTokenWithoutServerError() {
+        TestUser user = createUserWithPassword("Pass123!");
+        String legacyAccessToken = signedAccessTokenWithSubject(user.legacyId());
+
+        ExtractableResponse<Response> response = given()
+                .cookie(new Cookie.Builder("accessToken", legacyAccessToken)
+                        .setPath("/")
+                        .build())
+                .when()
+                .get("/api/v1/members/me")
+                .then()
+                .extract();
+
+        assertThat(response.statusCode()).isIn(401, 403);
+        assertThat(response.headers().getValues("Set-Cookie"))
+                .anyMatch(header -> header.startsWith("accessToken=") && header.contains("Max-Age=0"))
+                .anyMatch(header -> header.startsWith("refreshToken=") && header.contains("Max-Age=0"));
+    }
+
+    @Test
+    void appRefreshRejectsLegacyStringSubjectRefreshTokenWithoutServerError() {
+        TestUser user = createUserWithPassword("Pass123!");
+        String legacyRefreshToken = signedRefreshTokenWithSubject(user.legacyId());
+        saveRefreshTokenInCacheFake(user.legacyId(), legacyRefreshToken);
+
+        given()
+                .header("X-Refresh-Token", legacyRefreshToken)
+                .when()
+                .post("/api/v1/auth/app/refresh")
+                .then()
+                .statusCode(401)
+                .body("isSuccess", equalTo(false))
+                .body("code", equalTo("AUTH_412"));
+    }
+
+    @Test
     void loginRejectsWrongPassword() {
         TestUser user = createUserWithPassword("Pass123!");
 

--- a/src/test/java/checkmo/authentication/AuthSignupTermsApiTest.java
+++ b/src/test/java/checkmo/authentication/AuthSignupTermsApiTest.java
@@ -54,7 +54,7 @@ class AuthSignupTermsApiTest extends ApiTestSupport {
                 .then()
                 .statusCode(200);
 
-        String memberId = authRepository.findByEmail(email).orElseThrow().getId();
+        Long memberId = authRepository.findByEmail(email).orElseThrow().getId();
         Map<Long, MemberTerms> latestTerms = memberTermsRepository.findLatestByMemberIdAndTermsIdIn(
                         memberId,
                         List.of(service.getId(), privacy.getId(), marketing.getId())

--- a/src/test/java/checkmo/authentication/AuthSignupTermsStrictApiTest.java
+++ b/src/test/java/checkmo/authentication/AuthSignupTermsStrictApiTest.java
@@ -76,7 +76,7 @@ class AuthSignupTermsStrictApiTest extends ApiTestSupport {
                 .statusCode(200)
                 .body("result.email", equalTo(email));
 
-        String memberId = authRepository.findByEmail(email).orElseThrow().getId();
+        Long memberId = authRepository.findByEmail(email).orElseThrow().getId();
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(memberRepository.existsById(memberId)).isTrue();
             softly.assertThat(memberTermsRepository.countByMember_IdAndTerms_Id(memberId, service.getId())).isOne();

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2UserServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOAuth2UserServiceTest.java
@@ -55,7 +55,7 @@ class AppleOAuth2UserServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(attributes.getProviderId()).isEqualTo("apple-sub");
             softly.assertThat(attributes.getEmail()).isEqualTo("apple-user@example.com");
-            softly.assertThat(principalDetails.getUsername()).isEqualTo("APPLE_apple-sub");
+            softly.assertThat(principalDetails.getUsername()).isEqualTo("1");
             softly.assertThat(principalDetails.isNewSocialSignUp()).isTrue();
             softly.assertThat(principalDetails.getAttributes())
                     .containsEntry("sub", "apple-sub")
@@ -111,9 +111,12 @@ class AppleOAuth2UserServiceTest {
 
     private AuthUser user(String id, String email) {
         return AuthUser.builder()
-                .id(id)
+                .id(1L)
+                .legacyId(id)
                 .email(email)
                 .password("")
+                .provider("APPLE")
+                .providerUserId(id.substring(id.indexOf("_") + 1))
                 .role(Role.USER)
                 .profileCompleted(false)
                 .build();

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOidcUserServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/AppleOidcUserServiceTest.java
@@ -38,7 +38,7 @@ class AppleOidcUserServiceTest {
 
         assertSoftly(softly -> {
             softly.assertThat(oidcUser).isInstanceOf(PrincipalDetails.class);
-            softly.assertThat(((PrincipalDetails) oidcUser).getUser().getId()).isEqualTo("APPLE_apple-sub");
+            softly.assertThat(((PrincipalDetails) oidcUser).getUser().getId()).isEqualTo(1L);
             softly.assertThat(((PrincipalDetails) oidcUser).isNewSocialSignUp()).isTrue();
             softly.assertThat(oidcUser.getIdToken()).isSameAs(userRequest.getIdToken());
             softly.assertThat(oidcUser.getClaims()).containsEntry("sub", "apple-sub");
@@ -85,9 +85,12 @@ class AppleOidcUserServiceTest {
 
     private AuthUser user() {
         return AuthUser.builder()
-                .id("APPLE_apple-sub")
+                .id(1L)
+                .legacyId("APPLE_apple-sub")
                 .email("apple-user@example.com")
                 .password("")
+                .provider("APPLE")
+                .providerUserId("apple-sub")
                 .role(Role.USER)
                 .profileCompleted(false)
                 .build();

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
@@ -52,9 +52,12 @@ class OAuth2AuthenticationSuccessHandlerTest {
         );
         ReflectionTestUtils.setField(handler, "baseUri", "https://web.checkmo.test");
         AuthUser user = AuthUser.builder()
-                .id("GOOGLE_google-sub")
+                .id(1L)
+                .legacyId("GOOGLE_google-sub")
                 .email("social-user@example.com")
                 .password("")
+                .provider("GOOGLE")
+                .providerUserId("google-sub")
                 .role(Role.USER)
                 .profileCompleted(true)
                 .build();
@@ -84,8 +87,8 @@ class OAuth2AuthenticationSuccessHandlerTest {
                             && header.contains("Secure")
                             && header.contains("SameSite=None"));
         });
-        verify(authReactivationCommandService).reactivateIfDeactivated("GOOGLE_google-sub");
-        verify(tokenCacheService).saveRefreshToken("GOOGLE_google-sub", "refresh-token");
+        verify(authReactivationCommandService).reactivateIfDeactivated(1L);
+        verify(tokenCacheService).saveRefreshToken(1L, "refresh-token");
     }
 
     @Test
@@ -97,9 +100,12 @@ class OAuth2AuthenticationSuccessHandlerTest {
         ReflectionTestUtils.setField(handler, "baseUri", "https://web.checkmo.test");
         ReflectionTestUtils.setField(handler, "appUri", "checkmo://oauth-callback");
         AuthUser user = AuthUser.builder()
-                .id("APPLE_apple-sub")
+                .id(2L)
+                .legacyId("APPLE_apple-sub")
                 .email("apple-user@example.com")
                 .password("")
+                .provider("APPLE")
+                .providerUserId("apple-sub")
                 .role(Role.USER)
                 .profileCompleted(false)
                 .build();
@@ -134,7 +140,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
                     AppleOAuth2AuthorizationRequestResolver.sessionClientTypeKey("app-state"))).isNull();
             softly.assertThat(codeCaptor.getValue()).isNotBlank();
         });
-        verify(authReactivationCommandService).reactivateIfDeactivated("APPLE_apple-sub");
-        verify(tokenCacheService).saveRefreshToken("APPLE_apple-sub", "refresh-token");
+        verify(authReactivationCommandService).reactivateIfDeactivated(2L);
+        verify(tokenCacheService).saveRefreshToken(2L, "refresh-token");
     }
 }

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreatorIntegrationTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreatorIntegrationTest.java
@@ -65,11 +65,11 @@ class SocialAccountCreatorIntegrationTest {
         ));
 
         AuthUser createdUser = socialAccountCreator.create(attributes, "apple");
-        AuthUser savedUser = authRepository.findById("APPLE_apple-sub").orElseThrow();
+        AuthUser savedUser = authRepository.findByProviderAndProviderUserId("APPLE", "apple-sub").orElseThrow();
 
         assertSoftly(softly -> {
-            softly.assertThat(createdUser.getId()).isEqualTo("APPLE_apple-sub");
-            softly.assertThat(savedUser.getId()).isEqualTo("APPLE_apple-sub");
+            softly.assertThat(createdUser.getLegacyId()).isEqualTo("APPLE_apple-sub");
+            softly.assertThat(savedUser.getLegacyId()).isEqualTo("APPLE_apple-sub");
             softly.assertThat(savedUser.getEmail()).isEqualTo("apple-user@example.com");
             softly.assertThat(savedUser.isProfileCompleted()).isFalse();
         });
@@ -86,7 +86,7 @@ class SocialAccountCreatorIntegrationTest {
         assertThatThrownBy(() -> socialAccountCreator.create(attributes, "apple"))
                 .isInstanceOf(PersistenceException.class);
 
-        AuthUser savedUser = authRepository.findById("APPLE_apple-sub").orElseThrow();
+        AuthUser savedUser = authRepository.findByProviderAndProviderUserId("APPLE", "apple-sub").orElseThrow();
         assertSoftly(softly -> {
             softly.assertThat(savedUser.getEmail()).isEqualTo("existing@example.com");
             softly.assertThat(authRepository.findByEmail("new@example.com")).isEmpty();
@@ -94,10 +94,14 @@ class SocialAccountCreatorIntegrationTest {
     }
 
     private AuthUser user(String id, String email) {
+        String provider = id.substring(0, id.indexOf("_"));
+        String providerUserId = id.substring(id.indexOf("_") + 1);
         return AuthUser.builder()
-                .id(id)
+                .legacyId(id)
                 .email(email)
                 .password("")
+                .provider(provider)
+                .providerUserId(providerUserId)
                 .role(Role.USER)
                 .profileCompleted(false)
                 .build();

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolverTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolverTest.java
@@ -34,7 +34,7 @@ class SocialAccountResolverTest {
     void createsIncompleteAppleUserWhenFirstLoginHasEmail() {
         OAuth2Attributes attributes = appleAttributes("apple-sub", "apple-user@example.com");
 
-        when(authRepository.findById("APPLE_apple-sub")).thenReturn(Optional.empty());
+        when(authRepository.findByProviderAndProviderUserId("APPLE", "apple-sub")).thenReturn(Optional.empty());
         when(authRepository.findByEmail("apple-user@example.com")).thenReturn(Optional.empty());
         when(socialAccountCreator.create(attributes, "apple"))
                 .thenReturn(user("APPLE_apple-sub", "apple-user@example.com"));
@@ -43,7 +43,7 @@ class SocialAccountResolverTest {
 
         assertSoftly(softly -> {
             softly.assertThat(result.newSocialSignUp()).isTrue();
-            softly.assertThat(result.user().getId()).isEqualTo("APPLE_apple-sub");
+            softly.assertThat(result.user().getLegacyId()).isEqualTo("APPLE_apple-sub");
             softly.assertThat(result.user().getEmail()).isEqualTo("apple-user@example.com");
             softly.assertThat(result.user().isProfileCompleted()).isFalse();
         });
@@ -55,7 +55,7 @@ class SocialAccountResolverTest {
         AuthUser existingUser = user("APPLE_apple-sub", "apple-user@example.com");
         OAuth2Attributes attributes = appleAttributesWithoutEmail("apple-sub");
 
-        when(authRepository.findById("APPLE_apple-sub")).thenReturn(Optional.of(existingUser));
+        when(authRepository.findByProviderAndProviderUserId("APPLE", "apple-sub")).thenReturn(Optional.of(existingUser));
 
         SocialAccountResolution result = resolver.resolve(attributes, "apple");
 
@@ -71,7 +71,7 @@ class SocialAccountResolverTest {
     void rejectsAppleEmailCollisionWithControlledConflict() {
         OAuth2Attributes attributes = appleAttributes("apple-sub", "shared@example.com");
 
-        when(authRepository.findById("APPLE_apple-sub")).thenReturn(Optional.empty());
+        when(authRepository.findByProviderAndProviderUserId("APPLE", "apple-sub")).thenReturn(Optional.empty());
         when(authRepository.findByEmail("shared@example.com"))
                 .thenReturn(Optional.of(user("LOCAL_local-user", "shared@example.com")));
 
@@ -85,7 +85,7 @@ class SocialAccountResolverTest {
     void rejectsNewAppleLoginWithoutEmail() {
         OAuth2Attributes attributes = appleAttributesWithoutEmail("apple-sub");
 
-        when(authRepository.findById("APPLE_apple-sub")).thenReturn(Optional.empty());
+        when(authRepository.findByProviderAndProviderUserId("APPLE", "apple-sub")).thenReturn(Optional.empty());
 
         Throwable thrown = catchThrowable(() -> resolver.resolve(attributes, "apple"));
 
@@ -98,7 +98,7 @@ class SocialAccountResolverTest {
         AuthUser existingUser = user("APPLE_apple-sub", "apple-user@example.com");
         OAuth2Attributes attributes = appleAttributes("apple-sub", "apple-user@example.com");
 
-        when(authRepository.findById("APPLE_apple-sub"))
+        when(authRepository.findByProviderAndProviderUserId("APPLE", "apple-sub"))
                 .thenReturn(Optional.empty(), Optional.of(existingUser));
         when(authRepository.findByEmail("apple-user@example.com")).thenReturn(Optional.empty());
         when(socialAccountCreator.create(attributes, "apple"))
@@ -129,7 +129,7 @@ class SocialAccountResolverTest {
             softly.assertThat(result.user()).isSameAs(existingUser);
             softly.assertThat(result.newSocialSignUp()).isFalse();
         });
-        verify(authRepository, never()).findById(newProviderMemberId);
+        verify(authRepository, never()).findByProviderAndProviderUserId(any(), any());
         verify(socialAccountCreator, never()).create(attributes, registrationId);
     }
 
@@ -145,10 +145,15 @@ class SocialAccountResolverTest {
     }
 
     private AuthUser user(String id, String email) {
+        String provider = id.substring(0, id.indexOf("_"));
+        String providerUserId = id.substring(id.indexOf("_") + 1);
         return AuthUser.builder()
-                .id(id)
+                .id(1L)
+                .legacyId(id)
                 .email(email)
                 .password("")
+                .provider(provider)
+                .providerUserId(providerUserId)
                 .role(Role.USER)
                 .profileCompleted(false)
                 .build();

--- a/src/test/java/checkmo/book/BookRecommendationApiTest.java
+++ b/src/test/java/checkmo/book/BookRecommendationApiTest.java
@@ -37,7 +37,7 @@ class BookRecommendationApiTest extends ApiTestSupport {
         when(redisValueOperations.get(REDIS_UPDATED_AT_KEY)).thenReturn(LocalDate.now().minusDays(1).toString());
         when(recommendationRefreshClient.retrieveRecommendedBooks())
                 .thenThrow(new RuntimeException("aladin unavailable"));
-        when(aladinApiService.applyLikedByMe(staleCache, user.id())).thenReturn(staleCache);
+        when(aladinApiService.applyLikedByMe(staleCache, Long.valueOf(user.id()))).thenReturn(staleCache);
 
         given()
                 .cookie(accessTokenCookie(user))
@@ -77,7 +77,7 @@ class BookRecommendationApiTest extends ApiTestSupport {
 
         when(redisValueOperations.get(REDIS_KEY)).thenReturn(freshCache);
         when(redisValueOperations.get(REDIS_UPDATED_AT_KEY)).thenReturn(LocalDate.now().toString());
-        when(aladinApiService.applyLikedByMe(freshCache, user.id())).thenReturn(freshCache);
+        when(aladinApiService.applyLikedByMe(freshCache, Long.valueOf(user.id()))).thenReturn(freshCache);
 
         given()
                 .cookie(accessTokenCookie(user))

--- a/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
+++ b/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
@@ -508,13 +508,13 @@ class BookStoryNewsReportNotificationImageApiTest extends ApiTestSupport {
         TestUser receiver = createUser();
         TestUser sender = createUser();
         notificationSettingRepository.save(NotificationSetting.builder()
-                .memberId(receiver.id())
+                .memberId(Long.valueOf(receiver.id()))
                 .build());
         Notification notification = notificationRepository.save(Notification.builder()
                 .notificationType(NotificationType.FOLLOW)
                 .sourceId(100L)
-                .receiverId(receiver.id())
-                .senderId(sender.id())
+                .receiverId(Long.valueOf(receiver.id()))
+                .senderId(Long.valueOf(sender.id()))
                 .build());
 
         given().cookie(accessTokenCookie(receiver))

--- a/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
+++ b/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
@@ -163,8 +163,9 @@ class BookStoryNewsReportNotificationImageApiTest extends ApiTestSupport {
         TestUser author = createUser();
         TestUser other = createUser();
         Long clubId = 77L;
-        when(clubManagementAPI.validateAndFetchActiveClubMemberId(eq(clubId), eq(author.id()))).thenReturn(1L);
-        when(clubManagementAPI.fetchActiveMemberIds(clubId)).thenReturn(List.of(author.id()));
+        Long authorId = Long.valueOf(author.id());
+        when(clubManagementAPI.validateAndFetchActiveClubMemberId(eq(clubId), eq(authorId))).thenReturn(1L);
+        when(clubManagementAPI.fetchActiveMemberIds(clubId)).thenReturn(List.of(authorId));
 
         Number storyIdNumber = given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
+++ b/src/test/java/checkmo/book/BookStoryNewsReportNotificationImageApiTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -75,7 +75,7 @@ class BookStoryNewsReportNotificationImageApiTest extends ApiTestSupport {
                 .totalResults(123)
                 .build();
 
-        when(aladinApiService.retrieveSearchBooks(eq("자바"), eq(1), anyString())).thenReturn(oneBookList);
+        when(aladinApiService.retrieveSearchBooks(eq("자바"), eq(1), anyLong())).thenReturn(oneBookList);
         when(aladinApiService.retrieveBookDetailInfo(ISBN)).thenReturn(detail);
         when(aladinApiService.retrieveRecommendedBooks()).thenReturn(BookResponseDTO.BookList.builder()
                 .detailInfoList(IntStream.rangeClosed(1, 28)

--- a/src/test/java/checkmo/book/internal/service/BookRecommendationServiceTest.java
+++ b/src/test/java/checkmo/book/internal/service/BookRecommendationServiceTest.java
@@ -41,7 +41,7 @@ import org.springframework.web.client.RestClientException;
 
 class BookRecommendationServiceTest {
 
-    private static final String MEMBER_ID = "member-1";
+    private static final Long MEMBER_ID = 1L;
     private static final String REDIS_KEY = "book:recommendations:daily";
     private static final String REDIS_UPDATED_AT_KEY = "book:recommendations:daily:updated_at";
     private static final String SECRET_TTB_KEY = "SECRET_TTB_KEY";

--- a/src/test/java/checkmo/book/internal/service/query/AladinApiServiceTest.java
+++ b/src/test/java/checkmo/book/internal/service/query/AladinApiServiceTest.java
@@ -57,10 +57,10 @@ class AladinApiServiceTest {
 
     @Test
     void applyLikedByMePreservesSearchMetadata() {
-        when(bookLikedRepository.findLikedBookIds(eq("member-1"), anyList()))
+        when(bookLikedRepository.findLikedBookIds(eq(1L), anyList()))
                 .thenReturn(List.of("9791169213882"));
 
-        BookResponseDTO.BookList response = aladinApiService.applyLikedByMe(bookList(false, true), "member-1");
+        BookResponseDTO.BookList response = aladinApiService.applyLikedByMe(bookList(false, true), 1L);
 
         assertThat(response.getTotalResults()).isEqualTo(37);
         assertThat(response.getCurrentPage()).isEqualTo(2);
@@ -73,10 +73,10 @@ class AladinApiServiceTest {
     @Test
     void searchBooksUsesCachedRawResultAndAppliesLikedByMe() {
         when(bookSearchCacheService.retrieve("java", 10, 1)).thenReturn(Optional.of(bookList(false, true)));
-        when(bookLikedRepository.findLikedBookIds(eq("member-1"), anyList()))
+        when(bookLikedRepository.findLikedBookIds(eq(1L), anyList()))
                 .thenReturn(List.of("9791169213882"));
 
-        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("java", 1, "member-1");
+        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("java", 1, 1L);
 
         verify(aladinSearchClient, never()).fetchSearchBooks("java", 1);
         assertThat(response.getTotalResults()).isEqualTo(37);
@@ -87,7 +87,7 @@ class AladinApiServiceTest {
 
     @Test
     void searchBooksReturnsEmptyResultWhenKeywordIsBlank() {
-        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("   ", 1, "member-1");
+        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("   ", 1, 1L);
 
         assertThat(response.getTotalResults()).isZero();
         assertThat(response.getCurrentPage()).isEqualTo(1);
@@ -107,10 +107,10 @@ class AladinApiServiceTest {
         BookResponseDTO.BookList rawBookList = bookList(false, true);
         when(bookSearchCacheService.retrieve("java", 10, 1)).thenReturn(Optional.empty());
         when(aladinSearchClient.fetchSearchBooks("java", 1)).thenReturn(rawBookList);
-        when(bookLikedRepository.findLikedBookIds(eq("member-1"), anyList()))
+        when(bookLikedRepository.findLikedBookIds(eq(1L), anyList()))
                 .thenReturn(List.of("9791169213882"));
 
-        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("java", 1, "member-1");
+        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("java", 1, 1L);
 
         verify(bookSearchCacheService).save("java", 10, 1, rawBookList);
         verify(aladinSearchPrefetchService).prefetchNextPage("java", 1);
@@ -125,7 +125,7 @@ class AladinApiServiceTest {
         when(bookSearchCacheService.retrieve("java", 10, 1)).thenReturn(Optional.empty());
         when(aladinSearchClient.fetchSearchBooks("java", 1)).thenReturn(rawBookList);
 
-        aladinApiService.retrieveSearchBooks("java", 1, "member-1");
+        aladinApiService.retrieveSearchBooks("java", 1, 1L);
 
         verify(aladinSearchPrefetchService, never()).prefetchNextPage("java", 1);
     }
@@ -136,10 +136,10 @@ class AladinApiServiceTest {
         when(bookSearchCacheService.retrieve("java", 10, 1))
                 .thenReturn(Optional.empty(), Optional.of(bookList(false, false)));
         when(aladinSearchClient.fetchSearchBooks("java", 1)).thenThrow(failure);
-        when(bookLikedRepository.findLikedBookIds(eq("member-1"), anyList()))
+        when(bookLikedRepository.findLikedBookIds(eq(1L), anyList()))
                 .thenReturn(List.of("9791169213882"));
 
-        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("java", 1, "member-1");
+        BookResponseDTO.BookList response = aladinApiService.retrieveSearchBooks("java", 1, 1L);
 
         verify(sentryCaptureClient).captureException(failure);
         assertThat(response.getTotalResults()).isEqualTo(37);
@@ -154,7 +154,7 @@ class AladinApiServiceTest {
         when(bookSearchCacheService.retrieve("java", 10, 1)).thenReturn(Optional.empty());
         when(aladinSearchClient.fetchSearchBooks("java", 1)).thenThrow(failure);
 
-        assertThatThrownBy(() -> aladinApiService.retrieveSearchBooks("java", 1, "member-1"))
+        assertThatThrownBy(() -> aladinApiService.retrieveSearchBooks("java", 1, 1L))
                 .isInstanceOfSatisfying(BookException.class, exception ->
                         assertThat(exception.getErrorCode()).isEqualTo(BookErrorStatus.ALADIN_API_ERROR)
                 )

--- a/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
+++ b/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
@@ -510,7 +510,7 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
     }
 
     private String uniqueSuffix(TestUser user) {
-        return user.id().substring(user.id().length() - 4).toLowerCase();
+        return user.legacyId().substring(user.legacyId().length() - 4).toLowerCase();
     }
 
     private Map<String, Object> clubDetailPayload(String name) {

--- a/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
+++ b/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
@@ -136,7 +136,10 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
                 .when().post("/api/v1/clubs/{clubId}/join", club.getId())
                 .then().statusCode(200);
 
-        ClubMember joinedMember = clubMemberRepository.findByClubIdAndMemberId(club.getId(), member.id()).orElseThrow();
+        ClubMember joinedMember = clubMemberRepository.findByClubIdAndMemberId(
+                club.getId(),
+                Long.valueOf(member.id())
+        ).orElseThrow();
 
         given().cookie(accessTokenCookie(owner))
                 .queryParam("status", "ACTIVE")
@@ -259,7 +262,10 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
         TestUser owner = createUser();
         Club club = createClub(owner, "bookshelf" + uniqueSuffix(owner));
         Meeting meeting = createMeeting(owner, club.getId());
-        ClubMember ownerClubMember = clubMemberRepository.findByClubIdAndMemberId(club.getId(), owner.id()).orElseThrow();
+        ClubMember ownerClubMember = clubMemberRepository.findByClubIdAndMemberId(
+                club.getId(),
+                Long.valueOf(owner.id())
+        ).orElseThrow();
 
         given().cookie(accessTokenCookie(owner))
                 .when().get("/api/v1/clubs/{clubId}/bookshelves", club.getId())

--- a/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
+++ b/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
@@ -352,7 +352,7 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
                 .clubId(club.getId())
                 .meetingId(meeting.getId())
                 .teamId(team.getId())
-                .senderMemberId(owner.id())
+                .senderMemberId(Long.valueOf(owner.id()))
                 .content("안녕하세요")
                 .sentAt(LocalDateTime.now())
                 .build());

--- a/src/test/java/checkmo/clubManagement/internal/entity/ClubMemberTest.java
+++ b/src/test/java/checkmo/clubManagement/internal/entity/ClubMemberTest.java
@@ -165,7 +165,7 @@ class ClubMemberTest {
     private ClubMember clubMember(Club club, Long id, ClubMemberStatus status) {
         return ClubMember.builder()
                 .id(id)
-                .memberId("member-" + id)
+                .memberId(id)
                 .club(club)
                 .clubMemberStatus(status)
                 .appliedAt(APPLIED_AT)

--- a/src/test/java/checkmo/clubManagement/internal/entity/ClubTest.java
+++ b/src/test/java/checkmo/clubManagement/internal/entity/ClubTest.java
@@ -18,7 +18,7 @@ class ClubTest {
     void 클럽장을_추가하면_클럽을_참조하는_클럽장_회원이_생성된다() {
         Club club = club(1L, true);
 
-        ClubMember owner = club.createOwnerMember("owner-1", APPLIED_AT);
+        ClubMember owner = club.createOwnerMember(1L, APPLIED_AT);
 
         assertSoftly(softly -> {
             softly.assertThat(owner.getClubMemberStatus()).isEqualTo(ClubMemberStatus.OWNER);
@@ -31,7 +31,7 @@ class ClubTest {
     void 공개_클럽에_가입을_신청하면_활성_회원으로_추가된다() {
         Club club = club(1L, true);
 
-        ClubMember clubMember = club.applyForMembership("member-1", "join", APPLIED_AT);
+        ClubMember clubMember = club.applyForMembership(1L, "join", APPLIED_AT);
 
         assertSoftly(softly -> {
             softly.assertThat(clubMember.getClubMemberStatus()).isEqualTo(ClubMemberStatus.MEMBER);
@@ -44,7 +44,7 @@ class ClubTest {
     void 비공개_클럽에_가입을_신청하면_대기_회원으로_추가된다() {
         Club club = club(1L, false);
 
-        ClubMember clubMember = club.applyForMembership("member-1", "join", APPLIED_AT);
+        ClubMember clubMember = club.applyForMembership(1L, "join", APPLIED_AT);
 
         assertSoftly(softly -> {
             softly.assertThat(clubMember.getClubMemberStatus()).isEqualTo(ClubMemberStatus.PENDING);
@@ -57,7 +57,7 @@ class ClubTest {
     void 대기_회원의_가입을_거절할_수_있다() {
         Club club = club(1L, false);
         ClubMember actor = clubMember(club, 99L, ClubMemberStatus.STAFF);
-        ClubMember clubMember = club.applyForMembership("member-1", "join", APPLIED_AT);
+        ClubMember clubMember = club.applyForMembership(1L, "join", APPLIED_AT);
 
         assertThatCode(() -> club.validateJoinRejection(actor, clubMember))
                 .doesNotThrowAnyException();
@@ -67,7 +67,7 @@ class ClubTest {
     void 이미_가입된_회원은_가입을_거절할_수_없다() {
         Club club = club(1L, true);
         ClubMember actor = clubMember(club, 99L, ClubMemberStatus.STAFF);
-        ClubMember clubMember = club.applyForMembership("member-1", "join", APPLIED_AT);
+        ClubMember clubMember = club.applyForMembership(1L, "join", APPLIED_AT);
 
         assertThatThrownBy(() -> club.validateJoinRejection(actor, clubMember))
                 .isInstanceOfSatisfying(ClubManagementException.class, exception ->
@@ -80,7 +80,7 @@ class ClubTest {
     void 비운영진은_가입을_거절할_수_없다() {
         Club club = club(1L, true);
         ClubMember actor = clubMember(club, 99L, ClubMemberStatus.MEMBER);
-        ClubMember clubMember = club.applyForMembership("member-1", "join", APPLIED_AT);
+        ClubMember clubMember = club.applyForMembership(1L, "join", APPLIED_AT);
 
         assertThatThrownBy(() -> club.validateJoinRejection(actor, clubMember))
                 .isInstanceOfSatisfying(ClubManagementException.class, exception ->
@@ -94,7 +94,7 @@ class ClubTest {
         Club club = club(1L, true);
         ClubMember actor = clubMember(club, 99L, ClubMemberStatus.STAFF);
         Club anotherClub = club(2L, false);
-        ClubMember clubMember = anotherClub.applyForMembership("member-1", "join", APPLIED_AT);
+        ClubMember clubMember = anotherClub.applyForMembership(1L, "join", APPLIED_AT);
 
         assertThatThrownBy(() -> club.validateJoinRejection(actor, clubMember))
                 .isInstanceOfSatisfying(ClubManagementException.class, exception ->
@@ -107,7 +107,7 @@ class ClubTest {
     void 식별자가_없는_클럽도_자신의_가입_요청을_검증할_수_있다() {
         Club club = club(null, false);
         ClubMember actor = clubMember(club, 99L, ClubMemberStatus.STAFF);
-        ClubMember clubMember = club.applyForMembership("member-1", "join", APPLIED_AT);
+        ClubMember clubMember = club.applyForMembership(1L, "join", APPLIED_AT);
 
         assertThatCode(() -> club.validateJoinRejection(actor, clubMember))
                 .doesNotThrowAnyException();
@@ -118,7 +118,7 @@ class ClubTest {
         Club club = club(null, true);
         ClubMember actor = clubMember(club, 99L, ClubMemberStatus.STAFF);
         Club anotherClub = club(null, false);
-        ClubMember clubMember = anotherClub.applyForMembership("member-1", "join", APPLIED_AT);
+        ClubMember clubMember = anotherClub.applyForMembership(1L, "join", APPLIED_AT);
 
         assertThatThrownBy(() -> club.validateJoinRejection(actor, clubMember))
                 .isInstanceOfSatisfying(ClubManagementException.class, exception ->
@@ -131,7 +131,7 @@ class ClubTest {
     void 다른_클럽의_회원은_재신청할_수_없다() {
         Club club = club(1L, true);
         Club anotherClub = club(2L, true);
-        ClubMember clubMember = anotherClub.applyForMembership("member-1", "join", APPLIED_AT);
+        ClubMember clubMember = anotherClub.applyForMembership(1L, "join", APPLIED_AT);
         clubMember.leave(APPLIED_AT);
 
         assertThatThrownBy(() -> club.reApplyMember(clubMember, "again", APPLIED_AT))
@@ -342,7 +342,7 @@ class ClubTest {
         return ClubMember.builder()
                 .id(id)
                 .club(club)
-                .memberId("member-" + id)
+                .memberId(id)
                 .clubMemberStatus(status)
                 .appliedAt(APPLIED_AT)
                 .joinedAt(status.isActive() ? APPLIED_AT : null)

--- a/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
+++ b/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
@@ -119,17 +119,17 @@ class SentryBackgroundCaptureTest {
         );
         RuntimeException firstFailure = new RuntimeException("delete failed first");
         RuntimeException secondFailure = new RuntimeException("delete failed second");
-        Member first = Member.builder().id("member-1").build();
-        Member second = Member.builder().id("member-2").build();
+        Member first = Member.builder().id(1L).build();
+        Member second = Member.builder().id(2L).build();
         when(memberRepository.findAllByDeactivatedAtBefore(any(LocalDateTime.class)))
                 .thenReturn(List.of(first, second));
-        doThrow(firstFailure).when(memberCommandService).deleteMember("member-1");
-        doThrow(secondFailure).when(memberCommandService).deleteMember("member-2");
+        doThrow(firstFailure).when(memberCommandService).deleteMember(1L);
+        doThrow(secondFailure).when(memberCommandService).deleteMember(2L);
 
         assertDoesNotThrow(scheduler::cleanupExpiredDeactivatedMembers);
 
-        verify(memberCommandService).deleteMember("member-1");
-        verify(memberCommandService).deleteMember("member-2");
+        verify(memberCommandService).deleteMember(1L);
+        verify(memberCommandService).deleteMember(2L);
         assertThat(captureClient.captured()).containsExactly(firstFailure);
         assertThat(firstFailure.getSuppressed()).containsExactly(secondFailure);
     }

--- a/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
+++ b/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
@@ -67,9 +67,9 @@ class SentryBackgroundCaptureTest {
         when(valueOperations.get("book:recommendations:daily:updated_at"))
                 .thenReturn(LocalDate.now().minusDays(1).toString());
         when(aladinApiService.retrieveRecommendedBooks()).thenThrow(failure);
-        when(aladinApiService.applyLikedByMe(staleCache, "member-1")).thenReturn(likedStaleCache);
+        when(aladinApiService.applyLikedByMe(staleCache, 1L)).thenReturn(likedStaleCache);
 
-        BookResponseDTO.BookList response = service.retrieveRecommendedBooks("member-1");
+        BookResponseDTO.BookList response = service.retrieveRecommendedBooks(1L);
 
         assertThat(response).isSameAs(likedStaleCache);
         assertThat(captureClient.captured()).containsExactly(failure);

--- a/src/test/java/checkmo/member/MemberApiTest.java
+++ b/src/test/java/checkmo/member/MemberApiTest.java
@@ -560,7 +560,9 @@ class MemberApiTest extends ApiTestSupport {
                 .get("/api/v1/members/me/blocks")
                 .then()
                 .statusCode(200)
-                .body("isSuccess", equalTo(true));
+                .body("isSuccess", equalTo(true))
+                .body("result.blocks[0].memberId", equalTo(target.memberId().intValue()))
+                .body("result.blocks[0].nickname", equalTo(target.nickName()));
 
         given()
                 .cookie(accessTokenCookie(me))

--- a/src/test/java/checkmo/member/MemberApiTest.java
+++ b/src/test/java/checkmo/member/MemberApiTest.java
@@ -80,7 +80,7 @@ class MemberApiTest extends ApiTestSupport {
         TestUser user = createIncompleteUser();
         Terms service = saveTerms(TermsType.SERVICE_TERMS, "서비스", true, true);
         Terms marketing = saveTerms(TermsType.MARKETING, "마케팅", true, false);
-        saveMemberTerms(user.id(), marketing, true);
+        saveMemberTerms(user.memberId(), marketing, true);
 
         ExtractableResponse<Response> response = given()
                 .cookie(accessTokenCookie(user))
@@ -268,7 +268,7 @@ class MemberApiTest extends ApiTestSupport {
         SoftAssertions.assertSoftly(softly -> {
             softly.assertThat(response.jsonPath().getList("result.terms.agreed", Boolean.class))
                     .containsExactly(true);
-            softly.assertThat(memberTermsRepository.countByMember_IdAndTerms_Id(user.id(), marketing.getId()))
+            softly.assertThat(memberTermsRepository.countByMember_IdAndTerms_Id(user.memberId(), marketing.getId()))
                     .isEqualTo(3);
         });
     }
@@ -281,7 +281,7 @@ class MemberApiTest extends ApiTestSupport {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .cookie(accessTokenCookie(user))
                 .body(Map.of(
-                        "nickname", "complete" + user.id().substring(user.id().length() - 4).toLowerCase(),
+                        "nickname", "complete" + user.legacyId().substring(user.legacyId().length() - 4).toLowerCase(),
                         "name", "완료",
                         "phoneNumber", "010-1234-5678",
                         "description", "소개",
@@ -364,7 +364,7 @@ class MemberApiTest extends ApiTestSupport {
     @Test
     void 프로필_수정으로_닉네임을_변경하면_Member와_AuthUser가_함께_갱신된다() {
         TestUser user = createUser();
-        String newNickname = "nn" + user.id().substring(user.id().length() - 8);
+        String newNickname = "nn" + user.legacyId().substring(user.legacyId().length() - 8);
 
         given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -377,8 +377,8 @@ class MemberApiTest extends ApiTestSupport {
                 .body("isSuccess", equalTo(true))
                 .body("result.nickname", equalTo(newNickname));
 
-        var member = memberRepository.findById(user.id()).orElseThrow();
-        var authUser = authRepository.findById(user.id()).orElseThrow();
+        var member = memberRepository.findById(user.memberId()).orElseThrow();
+        var authUser = authRepository.findById(user.memberId()).orElseThrow();
         assertThat(member.getNickName()).isEqualTo(newNickname);
         assertThat(authUser.getNickName()).isEqualTo(newNickname);
     }
@@ -399,7 +399,7 @@ class MemberApiTest extends ApiTestSupport {
                 .body("isSuccess", equalTo(false))
                 .body("code", equalTo("MEMBER_416"));
 
-        var member = memberRepository.findById(me.id()).orElseThrow();
+        var member = memberRepository.findById(me.memberId()).orElseThrow();
         assertThat(member.getNickName()).isEqualTo(me.nickName());
     }
 
@@ -653,7 +653,7 @@ class MemberApiTest extends ApiTestSupport {
     @Test
     void updateEmailSucceedsAfterVerification() {
         TestUser user = createUserWithPassword("Pass123!");
-        String newEmail = "changed-" + user.id().substring(user.id().length() - 4).toLowerCase() + "@example.com";
+        String newEmail = "changed-" + user.legacyId().substring(user.legacyId().length() - 4).toLowerCase() + "@example.com";
         when(redisHashOperations.get("verification:" + newEmail, "code")).thenReturn("123456");
         when(redisHashOperations.get("verification:" + newEmail, "verified")).thenReturn(false);
 
@@ -735,7 +735,7 @@ class MemberApiTest extends ApiTestSupport {
                 .build());
     }
 
-    private void saveMemberTerms(String memberId, Terms terms, boolean agreed) {
+    private void saveMemberTerms(Long memberId, Terms terms, boolean agreed) {
         memberRepository.findById(memberId)
                 .map(member -> MemberTerms.builder()
                         .member(member)

--- a/src/test/java/checkmo/member/MemberProfileTermsStrictApiTest.java
+++ b/src/test/java/checkmo/member/MemberProfileTermsStrictApiTest.java
@@ -65,8 +65,8 @@ class MemberProfileTermsStrictApiTest extends ApiTestSupport {
                 .body("code", equalTo("TERMS_403"));
 
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(authRepository.findById(user.id()).orElseThrow().isProfileCompleted()).isFalse();
-            softly.assertThat(memberRepository.findById(user.id()).orElseThrow().getNickName()).isNull();
+            softly.assertThat(authRepository.findById(user.memberId()).orElseThrow().isProfileCompleted()).isFalse();
+            softly.assertThat(memberRepository.findById(user.memberId()).orElseThrow().getNickName()).isNull();
         });
     }
 
@@ -98,14 +98,14 @@ class MemberProfileTermsStrictApiTest extends ApiTestSupport {
                 .body("isSuccess", equalTo(true));
 
         SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(authRepository.findById(user.id()).orElseThrow().isProfileCompleted()).isTrue();
-            softly.assertThat(memberRepository.findById(user.id()).orElseThrow().getNickName()).startsWith("allowed");
+            softly.assertThat(authRepository.findById(user.memberId()).orElseThrow().isProfileCompleted()).isTrue();
+            softly.assertThat(memberRepository.findById(user.memberId()).orElseThrow().getNickName()).startsWith("allowed");
         });
     }
 
     private Map<String, Object> additionalInfoBody(TestUser user, String prefix) {
         return Map.of(
-                "nickname", prefix + user.id().substring(user.id().length() - 4).toLowerCase(),
+                "nickname", prefix + user.legacyId().substring(user.legacyId().length() - 4).toLowerCase(),
                 "name", "완료",
                 "phoneNumber", "010-1234-5678",
                 "description", "소개",

--- a/src/test/java/checkmo/member/TermsDomainServiceTest.java
+++ b/src/test/java/checkmo/member/TermsDomainServiceTest.java
@@ -217,7 +217,8 @@ class TermsDomainServiceTest {
     private Member saveMember() {
         String suffix = UUID.randomUUID().toString().substring(0, 8);
         return memberRepository.save(Member.builder()
-                .id("LOCAL_" + suffix)
+                .id(Math.abs(UUID.randomUUID().getMostSignificantBits()))
+                .legacyId("LOCAL_" + suffix)
                 .email(suffix + "@example.com")
                 .name("테스트")
                 .phoneNumber("01000000000")

--- a/src/test/java/checkmo/support/ApiTestSupport.java
+++ b/src/test/java/checkmo/support/ApiTestSupport.java
@@ -1,6 +1,7 @@
 package checkmo.support;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -171,11 +172,17 @@ public abstract class ApiTestSupport {
 
         when(tokenCacheService.isAccessTokenBlacklisted(anyString())).thenReturn(false);
         when(tokenCacheService.getRefreshToken(anyString()))
-                .thenAnswer(invocation -> refreshTokensByUserId.get(invocation.getArgument(0)));
+                .thenAnswer(invocation -> refreshTokensByUserId.get(refreshTokenKey(invocation.getArgument(0))));
+        when(tokenCacheService.getRefreshToken(anyLong()))
+                .thenAnswer(invocation -> refreshTokensByUserId.get(refreshTokenKey(invocation.getArgument(0))));
         doAnswer(invocation -> {
-            refreshTokensByUserId.put(invocation.getArgument(0), invocation.getArgument(1));
+            refreshTokensByUserId.put(refreshTokenKey(invocation.getArgument(0)), invocation.getArgument(1));
             return null;
         }).when(tokenCacheService).saveRefreshToken(anyString(), anyString());
+        doAnswer(invocation -> {
+            refreshTokensByUserId.put(refreshTokenKey(invocation.getArgument(0)), invocation.getArgument(1));
+            return null;
+        }).when(tokenCacheService).saveRefreshToken(anyLong(), anyString());
         when(tokenCacheService.compareAndRotateRefreshToken(
                 anyString(),
                 anyString(),
@@ -187,25 +194,30 @@ public abstract class ApiTestSupport {
                         invocation.getArgument(1),
                         invocation.getArgument(2)
                 ));
+        when(tokenCacheService.compareAndRotateRefreshToken(
+                anyLong(),
+                anyString(),
+                anyString(),
+                org.mockito.ArgumentMatchers.any(Duration.class)
+        ))
+                .thenAnswer(invocation -> rotateRefreshTokenIfCurrent(
+                        invocation.getArgument(0),
+                        invocation.getArgument(1),
+                        invocation.getArgument(2)
+                ));
         when(tokenCacheService.saveBlacklistToken(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
         doAnswer(invocation -> {
-            refreshTokensByUserId.remove(invocation.getArgument(0));
+            refreshTokensByUserId.remove(refreshTokenKey(invocation.getArgument(0)));
             return null;
         }).when(tokenCacheService).deleteRefreshToken(anyString());
+        doAnswer(invocation -> {
+            refreshTokensByUserId.remove(refreshTokenKey(invocation.getArgument(0)));
+            return null;
+        }).when(tokenCacheService).deleteRefreshToken(anyLong());
         when(tokenCacheService.deleteRefreshTokenIfMatches(anyString(), anyString()))
-                .thenAnswer(invocation -> {
-                    String userId = invocation.getArgument(0);
-                    String expectedRefreshToken = invocation.getArgument(1);
-                    AtomicBoolean deleted = new AtomicBoolean(false);
-                    refreshTokensByUserId.compute(userId, (ignored, currentRefreshToken) -> {
-                        if (expectedRefreshToken.equals(currentRefreshToken)) {
-                            deleted.set(true);
-                            return null;
-                        }
-                        return currentRefreshToken;
-                    });
-                    return deleted.get();
-                });
+                .thenAnswer(invocation -> deleteRefreshTokenIfCurrent(invocation.getArgument(0), invocation.getArgument(1)));
+        when(tokenCacheService.deleteRefreshTokenIfMatches(anyLong(), anyString()))
+                .thenAnswer(invocation -> deleteRefreshTokenIfCurrent(invocation.getArgument(0), invocation.getArgument(1)));
     }
 
     @AfterEach
@@ -264,22 +276,27 @@ public abstract class ApiTestSupport {
         return createUserWithId(role, profileCompleted, rawPassword, idPrefix + suffix);
     }
 
-    private TestUser createUserWithId(Role role, boolean profileCompleted, String rawPassword, String id) {
-        String email = id + "@example.com";
-        String nickName = role.name().toLowerCase() + id.substring(Math.max(0, id.length() - 8));
+    private TestUser createUserWithId(Role role, boolean profileCompleted, String rawPassword, String legacyId) {
+        String email = legacyId + "@example.com";
+        String nickName = role.name().toLowerCase() + legacyId.substring(Math.max(0, legacyId.length() - 8));
+        String provider = legacyId.contains("_") ? legacyId.substring(0, legacyId.indexOf("_")) : "LOCAL";
+        String providerUserId = legacyId.contains("_") ? legacyId.substring(legacyId.indexOf("_") + 1) : legacyId;
 
         AuthUser authUser = AuthUser.builder()
-                .id(id)
+                .legacyId(legacyId)
                 .email(email)
                 .password(passwordEncoder.encode(rawPassword))
+                .provider(provider)
+                .providerUserId(providerUserId)
                 .role(role)
                 .profileCompleted(profileCompleted)
                 .nickName(profileCompleted ? nickName : null)
                 .build();
-        authRepository.save(authUser);
+        AuthUser savedAuthUser = authRepository.save(authUser);
 
         Member member = Member.builder()
-                .id(id)
+                .id(savedAuthUser.getId())
+                .legacyId(legacyId)
                 .email(email)
                 .name("테스트")
                 .phoneNumber("01012345678")
@@ -288,8 +305,8 @@ public abstract class ApiTestSupport {
                 .build();
         memberRepository.save(member);
 
-        JwtToken token = jwtTokenProvider.generateToken(jwtTokenProvider.getAuthenticationFromMemberId(id));
-        return new TestUser(id, email, nickName, role, profileCompleted, token.getAccessToken(), token.getRefreshToken());
+        JwtToken token = jwtTokenProvider.generateToken(jwtTokenProvider.getAuthenticationFromMemberId(savedAuthUser.getId()));
+        return new TestUser(String.valueOf(savedAuthUser.getId()), savedAuthUser.getId(), legacyId, email, nickName, role, profileCompleted, token.getAccessToken(), token.getRefreshToken());
     }
 
     protected Cookie accessTokenCookie(TestUser user) {
@@ -318,16 +335,16 @@ public abstract class ApiTestSupport {
     }
 
     protected void saveRefreshTokenInCacheFake(String userId, String refreshToken) {
-        refreshTokensByUserId.put(userId, refreshToken);
+        refreshTokensByUserId.put(refreshTokenKey(userId), refreshToken);
     }
 
     protected boolean rotateRefreshTokenIfCurrent(
-            String userId,
+            Object userId,
             String expectedRefreshToken,
             String newRefreshToken
     ) {
         AtomicBoolean rotated = new AtomicBoolean(false);
-        refreshTokensByUserId.compute(userId, (ignored, currentRefreshToken) -> {
+        refreshTokensByUserId.compute(refreshTokenKey(userId), (ignored, currentRefreshToken) -> {
             if (expectedRefreshToken.equals(currentRefreshToken)) {
                 rotated.set(true);
                 return newRefreshToken;
@@ -337,8 +354,26 @@ public abstract class ApiTestSupport {
         return rotated.get();
     }
 
+    private boolean deleteRefreshTokenIfCurrent(Object userId, String expectedRefreshToken) {
+        AtomicBoolean deleted = new AtomicBoolean(false);
+        refreshTokensByUserId.compute(refreshTokenKey(userId), (ignored, currentRefreshToken) -> {
+            if (expectedRefreshToken.equals(currentRefreshToken)) {
+                deleted.set(true);
+                return null;
+            }
+            return currentRefreshToken;
+        });
+        return deleted.get();
+    }
+
+    private String refreshTokenKey(Object userId) {
+        return String.valueOf(userId);
+    }
+
     protected record TestUser(
             String id,
+            Long memberId,
+            String legacyId,
             String email,
             String nickName,
             Role role,

--- a/src/test/java/checkmo/support/ApiTestSupport.java
+++ b/src/test/java/checkmo/support/ApiTestSupport.java
@@ -322,14 +322,26 @@ public abstract class ApiTestSupport {
     }
 
     protected String expiredSignedRefreshToken(TestUser user) {
+        return signedTokenWithSubject(user.id(), -1_000L);
+    }
+
+    protected String signedAccessTokenWithSubject(String subject) {
+        return signedTokenWithSubject(subject, 3_600_000L);
+    }
+
+    protected String signedRefreshTokenWithSubject(String subject) {
+        return signedTokenWithSubject(subject, 86_400_000L);
+    }
+
+    private String signedTokenWithSubject(String subject, long expirationOffsetMillis) {
         byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.getSecret());
         Key key = Keys.hmacShaKeyFor(keyBytes);
         long now = System.currentTimeMillis();
 
         return Jwts.builder()
                 .id(UUID.randomUUID().toString())
-                .subject(user.id())
-                .expiration(new Date(now - 1_000L))
+                .subject(subject)
+                .expiration(new Date(now + expirationOffsetMillis))
                 .signWith(key)
                 .compact();
     }


### PR DESCRIPTION

## 요약

Refs #278

- `member.id`, `auth_user.id`를 내부용 `BIGINT AUTO_INCREMENT` 식별자로 전환했습니다.
- 기존 `LOCAL_*`, `GOOGLE_*`, `APPLE_*`, `KAKAO_*` 문자열 식별자는 `legacy_id`로 보존했습니다.
- `auth_user.provider`, `auth_user.provider_user_id`를 추가하고 `UNIQUE(provider, provider_user_id)` 정책으로 로그인 식별자를 분리했습니다.
- 회원 식별자 API 계약과 도메인 간 ID 전달을 `Long` 기준으로 정리했습니다.
- 운영 반영 절차와 검증 쿼리는 문서로 정리했습니다.

## 검증

- 로컬 `checkmo_db` drop/create 후 로컬 `db` 프로필 기준 Flyway 52개 migration 적용 확인, 최종 version `v20260706.2`
- 로컬 앱 실행 후 `GET /health` HTTP 200 확인
- DB 컬럼 확인: `member.id`, `auth_user.id` = `BIGINT AUTO_INCREMENT`; `legacy_id` 보존; `auth_user(provider, provider_user_id)` 구조 확인
- `./gradlew test --tests checkmo.CheckmoApplicationTests`
- `./gradlew test --tests '*Api*'`
- `./gradlew test`
- `git diff --check`

## 운영 반영 전 주의사항

- 운영 DB 마이그레이션은 배포 전에 운영 데이터 백업과 검증 쿼리 확인 후 진행해야 합니다.
- 기존 문자열 ID는 최소 한 릴리스 동안 `legacy_id`로 보존하는 전제입니다.
- JWT subject와 API memberId는 이번 변경 이후 내부 숫자 ID 기준으로 동작합니다.
