### PR TITLE
fix(club-management): 관리자 모임 목록 owner 조회 실패 방어

### DIFF
--- a/src/main/java/checkmo/clubManagement/internal/repository/ClubMemberRepository.java
+++ b/src/main/java/checkmo/clubManagement/internal/repository/ClubMemberRepository.java
@@ -39,6 +39,12 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
             + "ORDER BY cm.id DESC")
     List<ClubMember> findByClubIdAndStatuses(Long clubId, EnumSet<ClubMemberStatus> statuses, Long cursorId, Pageable pageable);
 
+    @Query("SELECT cm FROM ClubMember cm "
+            + "WHERE cm.club.id IN :clubIds "
+            + "AND cm.clubMemberStatus IN :statuses "
+            + "ORDER BY cm.club.id ASC, cm.id DESC")
+    List<ClubMember> findByClubIdInAndStatuses(List<Long> clubIds, EnumSet<ClubMemberStatus> statuses);
+
     List<ClubMember> findAllByMemberIdAndClubIdIn(Long memberId, List<Long> clubIds);
 
     long countByClubIdAndClubMemberStatusIn(Long clubId, EnumSet<ClubMemberStatus> statuses);

--- a/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
@@ -344,8 +344,28 @@ public class ClubManagementQueryFacade {
                 ADMIN_PAGE_SIZE
         );
 
+        Map<Long, List<ClubMember>> clubMembersByClubId = pageResult.content().stream()
+                .collect(Collectors.toMap(
+                        Club::getId,
+                        club -> clubMemberQueryService.retrieveClubMembers(club.getId(), ClubMemberStatus.activeStatuses())
+                ));
+
+        List<Long> ownerMemberIds = clubMembersByClubId.values().stream()
+                .flatMap(List::stream)
+                .filter(ClubMember::isOwner)
+                .map(ClubMember::getMemberId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        Map<Long, String> ownerEmailByMemberId =
+                memberAPI.fetchMemberEmailByMemberIdsIncludingDeactivated(ownerMemberIds);
+
         List<ClubAdminResponseDTO.ClubPreview> clubs = pageResult.content().stream()
-                .map(this::toAdminClubPreview)
+                .map(club -> toAdminClubPreview(
+                        club,
+                        clubMembersByClubId.getOrDefault(club.getId(), Collections.emptyList()),
+                        ownerEmailByMemberId
+                ))
                 .toList();
 
         return ClubAdminResponseDTO.ClubPreviewPage.builder()
@@ -358,14 +378,18 @@ public class ClubManagementQueryFacade {
                 .build();
     }
 
-    private ClubAdminResponseDTO.ClubPreview toAdminClubPreview(Club club) {
-        List<ClubMember> clubMembers = clubMemberQueryService.retrieveClubMembers(club.getId(), ClubMemberStatus.activeStatuses());
-
-        ClubMember owner = clubMembers.stream()
+    private ClubAdminResponseDTO.ClubPreview toAdminClubPreview(
+            Club club,
+            List<ClubMember> clubMembers,
+            Map<Long, String> ownerEmailByMemberId
+    ) {
+        Optional<ClubMember> owner = clubMembers.stream()
                 .filter(ClubMember::isOwner)
-                .findFirst()
-                .orElseThrow(() -> new ClubManagementException(ClubManagementErrorStatus.CLUB_OWNER_NOT_FOUND));
-        String ownerEmail = memberAPI.fetchMemberEmail(owner.getMemberId());
+                .findFirst();
+        String ownerEmail = owner
+                .map(ClubMember::getMemberId)
+                .map(ownerEmailByMemberId::get)
+                .orElse(null);
 
         long activeMemberCount = clubMembers.stream()
                 .filter(ClubMember::isActive)

--- a/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/ClubManagementQueryFacade.java
@@ -344,11 +344,12 @@ public class ClubManagementQueryFacade {
                 ADMIN_PAGE_SIZE
         );
 
-        Map<Long, List<ClubMember>> clubMembersByClubId = pageResult.content().stream()
-                .collect(Collectors.toMap(
-                        Club::getId,
-                        club -> clubMemberQueryService.retrieveClubMembers(club.getId(), ClubMemberStatus.activeStatuses())
-                ));
+        List<Long> clubIds = pageResult.content().stream()
+                .map(Club::getId)
+                .toList();
+        Map<Long, List<ClubMember>> clubMembersByClubId =
+                clubMemberQueryService.retrieveClubMembersByClubIds(clubIds, ClubMemberStatus.activeStatuses()).stream()
+                        .collect(Collectors.groupingBy(clubMember -> clubMember.getClub().getId()));
 
         List<Long> ownerMemberIds = clubMembersByClubId.values().stream()
                 .flatMap(List::stream)

--- a/src/main/java/checkmo/clubManagement/internal/service/query/ClubMemberQueryService.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/query/ClubMemberQueryService.java
@@ -75,6 +75,13 @@ public class ClubMemberQueryService {
         return clubMemberRepository.findByClubIdAndStatuses(clubId, statuses, null, Pageable.unpaged());
     }
 
+    public List<ClubMember> retrieveClubMembersByClubIds(List<Long> clubIds, EnumSet<ClubMemberStatus> statuses) {
+        if (clubIds == null || clubIds.isEmpty()) {
+            return List.of();
+        }
+        return clubMemberRepository.findByClubIdInAndStatuses(clubIds, statuses);
+    }
+
     public long countActiveClubMembers(Long clubId) {
         return clubMemberRepository.countByClubIdAndClubMemberStatusIn(clubId, ClubMemberStatus.activeStatuses());
     }

--- a/src/main/java/checkmo/member/MemberAPI.java
+++ b/src/main/java/checkmo/member/MemberAPI.java
@@ -148,4 +148,12 @@ public interface MemberAPI {
      * @return 회원 이메일
      */
     String fetchMemberEmail(Long memberId);
+
+    /**
+     * 회원 ID 목록으로 회원의 이메일을 조회합니다. 비활성 회원도 포함하며, 삭제된 회원은 결과에서 제외합니다.
+     *
+     * @param memberIds 회원 ID 목록
+     * @return 회원 ID와 이메일의 매핑 정보
+     */
+    Map<Long, String> fetchMemberEmailByMemberIdsIncludingDeactivated(List<Long> memberIds);
 }

--- a/src/main/java/checkmo/member/internal/MemberAPIImpl.java
+++ b/src/main/java/checkmo/member/internal/MemberAPIImpl.java
@@ -214,6 +214,20 @@ public class MemberAPIImpl implements MemberAPI {
         return member.getEmail();
     }
 
+    @Override
+    public Map<Long, String> fetchMemberEmailByMemberIdsIncludingDeactivated(List<Long> memberIds) {
+        List<Long> distinctMemberIds = distinctNonNullIds(memberIds);
+        if (distinctMemberIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return memberQueryService.retrieveMembersIncludingDeactivatedById(distinctMemberIds).stream()
+                .collect(Collectors.toMap(
+                        Member::getId,
+                        Member::getEmail
+                ));
+    }
+
     private MemberExternalDTO.BasicInfo withdrawnBasicInfo() {
         return MemberExternalDTO.BasicInfo.builder()
                 .nickname(WITHDRAWN_MEMBER_NICKNAME)

--- a/src/main/java/checkmo/member/internal/service/query/MemberQueryService.java
+++ b/src/main/java/checkmo/member/internal/service/query/MemberQueryService.java
@@ -58,6 +58,10 @@ public class MemberQueryService {
         return memberRepository.findAllByIdInAndDeactivatedAtIsNull(memberIds);
     }
 
+    public List<Member> retrieveMembersIncludingDeactivatedById(List<Long> memberIds) {
+        return memberRepository.findAllById(memberIds);
+    }
+
     /**
      * 회원 기본 정보 조회
      *

--- a/src/test/java/checkmo/admin/AdminApiTest.java
+++ b/src/test/java/checkmo/admin/AdminApiTest.java
@@ -242,6 +242,39 @@ class AdminApiTest extends ApiTestSupport {
     }
 
     @Test
+    void clubAdminListToleratesInactiveOrDeletedOwner() {
+        TestUser admin = createAdmin();
+        TestUser deactivatedOwner = createUser();
+        TestUser deletedOwner = createUser();
+        Club deactivatedOwnerClub = createClub(deactivatedOwner, "admin-club-deactivated-owner");
+        Club deletedOwnerClub = createClub(deletedOwner, "admin-club-deleted-owner");
+
+        var deactivatedMember = memberRepository.findById(deactivatedOwner.memberId()).orElseThrow();
+        deactivatedMember.deactivate();
+        memberRepository.save(deactivatedMember);
+        memberRepository.deleteById(deletedOwner.memberId());
+        memberRepository.flush();
+
+        given().cookie(accessTokenCookie(admin))
+                .queryParam("keyword", deactivatedOwnerClub.getName())
+                .queryParam("page", 1)
+                .when().get("/api/v1/admin/clubs")
+                .then().statusCode(200)
+                .body("result.clubs.size()", equalTo(1))
+                .body("result.clubs[0].clubId", equalTo(deactivatedOwnerClub.getId().intValue()))
+                .body("result.clubs[0].ownerEmail", equalTo(deactivatedOwner.email()));
+
+        given().cookie(accessTokenCookie(admin))
+                .queryParam("keyword", deletedOwnerClub.getName())
+                .queryParam("page", 1)
+                .when().get("/api/v1/admin/clubs")
+                .then().statusCode(200)
+                .body("result.clubs.size()", equalTo(1))
+                .body("result.clubs[0].clubId", equalTo(deletedOwnerClub.getId().intValue()))
+                .body("result.clubs[0].ownerEmail", nullValue());
+    }
+
+    @Test
     void newsAdminEndpointsCoverCrudMemberLookupValidationAndSecurity() {
         TestUser admin = createAdmin();
         TestUser requester = createUser();


### PR DESCRIPTION
## 🚀 변경사항
- 관리자 모임 목록 조회 시 모임 개설자(OWNER) 계정이 비활성/삭제된 경우에도 API가 실패하지 않도록 수정
- 목록 페이지의 owner memberId를 모아 이메일을 batch 조회하도록 변경
- 비활성 owner는 기존 이메일을 응답하고, 삭제된 owner는 `ownerEmail: null`로 응답하도록 처리
- 비활성/삭제 owner 케이스를 검증하는 관리자 API 회귀 테스트 추가

## 🔗 관련 이슈
- Closes #284

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
- 기존 `fetchMemberEmail`의 활성 회원 조회 동작은 유지하고, 관리자 모임 목록 전용으로 비활성 회원 포함 batch 조회 경로를 추가했습니다.
- 테스트: `./gradlew test --tests checkmo.admin.AdminApiTest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin club listings now include owner email information when available.

* **Bug Fixes**
  * Admin club results no longer fail when a club owner is inactive or deleted.
  * Missing owner details are now handled gracefully, showing no email instead of blocking the response.
  * Club admin list performance is improved by loading related member and email data in bulk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->