### PR TITLE
fix(club): 모임 추천 개수 6개로 변경

### DIFF
--- a/src/main/java/checkmo/clubManagement/internal/service/query/ClubManagementQueryService.java
+++ b/src/main/java/checkmo/clubManagement/internal/service/query/ClubManagementQueryService.java
@@ -26,6 +26,8 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ClubManagementQueryService {
 
+    private static final int RECOMMENDATION_SIZE = 6;
+
     private final ClubRepository clubRepository;
 
     public List<Club> retrieveClubs(ClubRequestDTO.ClubSearchFilter filter, Long cursorId, int pageSize) {
@@ -66,7 +68,7 @@ public class ClubManagementQueryService {
             LocalDateTime lastActivityAt,
             Long memberId
     ) {
-        return clubRepository.findRecommendations(interestCategories, lastActivityAt, memberId, 3);
+        return clubRepository.findRecommendations(interestCategories, lastActivityAt, memberId, RECOMMENDATION_SIZE);
     }
 
     public Page<Club> retrieveAdminClubs(String keyword, Pageable pageable) {

--- a/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
+++ b/src/test/java/checkmo/club/ClubMeetingNoticeApiTest.java
@@ -183,6 +183,24 @@ class ClubMeetingNoticeApiTest extends ApiTestSupport {
     }
 
     @Test
+    void clubRecommendationsReturnSixClubs() {
+        TestUser owner = createUser();
+        TestUser requester = createUser();
+
+        for (int index = 0; index < 7; index++) {
+            createClub(owner, "recommend-" + index + "-" + uniqueSuffix(owner));
+        }
+
+        Response response = given().cookie(accessTokenCookie(requester))
+                .when().get("/api/v1/clubs/recommendations")
+                .then().statusCode(200)
+                .extract().response();
+
+        List<Map<String, Object>> recommendations = response.jsonPath().getList("result.recommendations");
+        assertThat(recommendations).hasSize(6);
+    }
+
+    @Test
     void publicClubParticipantsCanBeViewedByLoggedInNonMemberWithFollowStatus() {
         TestUser owner = createUser();
         TestUser member = createUser();


### PR DESCRIPTION
## 🚀 변경사항
모임 추천 개수 6개로 변경

## 🔗 관련 이슈
- Closes #286 

## ✅ 체크리스트
- [ ] 로컬에서 테스트 완료
- [ ] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated club recommendations to consistently return 6 items instead of a smaller, hardcoded count.
  * Added coverage to verify the recommendations endpoint returns the expected number of clubs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->