### PR TITLE
fix(notification): 비활성 푸시 기기 재등록 오류 수정

### DIFF
--- a/src/main/java/checkmo/notification/internal/service/command/PushDeviceCommandService.java
+++ b/src/main/java/checkmo/notification/internal/service/command/PushDeviceCommandService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.UUID;
 
 @Service
@@ -31,7 +32,7 @@ public class PushDeviceCommandService {
             device = existing.get();
             // token이 바뀐 경우에만 다른 installation에 같은 token이 있는지 확인한다.
             // token이 동일하면 자기 자신만 존재할 수 있으므로 DB 조회를 생략한다.
-            if (!device.getExpoPushToken().equals(token)) {
+            if (!Objects.equals(device.getExpoPushToken(), token)) {
                 deactivateTokenConflict(token, installationId);
             }
             device.update(token, memberId, request.getPlatform(), request.getAppVersion(), request.getBuildNumber());

--- a/src/test/java/checkmo/notification/PushDeviceApiTest.java
+++ b/src/test/java/checkmo/notification/PushDeviceApiTest.java
@@ -1,0 +1,102 @@
+package checkmo.notification;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import checkmo.notification.internal.entity.PushDevice;
+import checkmo.notification.internal.repository.PushDeviceRepository;
+import checkmo.support.ApiTestSupport;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+class PushDeviceApiTest extends ApiTestSupport {
+
+    private static final String INSTALLATION_A = "11111111-1111-4111-8111-111111111111";
+    private static final String INSTALLATION_B = "22222222-2222-4222-8222-222222222222";
+    private static final String TOKEN_A = "ExponentPushToken[test-reactivation-a]";
+    private static final String TOKEN_B = "ExponentPushToken[test-reactivation-b]";
+
+    @Autowired
+    PushDeviceRepository pushDeviceRepository;
+
+    @Test
+    void 비활성화한_동일_설치_ID를_다시_등록하면_기기가_재활성화된다() {
+        TestUser user = createUser();
+        long originalDeviceId = registerPushDevice(user, INSTALLATION_A, TOKEN_A);
+
+        deregisterPushDevice(user, INSTALLATION_A);
+
+        PushDevice inactiveDevice = findDevice(INSTALLATION_A);
+        assertThat(inactiveDevice.isActive()).isFalse();
+        assertThat(inactiveDevice.getExpoPushToken()).isNull();
+        assertThat(inactiveDevice.getDeactivatedAt()).isNotNull();
+
+        long reactivatedDeviceId = registerPushDevice(user, INSTALLATION_A, TOKEN_A);
+
+        PushDevice reactivatedDevice = findDevice(INSTALLATION_A);
+        assertThat(reactivatedDeviceId).isEqualTo(originalDeviceId);
+        assertThat(pushDeviceRepository.count()).isOne();
+        assertThat(reactivatedDevice.isActive()).isTrue();
+        assertThat(reactivatedDevice.getExpoPushToken()).isEqualTo(TOKEN_A);
+        assertThat(reactivatedDevice.getDeactivatedAt()).isNull();
+        assertThat(reactivatedDevice.getMemberId()).isEqualTo(user.memberId());
+    }
+
+    @Test
+    void 비활성_설치가_다른_설치의_토큰으로_재등록되면_토큰_소유권이_이동한다() {
+        TestUser user = createUser();
+        long originalDeviceId = registerPushDevice(user, INSTALLATION_A, TOKEN_A);
+        deregisterPushDevice(user, INSTALLATION_A);
+        registerPushDevice(user, INSTALLATION_B, TOKEN_B);
+
+        long reactivatedDeviceId = registerPushDevice(user, INSTALLATION_A, TOKEN_B);
+
+        PushDevice reactivatedDevice = findDevice(INSTALLATION_A);
+        PushDevice conflictingDevice = findDevice(INSTALLATION_B);
+        assertThat(reactivatedDeviceId).isEqualTo(originalDeviceId);
+        assertThat(reactivatedDevice.isActive()).isTrue();
+        assertThat(reactivatedDevice.getExpoPushToken()).isEqualTo(TOKEN_B);
+        assertThat(conflictingDevice.isActive()).isFalse();
+        assertThat(conflictingDevice.getExpoPushToken()).isNull();
+    }
+
+    private long registerPushDevice(TestUser user, String installationId, String expoPushToken) {
+        return given()
+                .cookie(accessTokenCookie(user))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of(
+                        "installationId", installationId,
+                        "expoPushToken", expoPushToken,
+                        "platform", "ANDROID",
+                        "appVersion", "1.1.8",
+                        "buildNumber", "1"
+                ))
+                .when()
+                .put("/api/v1/notifications/push-devices")
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true))
+                .body("result.installationId", equalTo(installationId))
+                .body("result.active", equalTo(true))
+                .extract()
+                .jsonPath()
+                .getLong("result.deviceId");
+    }
+
+    private void deregisterPushDevice(TestUser user, String installationId) {
+        given()
+                .cookie(accessTokenCookie(user))
+                .when()
+                .delete("/api/v1/notifications/push-devices/{installationId}", installationId)
+                .then()
+                .statusCode(200)
+                .body("isSuccess", equalTo(true));
+    }
+
+    private PushDevice findDevice(String installationId) {
+        return pushDeviceRepository.findByInstallationId(installationId).orElseThrow();
+    }
+}


### PR DESCRIPTION
## 🚀 변경사항
- 비활성화된 푸시 기기의 `expoPushToken`이 `null`인 경우 발생하던 재등록 오류를 수정했습니다.
- 토큰 비교를 null-safe하게 변경해 동일 `installationId`로 푸시 알림을 다시 활성화할 수 있도록 했습니다.
- 다른 설치가 보유한 토큰으로 재등록할 때 토큰 소유권이 정상적으로 이동하는지 검증하는 API 테스트를 추가했습니다.

## 🔗 관련 이슈
- Closes #288

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
- DB 마이그레이션 및 API 계약 변경은 없습니다.
- `PushDeviceApiTest`와 전체 `./gradlew test`가 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push-device registration to safely handle missing notification tokens.
  * Restoring a previously deactivated device now correctly reactivates it and restores its token.
  * Prevented conflicting device registrations from retaining duplicate notification tokens.

* **Tests**
  * Added coverage for device reactivation and notification-token reassignment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->