### PR TITLE
fix(websocket): 앱 WebSocket 리프레시 토큰 인증 추가

### DIFF
--- a/src/main/java/checkmo/authentication/AuthenticationAPI.java
+++ b/src/main/java/checkmo/authentication/AuthenticationAPI.java
@@ -2,6 +2,8 @@ package checkmo.authentication;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import org.springframework.security.core.Authentication;
 
 public interface AuthenticationAPI {
 
@@ -49,4 +51,9 @@ public interface AuthenticationAPI {
     boolean canAccessAdmin(Long memberId);
 
     String fetchProvider(Long memberId);
+
+    /**
+     * 앱 WebSocket 핸드셰이크에서 전달한 Refresh Token을 회전 없이 검증하고 인증 정보를 반환합니다.
+     */
+    Optional<Authentication> authenticateAppRefreshToken(String refreshToken);
 }

--- a/src/main/java/checkmo/authentication/internal/AuthenticationAPIImpl.java
+++ b/src/main/java/checkmo/authentication/internal/AuthenticationAPIImpl.java
@@ -6,11 +6,14 @@ import checkmo.authentication.internal.exception.AuthErrorStatus;
 import checkmo.authentication.internal.exception.AuthException;
 import checkmo.authentication.internal.repository.AuthRepository;
 import checkmo.authentication.internal.security.jwt.TokenCacheService;
+import checkmo.authentication.internal.security.jwt.AppRefreshTokenAuthenticationService;
 import checkmo.authentication.internal.service.command.AuthSessionCommandService;
 import checkmo.authentication.internal.service.command.AuthUserCommandService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -21,6 +24,7 @@ public class AuthenticationAPIImpl implements AuthenticationAPI {
     private final AuthSessionCommandService authSessionCommandService;
     private final TokenCacheService tokenCacheService;
     private final AuthRepository authRepository;
+    private final AppRefreshTokenAuthenticationService appRefreshTokenAuthenticationService;
 
     @Override
     public void deleteAuthData(Long memberId) {
@@ -66,5 +70,10 @@ public class AuthenticationAPIImpl implements AuthenticationAPI {
         return authRepository.findById(memberId)
                 .map(AuthUser::getProvider)
                 .orElseThrow(() -> new AuthException(AuthErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    @Override
+    public Optional<Authentication> authenticateAppRefreshToken(String refreshToken) {
+        return appRefreshTokenAuthenticationService.authenticate(refreshToken);
     }
 }

--- a/src/main/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationService.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationService.java
@@ -1,0 +1,54 @@
+package checkmo.authentication.internal.security.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppRefreshTokenAuthenticationService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenCacheService tokenCacheService;
+
+    public Optional<Authentication> authenticate(String refreshToken) {
+        if (!StringUtils.hasText(refreshToken)) {
+            return Optional.empty();
+        }
+
+        try {
+            if (!jwtTokenProvider.isRefreshTokenValid(refreshToken)) {
+                log.warn("[앱 WS 인증] 유효하지 않은 Refresh Token");
+                return Optional.empty();
+            }
+
+            Long memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+            String storedRefreshToken = tokenCacheService.getRefreshToken(memberId);
+            if (!matchesStoredToken(refreshToken, storedRefreshToken)) {
+                log.warn("[앱 WS 인증] Redis Refresh Token 불일치 - memberId={}", memberId);
+                return Optional.empty();
+            }
+
+            return Optional.of(jwtTokenProvider.getAuthenticationFromMemberId(memberId));
+        } catch (RuntimeException e) {
+            log.warn("[앱 WS 인증] Refresh Token 인증 실패: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private boolean matchesStoredToken(String providedToken, String storedToken) {
+        if (!StringUtils.hasText(storedToken)) {
+            return false;
+        }
+        return MessageDigest.isEqual(
+                providedToken.getBytes(StandardCharsets.UTF_8),
+                storedToken.getBytes(StandardCharsets.UTF_8)
+        );
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationService.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationService.java
@@ -29,6 +29,11 @@ public class AppRefreshTokenAuthenticationService {
             }
 
             Long memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+            if (memberId == null) {
+                log.warn("[앱 WS 인증] Refresh Token에서 memberId를 추출할 수 없음");
+                return Optional.empty();
+            }
+
             String storedRefreshToken = tokenCacheService.getRefreshToken(memberId);
             if (!matchesStoredToken(refreshToken, storedRefreshToken)) {
                 log.warn("[앱 WS 인증] Redis Refresh Token 불일치 - memberId={}", memberId);

--- a/src/main/java/checkmo/realtime/web/websocket/interceptor/SecurityContextHandshakeInterceptor.java
+++ b/src/main/java/checkmo/realtime/web/websocket/interceptor/SecurityContextHandshakeInterceptor.java
@@ -1,7 +1,10 @@
 package checkmo.realtime.web.websocket.interceptor;
 
+import checkmo.authentication.AuthenticationAPI;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
@@ -16,20 +19,45 @@ import java.util.Map;
  * stateless JWT 환경에서 HttpSessionHandshakeInterceptor 대체용.
  */
 @Component
+@RequiredArgsConstructor
 public class SecurityContextHandshakeInterceptor implements HandshakeInterceptor {
+
+    public static final String APP_REFRESH_TOKEN_HEADER = "X-Refresh-Token";
+
+    private final AuthenticationAPI authenticationAPI;
 
     @Override
     public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
                                    WebSocketHandler wsHandler, Map<String, Object> attributes) {
         SecurityContext context = SecurityContextHolder.getContext();
-        if (context.getAuthentication() != null && context.getAuthentication().isAuthenticated()) {
-            attributes.put(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+        if (copyAuthenticatedContext(context, attributes)) {
+            return true;
         }
+
+        String refreshToken = request.getHeaders().getFirst(APP_REFRESH_TOKEN_HEADER);
+        authenticationAPI.authenticateAppRefreshToken(refreshToken)
+                .ifPresent(authentication -> storeAuthentication(authentication, attributes));
         return true;
     }
 
     @Override
     public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
                                WebSocketHandler wsHandler, Exception exception) {
+    }
+
+    private boolean copyAuthenticatedContext(SecurityContext context, Map<String, Object> attributes) {
+        Authentication authentication = context.getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return false;
+        }
+        attributes.put(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+        return true;
+    }
+
+    private void storeAuthentication(Authentication authentication, Map<String, Object> attributes) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+        attributes.put(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
     }
 }

--- a/src/main/java/checkmo/realtime/web/websocket/interceptor/SecurityContextHandshakeInterceptor.java
+++ b/src/main/java/checkmo/realtime/web/websocket/interceptor/SecurityContextHandshakeInterceptor.java
@@ -4,6 +4,7 @@ import checkmo.authentication.AuthenticationAPI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -47,7 +48,9 @@ public class SecurityContextHandshakeInterceptor implements HandshakeInterceptor
 
     private boolean copyAuthenticatedContext(SecurityContext context, Map<String, Object> attributes) {
         Authentication authentication = context.getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || authentication instanceof AnonymousAuthenticationToken) {
             return false;
         }
         attributes.put(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
@@ -57,7 +60,6 @@ public class SecurityContextHandshakeInterceptor implements HandshakeInterceptor
     private void storeAuthentication(Authentication authentication, Map<String, Object> attributes) {
         SecurityContext context = SecurityContextHolder.createEmptyContext();
         context.setAuthentication(authentication);
-        SecurityContextHolder.setContext(context);
         attributes.put(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
     }
 }

--- a/src/test/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationServiceTest.java
@@ -1,0 +1,80 @@
+package checkmo.authentication.internal.security.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+@ExtendWith(MockitoExtension.class)
+class AppRefreshTokenAuthenticationServiceTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private TokenCacheService tokenCacheService;
+
+    @Mock
+    private Authentication authentication;
+
+    @InjectMocks
+    private AppRefreshTokenAuthenticationService authenticationService;
+
+    @Test
+    void blankTokenDoesNotAuthenticate() {
+        Optional<Authentication> result = authenticationService.authenticate(" ");
+
+        assertThat(result).isEmpty();
+        verifyNoInteractions(jwtTokenProvider, tokenCacheService);
+    }
+
+    @Test
+    void invalidSignatureDoesNotAuthenticate() {
+        when(jwtTokenProvider.isRefreshTokenValid("refresh-token")).thenReturn(false);
+
+        Optional<Authentication> result = authenticationService.authenticate("refresh-token");
+
+        assertThat(result).isEmpty();
+        verify(jwtTokenProvider, never()).getUserIdFromToken("refresh-token");
+        verifyNoInteractions(tokenCacheService);
+    }
+
+    @Test
+    void mismatchedStoredTokenDoesNotAuthenticate() {
+        when(jwtTokenProvider.isRefreshTokenValid("refresh-token")).thenReturn(true);
+        when(jwtTokenProvider.getUserIdFromToken("refresh-token")).thenReturn(7L);
+        when(tokenCacheService.getRefreshToken(7L)).thenReturn("other-token");
+
+        Optional<Authentication> result = authenticationService.authenticate("refresh-token");
+
+        assertThat(result).isEmpty();
+        verify(jwtTokenProvider, never()).getAuthenticationFromMemberId(7L);
+    }
+
+    @Test
+    void matchingStoredTokenAuthenticatesWithoutRotation() {
+        when(jwtTokenProvider.isRefreshTokenValid("refresh-token")).thenReturn(true);
+        when(jwtTokenProvider.getUserIdFromToken("refresh-token")).thenReturn(7L);
+        when(tokenCacheService.getRefreshToken(7L)).thenReturn("refresh-token");
+        when(jwtTokenProvider.getAuthenticationFromMemberId(7L)).thenReturn(authentication);
+
+        Optional<Authentication> result = authenticationService.authenticate("refresh-token");
+
+        assertThat(result).containsSame(authentication);
+        verify(tokenCacheService, never()).compareAndRotateRefreshToken(
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationServiceTest.java
@@ -61,6 +61,17 @@ class AppRefreshTokenAuthenticationServiceTest {
     }
 
     @Test
+    void missingMemberIdDoesNotQueryTokenCache() {
+        when(jwtTokenProvider.isRefreshTokenValid("refresh-token")).thenReturn(true);
+        when(jwtTokenProvider.getUserIdFromToken("refresh-token")).thenReturn(null);
+
+        Optional<Authentication> result = authenticationService.authenticate("refresh-token");
+
+        assertThat(result).isEmpty();
+        verifyNoInteractions(tokenCacheService);
+    }
+
+    @Test
     void matchingStoredTokenAuthenticatesWithoutRotation() {
         when(jwtTokenProvider.isRefreshTokenValid("refresh-token")).thenReturn(true);
         when(jwtTokenProvider.getUserIdFromToken("refresh-token")).thenReturn(7L);

--- a/src/test/java/checkmo/realtime/web/websocket/interceptor/SecurityContextHandshakeInterceptorTest.java
+++ b/src/test/java/checkmo/realtime/web/websocket/interceptor/SecurityContextHandshakeInterceptorTest.java
@@ -20,7 +20,9 @@ import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
@@ -78,7 +80,30 @@ class SecurityContextHandshakeInterceptorTest {
                 HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY
         );
         assertThat(context.getAuthentication()).isSameAs(authentication);
-        assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(authentication);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    void ignoresAnonymousSecurityContextAndAuthenticatesAppRefreshTokenHeader() {
+        Authentication anonymous = new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS")
+        );
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(anonymous);
+        SecurityContextHolder.setContext(context);
+        when(authenticationAPI.authenticateAppRefreshToken("refresh-token"))
+                .thenReturn(Optional.of(authentication));
+        Map<String, Object> attributes = new HashMap<>();
+
+        interceptor.beforeHandshake(request("refresh-token"), response(), webSocketHandler, attributes);
+
+        SecurityContext storedContext = (SecurityContext) attributes.get(
+                HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY
+        );
+        assertThat(storedContext.getAuthentication()).isSameAs(authentication);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(anonymous);
     }
 
     @Test

--- a/src/test/java/checkmo/realtime/web/websocket/interceptor/SecurityContextHandshakeInterceptorTest.java
+++ b/src/test/java/checkmo/realtime/web/websocket/interceptor/SecurityContextHandshakeInterceptorTest.java
@@ -1,0 +1,107 @@
+package checkmo.realtime.web.websocket.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import checkmo.authentication.AuthenticationAPI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.web.socket.WebSocketHandler;
+
+@ExtendWith(MockitoExtension.class)
+class SecurityContextHandshakeInterceptorTest {
+
+    @Mock
+    private AuthenticationAPI authenticationAPI;
+
+    @Mock
+    private Authentication authentication;
+
+    @Mock
+    private WebSocketHandler webSocketHandler;
+
+    private SecurityContextHandshakeInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.clearContext();
+        interceptor = new SecurityContextHandshakeInterceptor(authenticationAPI);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void copiesExistingSecurityContextWithoutAppRefreshTokenLookup() {
+        when(authentication.isAuthenticated()).thenReturn(true);
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+        Map<String, Object> attributes = new HashMap<>();
+
+        interceptor.beforeHandshake(request(null), response(), webSocketHandler, attributes);
+
+        assertThat(attributes)
+                .containsEntry(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
+        verifyNoInteractions(authenticationAPI);
+    }
+
+    @Test
+    void authenticatesAppRefreshTokenHeaderIntoWebSocketSecurityContext() {
+        when(authenticationAPI.authenticateAppRefreshToken("refresh-token"))
+                .thenReturn(Optional.of(authentication));
+        Map<String, Object> attributes = new HashMap<>();
+
+        interceptor.beforeHandshake(request("refresh-token"), response(), webSocketHandler, attributes);
+
+        SecurityContext context = (SecurityContext) attributes.get(
+                HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY
+        );
+        assertThat(context.getAuthentication()).isSameAs(authentication);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(authentication);
+    }
+
+    @Test
+    void leavesHandshakeUnauthenticatedWithoutAppRefreshTokenHeader() {
+        when(authenticationAPI.authenticateAppRefreshToken(null)).thenReturn(Optional.empty());
+        Map<String, Object> attributes = new HashMap<>();
+
+        interceptor.beforeHandshake(request(null), response(), webSocketHandler, attributes);
+
+        assertThat(attributes)
+                .doesNotContainKey(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    private ServerHttpRequest request(String refreshToken) {
+        MockHttpServletRequest servletRequest = new MockHttpServletRequest("GET", "/ws-stomp");
+        if (refreshToken != null) {
+            servletRequest.addHeader(SecurityContextHandshakeInterceptor.APP_REFRESH_TOKEN_HEADER, refreshToken);
+        }
+        return new ServletServerHttpRequest(servletRequest);
+    }
+
+    private ServerHttpResponse response() {
+        return new ServletServerHttpResponse(new MockHttpServletResponse());
+    }
+}


### PR DESCRIPTION
RN release WebSocket 핸드셰이크에서 X-Refresh-Token을 검증해 SecurityContext를 설정하도록 앱 전용 인증 경로를 추가합니다.

Tested: ./gradlew test --tests checkmo.authentication.internal.security.jwt.AppRefreshTokenAuthenticationServiceTest --tests checkmo.realtime.web.websocket.interceptor.SecurityContextHandshakeInterceptorTest --tests checkmo.CheckmoApplicationTests

Tested: ./gradlew test

## 🚀 변경사항
<!-- 뭘 구현했는지/수정했는지 간단히 -->

## 🔗 관련 이슈
- Closes #이슈번호

## ✅ 체크리스트
- [ ] 로컬에서 테스트 완료
- [ ] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket connections can now authenticate using an app refresh token when no active login session is present.
  * A new refresh-token header is supported during the handshake to establish a security context automatically.

* **Bug Fixes**
  * Improved handling of WebSocket authentication so authenticated sessions are carried into the connection only when valid.
  * Invalid, empty, or mismatched refresh tokens are safely rejected without creating a session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->