### PR TITLE
fix(chat): 채팅 가능 기간 180일로 연장

### DIFF
--- a/src/main/java/checkmo/clubMeeting/internal/entity/Meeting.java
+++ b/src/main/java/checkmo/clubMeeting/internal/entity/Meeting.java
@@ -15,6 +15,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Meeting extends BaseEntity {
+    private static final int CHAT_AVAILABLE_DAYS_AFTER_MEETING = 180;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -88,7 +89,7 @@ public class Meeting extends BaseEntity {
     }
 
     public LocalDateTime getChatDeadline() {
-        return this.getMeetingTime().plusDays(3);
+        return this.getMeetingTime().plusDays(CHAT_AVAILABLE_DAYS_AFTER_MEETING);
     }
 
     // ========= 연관관계 메서드 =========


### PR DESCRIPTION
## 🚀 변경사항
- 정기모임 조별 채팅 가능 기간을 모임 시간 기준 3일에서 180일로 연장했습니다.
- `Meeting#getChatDeadline()`의 기준일을 상수로 분리해 채팅 가능 기간 정책을 명확하게 했습니다.

## 🔗 관련 이슈
- Closes #282

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
- 검증: `./gradlew compileJava`
- `meetingTime`이 없는 정기모임은 기존과 동일하게 채팅 전송이 불가능합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended the post-meeting chat availability window to 180 days after a meeting.
  * Updated the chat deadline calculation so users can access meeting chat for a longer period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->