### PR TITLE
fix(auth): 리프레시 토큰을 세션 단위로 관리

### DIFF
--- a/src/main/java/checkmo/authentication/internal/AuthenticationAPIImpl.java
+++ b/src/main/java/checkmo/authentication/internal/AuthenticationAPIImpl.java
@@ -40,6 +40,7 @@ public class AuthenticationAPIImpl implements AuthenticationAPI {
     @Override
     public void deactivateMember(Long memberId, HttpServletRequest request, HttpServletResponse response) {
         authSessionCommandService.logout(request, response);
+        tokenCacheService.deleteRefreshToken(memberId);
         authUserCommandService.deactivateMember(memberId);
     }
 

--- a/src/main/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationService.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationService.java
@@ -33,10 +33,15 @@ public class AppRefreshTokenAuthenticationService {
                 log.warn("[앱 WS 인증] Refresh Token에서 memberId를 추출할 수 없음");
                 return Optional.empty();
             }
+            String sessionId = jwtTokenProvider.getSessionIdFromToken(refreshToken);
 
-            String storedRefreshToken = tokenCacheService.getRefreshToken(memberId);
+            String storedRefreshToken = tokenCacheService.getRefreshToken(memberId, sessionId);
             if (!matchesStoredToken(refreshToken, storedRefreshToken)) {
-                log.warn("[앱 WS 인증] Redis Refresh Token 불일치 - memberId={}", memberId);
+                log.warn(
+                        "[앱 WS 인증] Redis Refresh Token 불일치 - memberId={}, sessionId={}",
+                        memberId,
+                        sessionId
+                );
                 return Optional.empty();
             }
 

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtLoginProcessor.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtLoginProcessor.java
@@ -29,6 +29,17 @@ public class JwtLoginProcessor {
         return jwtToken.getRefreshToken();
     }
 
+    // 앱 로그인은 Refresh Token을 응답 본문으로 전달하므로 쿠키에는 Access Token만 유지한다.
+    public String processAppLogin(HttpServletResponse response, Authentication authentication) {
+        JwtToken jwtToken = issueToken(authentication);
+
+        int accessTokenMaxAge = (int) (jwtTokenProvider.getAccessTokenExpirationTime() / 1000L);
+        jwtCookieUtil.addTokenToCookie(response, "accessToken", jwtToken.getAccessToken(), accessTokenMaxAge);
+        jwtCookieUtil.deleteTokenFromCookie(response, "refreshToken");
+
+        return jwtToken.getRefreshToken();
+    }
+
     public String processLoginWithoutCookies(Authentication authentication) {
         JwtToken jwtToken = issueToken(authentication);
         return jwtToken.getRefreshToken();
@@ -44,7 +55,7 @@ public class JwtLoginProcessor {
         JwtToken jwtToken = jwtTokenProvider.generateToken(authentication);
 
         // RefreshToken Redis에 저장
-        tokenCacheService.saveRefreshToken(userId, jwtToken.getRefreshToken());
+        tokenCacheService.saveRefreshToken(userId, jwtToken.getSessionId(), jwtToken.getRefreshToken());
         return jwtToken;
     }
 }

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtToken.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtToken.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class JwtToken {
+    private String sessionId;
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProvider.java
@@ -13,11 +13,15 @@ public interface JwtTokenProvider {
 
     JwtToken generateToken(Authentication authentication);
 
+    JwtToken generateToken(Authentication authentication, String sessionId);
+
     Authentication getAuthentication(String accessToken);
 
     boolean validateToken(String token);
 
     Long getUserIdFromToken(String token);
+
+    String getSessionIdFromToken(String token);
 
     boolean isRefreshTokenValid(String refreshToken);
 

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package checkmo.authentication.internal.security.jwt;
 
+import java.util.Optional;
 import org.springframework.security.core.Authentication;
 
 /**
@@ -22,6 +23,8 @@ public interface JwtTokenProvider {
     Long getUserIdFromToken(String token);
 
     String getSessionIdFromToken(String token);
+
+    Optional<String> getExplicitSessionIdFromToken(String token);
 
     boolean isRefreshTokenValid(String refreshToken);
 

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImpl.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImpl.java
@@ -13,6 +13,7 @@ import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SecurityException;
 import java.security.Key;
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
@@ -171,6 +172,25 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
                     e.getClaims().getId()
             );
         }
+    }
+
+    @Override
+    public Optional<String> getExplicitSessionIdFromToken(String token) {
+        try {
+            String sessionId = Jwts.parser()
+                    .verifyWith((SecretKey) key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .get(SESSION_ID_CLAIM, String.class);
+            return optionalSessionId(sessionId);
+        } catch (ExpiredJwtException e) {
+            return optionalSessionId(e.getClaims().get(SESSION_ID_CLAIM, String.class));
+        }
+    }
+
+    private Optional<String> optionalSessionId(String sessionId) {
+        return StringUtils.hasText(sessionId) ? Optional.of(sessionId) : Optional.empty();
     }
 
     private String resolveSessionId(String sessionId, String tokenId) {

--- a/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImpl.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImpl.java
@@ -28,6 +28,8 @@ import org.springframework.util.StringUtils;
 @Component
 public class JwtTokenProviderImpl implements JwtTokenProvider {
 
+    private static final String SESSION_ID_CLAIM = "sid";
+
     private final Key key;
     private final JwtProperties jwtProperties;
     private final CustomUserDetailsService customUserDetailsService;
@@ -44,6 +46,15 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
 
     @Override
     public JwtToken generateToken(Authentication authentication) {
+        return generateToken(authentication, UUID.randomUUID().toString());
+    }
+
+    @Override
+    public JwtToken generateToken(Authentication authentication, String sessionId) {
+        if (!StringUtils.hasText(sessionId)) {
+            throw new IllegalArgumentException("sessionId는 비어 있을 수 없습니다.");
+        }
+
         // 권한 가져오기
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
@@ -61,6 +72,7 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
                 .id(UUID.randomUUID().toString())
                 .subject(authentication.getName())
                 .claim("role", authorities)
+                .claim(SESSION_ID_CLAIM, sessionId)
                 .expiration(new Date(now + accessTokenValidity))
                 .signWith(key)
                 .compact();
@@ -69,11 +81,13 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
         String refreshToken = Jwts.builder()
                 .id(UUID.randomUUID().toString())
                 .subject(authentication.getName())
+                .claim(SESSION_ID_CLAIM, sessionId)
                 .expiration(new Date(now + refreshTokenValidity))
                 .signWith(key)
                 .compact();
 
         return JwtToken.builder()
+                .sessionId(sessionId)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
@@ -140,6 +154,33 @@ public class JwtTokenProviderImpl implements JwtTokenProvider {
         } catch (ExpiredJwtException e) {
             return parseMemberIdSubject(e.getClaims().getSubject());
         }
+    }
+
+    @Override
+    public String getSessionIdFromToken(String token) {
+        try {
+            var claims = Jwts.parser()
+                    .verifyWith((SecretKey) key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return resolveSessionId(claims.get(SESSION_ID_CLAIM, String.class), claims.getId());
+        } catch (ExpiredJwtException e) {
+            return resolveSessionId(
+                    e.getClaims().get(SESSION_ID_CLAIM, String.class),
+                    e.getClaims().getId()
+            );
+        }
+    }
+
+    private String resolveSessionId(String sessionId, String tokenId) {
+        if (StringUtils.hasText(sessionId)) {
+            return sessionId;
+        }
+        if (StringUtils.hasText(tokenId)) {
+            return tokenId;
+        }
+        throw new AuthException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
     }
 
     private Long parseMemberIdSubject(String subject) {

--- a/src/main/java/checkmo/authentication/internal/security/jwt/TokenCacheService.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/TokenCacheService.java
@@ -21,13 +21,31 @@ import org.springframework.stereotype.Service;
 public class TokenCacheService {
 
     private static final String REFRESH_TOKEN_PREFIX = "refreshToken::";
+    private static final String REFRESH_TOKEN_SESSION_INDEX_PREFIX = "refreshTokenSessions::";
     private static final String BLACKLIST_PREFIX = "blacklist::";
     private static final String OAUTH_CODE_PREFIX = "oauthCode::";
     private static final long OAUTH_CODE_TTL_MS = 120_000L;
+    private static final String SAVE_REFRESH_TOKEN_SCRIPT = """
+            redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[2])
+            redis.call('SADD', KEYS[2], KEYS[1])
+            redis.call('PEXPIRE', KEYS[2], ARGV[2])
+            return 1
+            """;
     private static final String COMPARE_AND_ROTATE_REFRESH_TOKEN_SCRIPT = """
             local current = redis.call('GET', KEYS[1])
             if current == ARGV[1] or current == ARGV[2] then
                 redis.call('SET', KEYS[1], ARGV[3], 'PX', ARGV[4])
+                redis.call('SADD', KEYS[3], KEYS[1])
+                redis.call('PEXPIRE', KEYS[3], ARGV[4])
+                return 1
+            end
+
+            local legacy = redis.call('GET', KEYS[2])
+            if legacy == ARGV[1] or legacy == ARGV[2] then
+                redis.call('SET', KEYS[1], ARGV[3], 'PX', ARGV[4])
+                redis.call('DEL', KEYS[2])
+                redis.call('SADD', KEYS[3], KEYS[1])
+                redis.call('PEXPIRE', KEYS[3], ARGV[4])
                 return 1
             end
             return 0
@@ -36,9 +54,28 @@ public class TokenCacheService {
             local current = redis.call('GET', KEYS[1])
             if current == ARGV[1] or current == ARGV[2] then
                 redis.call('DEL', KEYS[1])
+                redis.call('SREM', KEYS[3], KEYS[1])
+                if redis.call('SCARD', KEYS[3]) == 0 then
+                    redis.call('DEL', KEYS[3])
+                end
+                return 1
+            end
+
+            local legacy = redis.call('GET', KEYS[2])
+            if legacy == ARGV[1] or legacy == ARGV[2] then
+                redis.call('DEL', KEYS[2])
                 return 1
             end
             return 0
+            """;
+    private static final String DELETE_ALL_REFRESH_TOKENS_SCRIPT = """
+            local sessionKeys = redis.call('SMEMBERS', KEYS[1])
+            for _, sessionKey in ipairs(sessionKeys) do
+                redis.call('DEL', sessionKey)
+            end
+            redis.call('DEL', KEYS[1])
+            redis.call('DEL', KEYS[2])
+            return #sessionKeys
             """;
     private static final String CONSUME_OAUTH_CODE_SCRIPT = """
             local value = redis.call('GET', KEYS[1])
@@ -52,60 +89,83 @@ public class TokenCacheService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final JwtProperties jwtProperties;
 
-    public void saveRefreshToken(Long userId, String refreshToken) {
-        saveRefreshToken(String.valueOf(userId), refreshToken);
+    public void saveRefreshToken(Long userId, String sessionId, String refreshToken) {
+        saveRefreshToken(String.valueOf(userId), sessionId, refreshToken);
     }
 
-    public void saveRefreshToken(String userId, String refreshToken) {
-        log.info("리프레시 토큰 저장 - userId={}", userId);
+    public void saveRefreshToken(String userId, String sessionId, String refreshToken) {
+        log.info("리프레시 토큰 저장 - userId={}, sessionId={}", userId, sessionId);
         long ttlMs = jwtProperties.getTokenValidity().getRefreshToken();
-        byte[] key = serialize(REFRESH_TOKEN_PREFIX + userId);
+        byte[] sessionKey = serialize(refreshTokenSessionKey(userId, sessionId));
+        byte[] sessionIndexKey = serialize(refreshTokenSessionIndexKey(userId));
         byte[] value = serialize(refreshToken);
-        redisTemplate.execute((RedisCallback<Boolean>) connection ->
-                connection.stringCommands().set(
-                        key,
-                        value,
-                        Expiration.milliseconds(ttlMs),
-                        SetOption.upsert()
-                )
+        byte[] ttl = serialize(String.valueOf(ttlMs));
+        executeBooleanScript(
+                SAVE_REFRESH_TOKEN_SCRIPT,
+                new byte[][]{sessionKey, sessionIndexKey},
+                value,
+                ttl
         );
     }
 
-    public String getRefreshToken(Long userId) {
-        return getRefreshToken(String.valueOf(userId));
+    public String getRefreshToken(Long userId, String sessionId) {
+        return getRefreshToken(String.valueOf(userId), sessionId);
     }
 
-    public String getRefreshToken(String userId) {
-        log.info("리프레시 토큰 조회 - userId={}", userId);
-        byte[] key = serialize(REFRESH_TOKEN_PREFIX + userId);
+    public String getRefreshToken(String userId, String sessionId) {
+        log.info("리프레시 토큰 조회 - userId={}, sessionId={}", userId, sessionId);
+        byte[] sessionKey = serialize(refreshTokenSessionKey(userId, sessionId));
+        byte[] legacyKey = serialize(legacyRefreshTokenKey(userId));
         byte[] value = redisTemplate.execute((RedisCallback<byte[]>) connection ->
-                connection.stringCommands().get(key)
+                {
+                    byte[] sessionValue = connection.stringCommands().get(sessionKey);
+                    return sessionValue != null
+                            ? sessionValue
+                            : connection.stringCommands().get(legacyKey);
+                }
         );
         return value == null ? null : deserializeRefreshToken(value);
     }
 
     public boolean compareAndRotateRefreshToken(
             Long userId,
+            String sessionId,
             String expectedRefreshToken,
             String newRefreshToken,
             Duration ttl
     ) {
-        return compareAndRotateRefreshToken(String.valueOf(userId), expectedRefreshToken, newRefreshToken, ttl);
+        return compareAndRotateRefreshToken(
+                String.valueOf(userId),
+                sessionId,
+                expectedRefreshToken,
+                newRefreshToken,
+                ttl
+        );
     }
 
     public boolean compareAndRotateRefreshToken(
             String userId,
+            String sessionId,
             String expectedRefreshToken,
             String newRefreshToken,
             Duration ttl
     ) {
-        log.info("리프레시 토큰 원자적 회전 - userId={}", userId);
-        byte[] key = serialize(REFRESH_TOKEN_PREFIX + userId);
+        log.info("리프레시 토큰 원자적 회전 - userId={}, sessionId={}", userId, sessionId);
+        byte[] sessionKey = serialize(refreshTokenSessionKey(userId, sessionId));
+        byte[] legacyKey = serialize(legacyRefreshTokenKey(userId));
+        byte[] sessionIndexKey = serialize(refreshTokenSessionIndexKey(userId));
         byte[] expected = serialize(expectedRefreshToken);
         byte[] legacyExpected = serializeLegacyValue(expectedRefreshToken);
         byte[] next = serialize(newRefreshToken);
         byte[] ttlMs = serialize(String.valueOf(ttl.toMillis()));
-        return executeBooleanScript(COMPARE_AND_ROTATE_REFRESH_TOKEN_SCRIPT, key, expected, legacyExpected, next, ttlMs);
+        return executeBooleanScript(
+                COMPARE_AND_ROTATE_REFRESH_TOKEN_SCRIPT,
+                new byte[][]{sessionKey, legacyKey, sessionIndexKey},
+                expected,
+                legacyExpected,
+                next,
+                ttlMs
+        );
     }
 
     public void deleteRefreshToken(Long userId) {
@@ -113,20 +173,37 @@ public class TokenCacheService {
     }
 
     public void deleteRefreshToken(String userId) {
-        log.info("리프레시 토큰 삭제 - userId={}", userId);
-        redisTemplate.delete(REFRESH_TOKEN_PREFIX + userId);
+        log.info("회원의 모든 리프레시 토큰 삭제 - userId={}", userId);
+        byte[] sessionIndexKey = serialize(refreshTokenSessionIndexKey(userId));
+        byte[] legacyKey = serialize(legacyRefreshTokenKey(userId));
+        redisTemplate.execute((RedisCallback<Long>) connection ->
+                connection.scriptingCommands().eval(
+                        DELETE_ALL_REFRESH_TOKENS_SCRIPT.getBytes(StandardCharsets.UTF_8),
+                        ReturnType.INTEGER,
+                        2,
+                        sessionIndexKey,
+                        legacyKey
+                )
+        );
     }
 
-    public boolean deleteRefreshTokenIfMatches(Long userId, String expectedRefreshToken) {
-        return deleteRefreshTokenIfMatches(String.valueOf(userId), expectedRefreshToken);
+    public boolean deleteRefreshTokenIfMatches(Long userId, String sessionId, String expectedRefreshToken) {
+        return deleteRefreshTokenIfMatches(String.valueOf(userId), sessionId, expectedRefreshToken);
     }
 
-    public boolean deleteRefreshTokenIfMatches(String userId, String expectedRefreshToken) {
-        log.info("리프레시 토큰 일치 시 삭제 - userId={}", userId);
-        byte[] key = serialize(REFRESH_TOKEN_PREFIX + userId);
+    public boolean deleteRefreshTokenIfMatches(String userId, String sessionId, String expectedRefreshToken) {
+        log.info("리프레시 토큰 일치 시 삭제 - userId={}, sessionId={}", userId, sessionId);
+        byte[] sessionKey = serialize(refreshTokenSessionKey(userId, sessionId));
+        byte[] legacyKey = serialize(legacyRefreshTokenKey(userId));
+        byte[] sessionIndexKey = serialize(refreshTokenSessionIndexKey(userId));
         byte[] expected = serialize(expectedRefreshToken);
         byte[] legacyExpected = serializeLegacyValue(expectedRefreshToken);
-        return executeBooleanScript(DELETE_REFRESH_TOKEN_IF_MATCHES_SCRIPT, key, expected, legacyExpected);
+        return executeBooleanScript(
+                DELETE_REFRESH_TOKEN_IF_MATCHES_SCRIPT,
+                new byte[][]{sessionKey, legacyKey, sessionIndexKey},
+                expected,
+                legacyExpected
+        );
     }
 
     public void saveOAuthExchangeCode(String code, String value) {
@@ -155,20 +232,32 @@ public class TokenCacheService {
         return value == null ? null : STRING_SERIALIZER.deserialize(value);
     }
 
-    private boolean executeBooleanScript(String script, byte[] key, byte[]... args) {
-        byte[][] keysAndArgs = new byte[args.length + 1][];
-        keysAndArgs[0] = key;
-        System.arraycopy(args, 0, keysAndArgs, 1, args.length);
+    private boolean executeBooleanScript(String script, byte[][] keys, byte[]... args) {
+        byte[][] keysAndArgs = new byte[keys.length + args.length][];
+        System.arraycopy(keys, 0, keysAndArgs, 0, keys.length);
+        System.arraycopy(args, 0, keysAndArgs, keys.length, args.length);
 
         Long result = redisTemplate.execute((RedisCallback<Long>) connection ->
                 connection.scriptingCommands().eval(
                         script.getBytes(StandardCharsets.UTF_8),
                         ReturnType.INTEGER,
-                        1,
+                        keys.length,
                         keysAndArgs
                 )
         );
         return Long.valueOf(1L).equals(result);
+    }
+
+    private String legacyRefreshTokenKey(String userId) {
+        return REFRESH_TOKEN_PREFIX + userId;
+    }
+
+    private String refreshTokenSessionKey(String userId, String sessionId) {
+        return legacyRefreshTokenKey(userId) + "::" + sessionId;
+    }
+
+    private String refreshTokenSessionIndexKey(String userId) {
+        return REFRESH_TOKEN_SESSION_INDEX_PREFIX + userId;
     }
 
     private byte[] serialize(String value) {

--- a/src/main/java/checkmo/authentication/internal/security/jwt/TokenCacheService.java
+++ b/src/main/java/checkmo/authentication/internal/security/jwt/TokenCacheService.java
@@ -26,16 +26,36 @@ public class TokenCacheService {
     private static final String OAUTH_CODE_PREFIX = "oauthCode::";
     private static final long OAUTH_CODE_TTL_MS = 120_000L;
     private static final String SAVE_REFRESH_TOKEN_SCRIPT = """
+            local function pruneMissingSessionKeys(sessionIndexKey)
+                local sessionKeys = redis.call('SMEMBERS', sessionIndexKey)
+                for _, sessionKey in ipairs(sessionKeys) do
+                    if redis.call('EXISTS', sessionKey) == 0 then
+                        redis.call('SREM', sessionIndexKey, sessionKey)
+                    end
+                end
+            end
+
             redis.call('SET', KEYS[1], ARGV[1], 'PX', ARGV[2])
             redis.call('SADD', KEYS[2], KEYS[1])
+            pruneMissingSessionKeys(KEYS[2])
             redis.call('PEXPIRE', KEYS[2], ARGV[2])
             return 1
             """;
     private static final String COMPARE_AND_ROTATE_REFRESH_TOKEN_SCRIPT = """
+            local function pruneMissingSessionKeys(sessionIndexKey)
+                local sessionKeys = redis.call('SMEMBERS', sessionIndexKey)
+                for _, sessionKey in ipairs(sessionKeys) do
+                    if redis.call('EXISTS', sessionKey) == 0 then
+                        redis.call('SREM', sessionIndexKey, sessionKey)
+                    end
+                end
+            end
+
             local current = redis.call('GET', KEYS[1])
             if current == ARGV[1] or current == ARGV[2] then
                 redis.call('SET', KEYS[1], ARGV[3], 'PX', ARGV[4])
                 redis.call('SADD', KEYS[3], KEYS[1])
+                pruneMissingSessionKeys(KEYS[3])
                 redis.call('PEXPIRE', KEYS[3], ARGV[4])
                 return 1
             end
@@ -45,25 +65,37 @@ public class TokenCacheService {
                 redis.call('SET', KEYS[1], ARGV[3], 'PX', ARGV[4])
                 redis.call('DEL', KEYS[2])
                 redis.call('SADD', KEYS[3], KEYS[1])
+                pruneMissingSessionKeys(KEYS[3])
                 redis.call('PEXPIRE', KEYS[3], ARGV[4])
                 return 1
             end
             return 0
             """;
     private static final String DELETE_REFRESH_TOKEN_IF_MATCHES_SCRIPT = """
+            local function cleanupSessionIndex(sessionIndexKey)
+                local sessionKeys = redis.call('SMEMBERS', sessionIndexKey)
+                for _, sessionKey in ipairs(sessionKeys) do
+                    if redis.call('EXISTS', sessionKey) == 0 then
+                        redis.call('SREM', sessionIndexKey, sessionKey)
+                    end
+                end
+                if redis.call('SCARD', sessionIndexKey) == 0 then
+                    redis.call('DEL', sessionIndexKey)
+                end
+            end
+
             local current = redis.call('GET', KEYS[1])
             if current == ARGV[1] or current == ARGV[2] then
                 redis.call('DEL', KEYS[1])
                 redis.call('SREM', KEYS[3], KEYS[1])
-                if redis.call('SCARD', KEYS[3]) == 0 then
-                    redis.call('DEL', KEYS[3])
-                end
+                cleanupSessionIndex(KEYS[3])
                 return 1
             end
 
             local legacy = redis.call('GET', KEYS[2])
             if legacy == ARGV[1] or legacy == ARGV[2] then
                 redis.call('DEL', KEYS[2])
+                cleanupSessionIndex(KEYS[3])
                 return 1
             end
             return 0

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/AppleAppLoginService.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/AppleAppLoginService.java
@@ -46,7 +46,7 @@ public class AppleAppLoginService {
                 principalDetails.getAuthorities()
         );
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        return jwtLoginProcessor.processLogin(response, authentication);
+        return jwtLoginProcessor.processAppLogin(response, authentication);
     }
 
     private AppleIdentity verifyIdentity(String identityToken, String rawNonce) {

--- a/src/main/java/checkmo/authentication/internal/service/AuthFacade.java
+++ b/src/main/java/checkmo/authentication/internal/service/AuthFacade.java
@@ -50,6 +50,12 @@ public class AuthFacade {
         return jwtLoginProcessor.processLogin(response, authentication);
     }
 
+    public String loginApp(AuthRequestDTO.Login request, HttpServletResponse response) {
+        Authentication authentication = authSessionCommandService.login(request);
+
+        return jwtLoginProcessor.processAppLogin(response, authentication);
+    }
+
     public String loginWithApple(AuthRequestDTO.AppleAppLogin request, HttpServletResponse response) {
         return appleAppLoginService.login(request.getIdentityToken(), request.getRawNonce(), response);
     }
@@ -75,7 +81,7 @@ public class AuthFacade {
 
     public String refreshAppToken(String refreshToken, HttpServletResponse response) {
         AuthTokenRotationResult rotationResult = authTokenRotationService.rotateRefreshToken(refreshToken);
-        authTokenRotationService.writeTokenCookies(response, rotationResult.getJwtToken());
+        authTokenRotationService.writeAppTokenCookie(response, rotationResult.getJwtToken());
         return rotationResult.getJwtToken().getRefreshToken();
     }
 

--- a/src/main/java/checkmo/authentication/internal/service/command/AuthSessionCommandService.java
+++ b/src/main/java/checkmo/authentication/internal/service/command/AuthSessionCommandService.java
@@ -8,6 +8,7 @@ import checkmo.authentication.internal.security.jwt.TokenCacheService;
 import checkmo.authentication.web.dto.AuthRequestDTO;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -93,12 +94,14 @@ public class AuthSessionCommandService {
 
         Long memberId;
         String sessionId;
+        Optional<String> explicitRefreshSessionId;
         try {
             memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
             if (memberId == null) {
                 throw new AuthException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
             }
             sessionId = jwtTokenProvider.getSessionIdFromToken(refreshToken);
+            explicitRefreshSessionId = jwtTokenProvider.getExplicitSessionIdFromToken(refreshToken);
             if (!tokenCacheService.deleteRefreshTokenIfMatches(memberId, sessionId, refreshToken)) {
                 throw new AuthException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
             }
@@ -114,7 +117,8 @@ public class AuthSessionCommandService {
         jwtCookieUtil.deleteTokenFromCookie(response, "accessToken");
         jwtCookieUtil.deleteTokenFromCookie(response, "refreshToken");
 
-        if (StringUtils.hasText(accessToken) && belongsToMember(accessToken, memberId)) {
+        if (StringUtils.hasText(accessToken)
+                && belongsToLogoutSession(accessToken, memberId, explicitRefreshSessionId)) {
             try {
                 tokenCacheService.saveBlacklistToken(accessToken);
             } catch (Exception e) {
@@ -123,11 +127,22 @@ public class AuthSessionCommandService {
         }
     }
 
-    private boolean belongsToMember(String accessToken, Long memberId) {
+    private boolean belongsToLogoutSession(
+            String accessToken,
+            Long memberId,
+            Optional<String> refreshSessionId
+    ) {
         try {
-            return memberId.equals(jwtTokenProvider.getUserIdFromToken(accessToken));
+            if (!memberId.equals(jwtTokenProvider.getUserIdFromToken(accessToken))) {
+                return false;
+            }
+
+            Optional<String> accessSessionId = jwtTokenProvider.getExplicitSessionIdFromToken(accessToken);
+            // 구버전 토큰 쌍은 둘 다 sid가 없으므로 기존 회원 단위 로그아웃을 유지한다.
+            // 신·구 토큰이 섞이거나 신형 세션끼리 sid가 다르면 다른 세션으로 판단한다.
+            return refreshSessionId.equals(accessSessionId);
         } catch (RuntimeException e) {
-            log.warn("[앱 로그아웃] AccessToken 회원 확인 실패: {}", e.getMessage());
+            log.warn("[앱 로그아웃] AccessToken 세션 확인 실패: {}", e.getMessage());
             return false;
         }
     }

--- a/src/main/java/checkmo/authentication/internal/service/command/AuthSessionCommandService.java
+++ b/src/main/java/checkmo/authentication/internal/service/command/AuthSessionCommandService.java
@@ -77,7 +77,8 @@ public class AuthSessionCommandService {
             try {
                 if (jwtTokenProvider.isRefreshTokenValid(refreshToken)) {
                     Long memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
-                    tokenCacheService.deleteRefreshTokenIfMatches(memberId, refreshToken);
+                    String sessionId = jwtTokenProvider.getSessionIdFromToken(refreshToken);
+                    tokenCacheService.deleteRefreshTokenIfMatches(memberId, sessionId, refreshToken);
                 }
             } catch (Exception e) {
                 log.error("[로그아웃] RefreshToken 삭제 실패", e);
@@ -90,12 +91,15 @@ public class AuthSessionCommandService {
             throw new AuthException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
         }
 
+        Long memberId;
+        String sessionId;
         try {
-            Long memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+            memberId = jwtTokenProvider.getUserIdFromToken(refreshToken);
             if (memberId == null) {
                 throw new AuthException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
             }
-            if (!tokenCacheService.deleteRefreshTokenIfMatches(memberId, refreshToken)) {
+            sessionId = jwtTokenProvider.getSessionIdFromToken(refreshToken);
+            if (!tokenCacheService.deleteRefreshTokenIfMatches(memberId, sessionId, refreshToken)) {
                 throw new AuthException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
             }
         } catch (AuthException e) {
@@ -110,12 +114,21 @@ public class AuthSessionCommandService {
         jwtCookieUtil.deleteTokenFromCookie(response, "accessToken");
         jwtCookieUtil.deleteTokenFromCookie(response, "refreshToken");
 
-        if (StringUtils.hasText(accessToken)) {
+        if (StringUtils.hasText(accessToken) && belongsToMember(accessToken, memberId)) {
             try {
                 tokenCacheService.saveBlacklistToken(accessToken);
             } catch (Exception e) {
                 log.error("[앱 로그아웃] AccessToken 블랙리스트 저장 실패", e);
             }
+        }
+    }
+
+    private boolean belongsToMember(String accessToken, Long memberId) {
+        try {
+            return memberId.equals(jwtTokenProvider.getUserIdFromToken(accessToken));
+        } catch (RuntimeException e) {
+            log.warn("[앱 로그아웃] AccessToken 회원 확인 실패: {}", e.getMessage());
+            return false;
         }
     }
 

--- a/src/main/java/checkmo/authentication/internal/service/command/AuthTokenRotationService.java
+++ b/src/main/java/checkmo/authentication/internal/service/command/AuthTokenRotationService.java
@@ -31,11 +31,13 @@ public class AuthTokenRotationService {
         if (memberId == null) {
             throw new AuthException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
         }
+        String sessionId = jwtTokenProvider.getSessionIdFromToken(refreshToken);
 
         Authentication authentication = jwtTokenProvider.getAuthenticationFromMemberId(memberId);
-        JwtToken newJwtToken = jwtTokenProvider.generateToken(authentication);
+        JwtToken newJwtToken = jwtTokenProvider.generateToken(authentication, sessionId);
         boolean rotated = tokenCacheService.compareAndRotateRefreshToken(
                 memberId,
+                sessionId,
                 refreshToken,
                 newJwtToken.getRefreshToken(),
                 Duration.ofMillis(jwtTokenProvider.getRefreshTokenExpirationTime())
@@ -53,5 +55,12 @@ public class AuthTokenRotationService {
 
         jwtCookieUtil.addTokenToCookie(response, "accessToken", jwtToken.getAccessToken(), accessTokenMaxAge);
         jwtCookieUtil.addTokenToCookie(response, "refreshToken", jwtToken.getRefreshToken(), refreshTokenMaxAge);
+    }
+
+    public void writeAppTokenCookie(HttpServletResponse response, JwtToken jwtToken) {
+        int accessTokenMaxAge = (int) (jwtTokenProvider.getAccessTokenExpirationTime() / 1000L);
+
+        jwtCookieUtil.addTokenToCookie(response, "accessToken", jwtToken.getAccessToken(), accessTokenMaxAge);
+        jwtCookieUtil.deleteTokenFromCookie(response, "refreshToken");
     }
 }

--- a/src/main/java/checkmo/authentication/web/controller/AuthController.java
+++ b/src/main/java/checkmo/authentication/web/controller/AuthController.java
@@ -103,7 +103,7 @@ public class AuthController {
             @Valid @RequestBody AuthRequestDTO.Login request,
             HttpServletResponse response
     ) {
-        String refreshToken = authFacade.login(request, response);
+        String refreshToken = authFacade.loginApp(request, response);
         return ApiResponse.onSuccess(AuthResponseDTO.Login.builder().refreshToken(refreshToken).build());
     }
 

--- a/src/test/java/checkmo/authentication/AppleAppLoginApiTest.java
+++ b/src/test/java/checkmo/authentication/AppleAppLoginApiTest.java
@@ -42,8 +42,9 @@ class AppleAppLoginApiTest extends ApiTestSupport {
         String refreshToken = response.jsonPath().getString("result.refreshToken");
         assertSoftly(softly -> {
             softly.assertThat(refreshToken).isNotBlank();
-            softly.assertThat(response.cookie("refreshToken")).isEqualTo(refreshToken);
             softly.assertThat(response.cookie("accessToken")).isNotBlank();
+            softly.assertThat(response.headers().getValues("Set-Cookie"))
+                    .anyMatch(header -> header.startsWith("refreshToken=") && header.contains("Max-Age=0"));
             softly.assertThat(authRepository.findByProviderAndProviderUserId("APPLE", "apple-sub")).isPresent();
         });
     }

--- a/src/test/java/checkmo/authentication/AuthApiTest.java
+++ b/src/test/java/checkmo/authentication/AuthApiTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
@@ -222,11 +223,12 @@ class AuthApiTest extends ApiTestSupport {
                 .statusCode(200)
                 .extract();
 
-        assertJwtCookiesWereSet(response);
+        assertAppTokenCookieWasSet(response);
         String responseRefreshToken = response.jsonPath().getString("result.refreshToken");
         assertSoftly(softly -> {
             softly.assertThat(responseRefreshToken).isNotBlank();
-            softly.assertThat(response.cookie("refreshToken")).isEqualTo(responseRefreshToken);
+            softly.assertThat(response.headers().getValues("Set-Cookie"))
+                    .anyMatch(header -> header.startsWith("refreshToken=") && header.contains("Max-Age=0"));
         });
     }
 
@@ -330,7 +332,7 @@ class AuthApiTest extends ApiTestSupport {
                 .statusCode(200)
                 .extract();
 
-        assertJwtCookiesWereSet(refreshResponse);
+        assertAppTokenCookieWasSet(refreshResponse);
         String newRefreshToken = refreshResponse.jsonPath().getString("result.refreshToken");
         assertThat(newRefreshToken).isNotBlank();
         assertThat(newRefreshToken).isNotEqualTo(oldRefreshToken);
@@ -342,6 +344,94 @@ class AuthApiTest extends ApiTestSupport {
                 .then()
                 .statusCode(401)
                 .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void sameMemberAppSessionsRotateIndependently() {
+        TestUser user = createUserWithPassword("Pass123!");
+        String firstRefreshToken = appLoginRefreshToken(user);
+        String secondRefreshToken = appLoginRefreshToken(user);
+
+        String rotatedFirstToken = refreshAppToken(firstRefreshToken);
+        String rotatedSecondToken = refreshAppToken(secondRefreshToken);
+
+        assertSoftly(softly -> {
+            softly.assertThat(firstRefreshToken).isNotEqualTo(secondRefreshToken);
+            softly.assertThat(rotatedFirstToken).isNotEqualTo(firstRefreshToken);
+            softly.assertThat(rotatedSecondToken).isNotEqualTo(secondRefreshToken);
+            softly.assertThat(appRefreshStatus(firstRefreshToken)).isEqualTo(401);
+            softly.assertThat(appRefreshStatus(secondRefreshToken)).isEqualTo(401);
+            softly.assertThat(appRefreshStatus(rotatedFirstToken)).isEqualTo(200);
+            softly.assertThat(appRefreshStatus(rotatedSecondToken)).isEqualTo(200);
+        });
+    }
+
+    @Test
+    void appAndWebSessionsDoNotInvalidateEachOther() {
+        TestUser user = createUserWithPassword("Pass123!");
+        ExtractableResponse<Response> webLoginResponse = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("identifier", user.email(), "password", "Pass123!"))
+                .when()
+                .post("/api/v1/auth/login")
+                .then()
+                .statusCode(200)
+                .extract();
+        String webRefreshToken = webLoginResponse.cookie("refreshToken");
+        String appRefreshToken = appLoginRefreshToken(user);
+
+        assertSoftly(softly -> {
+            softly.assertThat(appRefreshStatus(webRefreshToken)).isEqualTo(200);
+            softly.assertThat(appRefreshStatus(appRefreshToken)).isEqualTo(200);
+        });
+    }
+
+    @Test
+    void appLogoutRevokesOnlyTargetSession() {
+        TestUser user = createUserWithPassword("Pass123!");
+        String firstRefreshToken = appLoginRefreshToken(user);
+        String secondRefreshToken = appLoginRefreshToken(user);
+
+        given()
+                .header("X-Refresh-Token", firstRefreshToken)
+                .when()
+                .post("/api/v1/auth/app/logout")
+                .then()
+                .statusCode(200);
+
+        assertSoftly(softly -> {
+            softly.assertThat(appRefreshStatus(firstRefreshToken)).isEqualTo(401);
+            softly.assertThat(appRefreshStatus(secondRefreshToken)).isEqualTo(200);
+        });
+    }
+
+    @Test
+    void webLogoutRevokesOnlyWebSession() {
+        TestUser user = createUserWithPassword("Pass123!");
+        ExtractableResponse<Response> webLoginResponse = given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(Map.of("identifier", user.email(), "password", "Pass123!"))
+                .when()
+                .post("/api/v1/auth/login")
+                .then()
+                .statusCode(200)
+                .extract();
+        String webAccessToken = webLoginResponse.cookie("accessToken");
+        String webRefreshToken = webLoginResponse.cookie("refreshToken");
+        String appRefreshToken = appLoginRefreshToken(user);
+
+        given()
+                .cookie("accessToken", webAccessToken)
+                .cookie("refreshToken", webRefreshToken)
+                .when()
+                .post("/api/v1/auth/logout")
+                .then()
+                .statusCode(200);
+
+        assertSoftly(softly -> {
+            softly.assertThat(appRefreshStatus(webRefreshToken)).isEqualTo(401);
+            softly.assertThat(appRefreshStatus(appRefreshToken)).isEqualTo(200);
+        });
     }
 
     @Test
@@ -364,11 +454,13 @@ class AuthApiTest extends ApiTestSupport {
                 throw new AssertionError("concurrent refresh requests did not reach token rotation together");
             }
 
-            String userId = invocation.getArgument(0);
-            String expectedRefreshToken = invocation.getArgument(1);
-            String newRefreshToken = invocation.getArgument(2);
-            return rotateRefreshTokenIfCurrent(userId, expectedRefreshToken, newRefreshToken);
+            Long userId = invocation.getArgument(0);
+            String sessionId = invocation.getArgument(1);
+            String expectedRefreshToken = invocation.getArgument(2);
+            String newRefreshToken = invocation.getArgument(3);
+            return rotateRefreshTokenIfCurrent(userId, sessionId, expectedRefreshToken, newRefreshToken);
         }).when(tokenCacheService).compareAndRotateRefreshToken(
+                anyLong(),
                 anyString(),
                 anyString(),
                 anyString(),
@@ -387,6 +479,26 @@ class AuthApiTest extends ApiTestSupport {
                     .toList();
 
             assertThat(statuses).containsExactlyInAnyOrder(200, 401);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void differentSessionsCanRefreshConcurrently() {
+        TestUser user = createUserWithPassword("Pass123!");
+        String firstRefreshToken = appLoginRefreshToken(user);
+        String secondRefreshToken = appLoginRefreshToken(user);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            List<Future<Integer>> responses = List.of(
+                    executor.submit(() -> appRefreshStatus(firstRefreshToken)),
+                    executor.submit(() -> appRefreshStatus(secondRefreshToken))
+            );
+
+            assertThat(responses.stream().map(this::getFutureStatus).toList())
+                    .containsExactlyInAnyOrder(200, 200);
         } finally {
             executor.shutdownNow();
         }
@@ -698,6 +810,12 @@ class AuthApiTest extends ApiTestSupport {
                 .anyMatch(header -> header.startsWith("refreshToken=") && header.contains("HttpOnly"));
     }
 
+    private void assertAppTokenCookieWasSet(ExtractableResponse<Response> response) {
+        assertThat(response.headers().getValues("Set-Cookie"))
+                .anyMatch(header -> header.startsWith("accessToken=") && header.contains("HttpOnly"))
+                .anyMatch(header -> header.startsWith("refreshToken=") && header.contains("Max-Age=0"));
+    }
+
     private String appLoginRefreshToken(TestUser user) {
         return given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -719,6 +837,18 @@ class AuthApiTest extends ApiTestSupport {
                 .then()
                 .extract()
                 .statusCode();
+    }
+
+    private String refreshAppToken(String refreshToken) {
+        return given()
+                .header("X-Refresh-Token", refreshToken)
+                .when()
+                .post("/api/v1/auth/app/refresh")
+                .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+                .getString("result.refreshToken");
     }
 
     private int getFutureStatus(Future<Integer> future) {

--- a/src/test/java/checkmo/authentication/AuthApiTest.java
+++ b/src/test/java/checkmo/authentication/AuthApiTest.java
@@ -674,14 +674,7 @@ class AuthApiTest extends ApiTestSupport {
     @Test
     void appLogoutInvalidatesHeaderOnlyRefreshToken() {
         TestUser user = createUserWithPassword("Pass123!");
-        ExtractableResponse<Response> loginResponse = given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(Map.of("identifier", user.email(), "password", "Pass123!"))
-                .when()
-                .post("/api/v1/auth/app/login")
-                .then()
-                .statusCode(200)
-                .extract();
+        ExtractableResponse<Response> loginResponse = appLogin(user);
         String refreshToken = loginResponse.jsonPath().getString("result.refreshToken");
 
         given()
@@ -698,6 +691,67 @@ class AuthApiTest extends ApiTestSupport {
                 .then()
                 .statusCode(401)
                 .body("isSuccess", equalTo(false));
+    }
+
+    @Test
+    void appLogoutBlacklistsAccessTokenFromMatchingSession() {
+        TestUser user = createUserWithPassword("Pass123!");
+        ExtractableResponse<Response> loginResponse = appLogin(user);
+        String accessToken = loginResponse.cookie("accessToken");
+        String refreshToken = loginResponse.jsonPath().getString("result.refreshToken");
+
+        given()
+                .header("X-Refresh-Token", refreshToken)
+                .cookie("accessToken", accessToken)
+                .when()
+                .post("/api/v1/auth/app/logout")
+                .then()
+                .statusCode(200);
+
+        verify(tokenCacheService).saveBlacklistToken(accessToken);
+    }
+
+    @Test
+    void appLogoutDoesNotBlacklistAccessTokenFromAnotherSessionOfSameMember() {
+        TestUser user = createUserWithPassword("Pass123!");
+        ExtractableResponse<Response> firstLoginResponse = appLogin(user);
+        ExtractableResponse<Response> secondLoginResponse = appLogin(user);
+        String firstRefreshToken = firstLoginResponse.jsonPath().getString("result.refreshToken");
+        String secondAccessToken = secondLoginResponse.cookie("accessToken");
+        String secondRefreshToken = secondLoginResponse.jsonPath().getString("result.refreshToken");
+
+        given()
+                .header("X-Refresh-Token", firstRefreshToken)
+                .cookie("accessToken", secondAccessToken)
+                .when()
+                .post("/api/v1/auth/app/logout")
+                .then()
+                .statusCode(200);
+
+        verify(tokenCacheService, never()).saveBlacklistToken(secondAccessToken);
+        assertSoftly(softly -> {
+            softly.assertThat(appRefreshStatus(firstRefreshToken)).isEqualTo(401);
+            softly.assertThat(appRefreshStatus(secondRefreshToken)).isEqualTo(200);
+        });
+    }
+
+    @Test
+    void appLogoutKeepsSidlessLegacyTokenCompatibility() {
+        TestUser user = createUserWithPassword("Pass123!");
+        String legacyAccessToken = signedAccessTokenWithSubject(user.id());
+        String legacyRefreshToken = signedRefreshTokenWithSubject(user.id());
+        saveRefreshTokenInCacheFake(user.id(), legacyRefreshToken);
+
+        given()
+                .header("X-Refresh-Token", legacyRefreshToken)
+                .cookie("accessToken", legacyAccessToken)
+                .when()
+                .post("/api/v1/auth/app/logout")
+                .then()
+                .statusCode(200);
+
+        verify(tokenCacheService).saveBlacklistToken(legacyAccessToken);
+        assertThat(appRefreshStatus(legacyRefreshToken)).isEqualTo(401);
     }
 
     @Test
@@ -817,6 +871,12 @@ class AuthApiTest extends ApiTestSupport {
     }
 
     private String appLoginRefreshToken(TestUser user) {
+        return appLogin(user)
+                .jsonPath()
+                .getString("result.refreshToken");
+    }
+
+    private ExtractableResponse<Response> appLogin(TestUser user) {
         return given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(Map.of("identifier", user.email(), "password", "Pass123!"))
@@ -824,9 +884,7 @@ class AuthApiTest extends ApiTestSupport {
                 .post("/api/v1/auth/app/login")
                 .then()
                 .statusCode(200)
-                .extract()
-                .jsonPath()
-                .getString("result.refreshToken");
+                .extract();
     }
 
     private int appRefreshStatus(String refreshToken) {

--- a/src/test/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/jwt/AppRefreshTokenAuthenticationServiceTest.java
@@ -52,7 +52,8 @@ class AppRefreshTokenAuthenticationServiceTest {
     void mismatchedStoredTokenDoesNotAuthenticate() {
         when(jwtTokenProvider.isRefreshTokenValid("refresh-token")).thenReturn(true);
         when(jwtTokenProvider.getUserIdFromToken("refresh-token")).thenReturn(7L);
-        when(tokenCacheService.getRefreshToken(7L)).thenReturn("other-token");
+        when(jwtTokenProvider.getSessionIdFromToken("refresh-token")).thenReturn("session-1");
+        when(tokenCacheService.getRefreshToken(7L, "session-1")).thenReturn("other-token");
 
         Optional<Authentication> result = authenticationService.authenticate("refresh-token");
 
@@ -75,7 +76,8 @@ class AppRefreshTokenAuthenticationServiceTest {
     void matchingStoredTokenAuthenticatesWithoutRotation() {
         when(jwtTokenProvider.isRefreshTokenValid("refresh-token")).thenReturn(true);
         when(jwtTokenProvider.getUserIdFromToken("refresh-token")).thenReturn(7L);
-        when(tokenCacheService.getRefreshToken(7L)).thenReturn("refresh-token");
+        when(jwtTokenProvider.getSessionIdFromToken("refresh-token")).thenReturn("session-1");
+        when(tokenCacheService.getRefreshToken(7L, "session-1")).thenReturn("refresh-token");
         when(jwtTokenProvider.getAuthenticationFromMemberId(7L)).thenReturn(authentication);
 
         Optional<Authentication> result = authenticationService.authenticate("refresh-token");
@@ -83,6 +85,7 @@ class AppRefreshTokenAuthenticationServiceTest {
         assertThat(result).containsSame(authentication);
         verify(tokenCacheService, never()).compareAndRotateRefreshToken(
                 org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyString(),
                 org.mockito.ArgumentMatchers.anyString(),
                 org.mockito.ArgumentMatchers.anyString(),
                 org.mockito.ArgumentMatchers.any()

--- a/src/test/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImplTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImplTest.java
@@ -55,6 +55,10 @@ class JwtTokenProviderImplTest {
                     .isEqualTo(first.getSessionId());
             softly.assertThat(jwtTokenProvider.getSessionIdFromToken(first.getRefreshToken()))
                     .isEqualTo(first.getSessionId());
+            softly.assertThat(jwtTokenProvider.getExplicitSessionIdFromToken(first.getAccessToken()))
+                    .contains(first.getSessionId());
+            softly.assertThat(jwtTokenProvider.getExplicitSessionIdFromToken(first.getRefreshToken()))
+                    .contains(first.getSessionId());
             softly.assertThat(second.getSessionId()).isNotEqualTo(first.getSessionId());
         });
     }
@@ -82,7 +86,11 @@ class JwtTokenProviderImplTest {
                 .signWith(secretKey)
                 .compact();
 
-        assertThat(jwtTokenProvider.getSessionIdFromToken(legacyToken))
-                .isEqualTo("legacy-token-id");
+        assertSoftly(softly -> {
+            softly.assertThat(jwtTokenProvider.getSessionIdFromToken(legacyToken))
+                    .isEqualTo("legacy-token-id");
+            softly.assertThat(jwtTokenProvider.getExplicitSessionIdFromToken(legacyToken))
+                    .isEmpty();
+        });
     }
 }

--- a/src/test/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImplTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/jwt/JwtTokenProviderImplTest.java
@@ -1,0 +1,88 @@
+package checkmo.authentication.internal.security.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.mock;
+
+import checkmo.authentication.internal.config.properties.JwtProperties;
+import checkmo.authentication.internal.security.auth.CustomUserDetailsService;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+class JwtTokenProviderImplTest {
+
+    private static final String RAW_SECRET = "checkmo-session-test-secret-32bytes";
+
+    private JwtTokenProviderImpl jwtTokenProvider;
+    private Authentication authentication;
+    private SecretKey secretKey;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties properties = new JwtProperties();
+        JwtProperties.TokenValidity tokenValidity = new JwtProperties.TokenValidity();
+        tokenValidity.setAccessToken(7_200_000L);
+        tokenValidity.setRefreshToken(2_592_000_000L);
+        properties.setTokenValidity(tokenValidity);
+
+        byte[] secretBytes = RAW_SECRET.getBytes(StandardCharsets.UTF_8);
+        properties.setSecret(Encoders.BASE64.encode(secretBytes));
+        secretKey = Keys.hmacShaKeyFor(secretBytes);
+
+        jwtTokenProvider = new JwtTokenProviderImpl(
+                properties,
+                mock(CustomUserDetailsService.class)
+        );
+        authentication = new TestingAuthenticationToken("7", null, "ROLE_USER");
+    }
+
+    @Test
+    void newLoginCreatesIndependentSessionSharedByAccessAndRefreshTokens() {
+        JwtToken first = jwtTokenProvider.generateToken(authentication);
+        JwtToken second = jwtTokenProvider.generateToken(authentication);
+
+        assertSoftly(softly -> {
+            softly.assertThat(first.getSessionId()).isNotBlank();
+            softly.assertThat(jwtTokenProvider.getSessionIdFromToken(first.getAccessToken()))
+                    .isEqualTo(first.getSessionId());
+            softly.assertThat(jwtTokenProvider.getSessionIdFromToken(first.getRefreshToken()))
+                    .isEqualTo(first.getSessionId());
+            softly.assertThat(second.getSessionId()).isNotEqualTo(first.getSessionId());
+        });
+    }
+
+    @Test
+    void refreshRotationKeepsSessionIdWhileReplacingTokenPair() {
+        JwtToken original = jwtTokenProvider.generateToken(authentication);
+        JwtToken rotated = jwtTokenProvider.generateToken(authentication, original.getSessionId());
+
+        assertSoftly(softly -> {
+            softly.assertThat(rotated.getSessionId()).isEqualTo(original.getSessionId());
+            softly.assertThat(rotated.getAccessToken()).isNotEqualTo(original.getAccessToken());
+            softly.assertThat(rotated.getRefreshToken()).isNotEqualTo(original.getRefreshToken());
+            softly.assertThat(jwtTokenProvider.getSessionIdFromToken(rotated.getRefreshToken()))
+                    .isEqualTo(original.getSessionId());
+        });
+    }
+
+    @Test
+    void legacyRefreshTokenUsesTokenIdAsSessionId() {
+        String legacyToken = Jwts.builder()
+                .id("legacy-token-id")
+                .subject("7")
+                .expiration(new Date(System.currentTimeMillis() + 60_000L))
+                .signWith(secretKey)
+                .compact();
+
+        assertThat(jwtTokenProvider.getSessionIdFromToken(legacyToken))
+                .isEqualTo("legacy-token-id");
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/jwt/TokenCacheServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/jwt/TokenCacheServiceTest.java
@@ -61,13 +61,20 @@ class TokenCacheServiceTest {
 
             Object result = callback.doInRedis(connection);
 
+            ArgumentCaptor<byte[]> scriptCaptor = ArgumentCaptor.forClass(byte[].class);
             ArgumentCaptor<byte[][]> keysAndArgsCaptor = ArgumentCaptor.forClass(byte[][].class);
             verify(scriptingCommands).eval(
-                    any(byte[].class),
+                    scriptCaptor.capture(),
                     org.mockito.ArgumentMatchers.eq(ReturnType.INTEGER),
                     org.mockito.ArgumentMatchers.eq(3),
                     keysAndArgsCaptor.capture()
             );
+            String script = new String(scriptCaptor.getValue(), StandardCharsets.UTF_8);
+            assertThat(script)
+                    .contains("if redis.call('EXISTS', sessionKey) == 0 then")
+                    .contains("redis.call('SREM', sessionIndexKey, sessionKey)");
+            assertThat(occurrencesOf(script, "pruneMissingSessionKeys(KEYS[3])"))
+                    .isEqualTo(2);
             byte[][] keysAndArgs = keysAndArgsCaptor.getValue();
             assertThat(Arrays.stream(keysAndArgs)
                     .map(value -> new String(value, StandardCharsets.UTF_8))
@@ -156,13 +163,21 @@ class TokenCacheServiceTest {
 
             Object result = callback.doInRedis(connection);
 
+            ArgumentCaptor<byte[]> scriptCaptor = ArgumentCaptor.forClass(byte[].class);
             ArgumentCaptor<byte[][]> keysAndArgsCaptor = ArgumentCaptor.forClass(byte[][].class);
             verify(scriptingCommands).eval(
-                    any(byte[].class),
+                    scriptCaptor.capture(),
                     org.mockito.ArgumentMatchers.eq(ReturnType.INTEGER),
                     org.mockito.ArgumentMatchers.eq(3),
                     keysAndArgsCaptor.capture()
             );
+            String script = new String(scriptCaptor.getValue(), StandardCharsets.UTF_8);
+            assertThat(script)
+                    .contains("if redis.call('EXISTS', sessionKey) == 0 then")
+                    .contains("redis.call('SREM', sessionIndexKey, sessionKey)")
+                    .doesNotContain("PEXPIRE");
+            assertThat(occurrencesOf(script, "cleanupSessionIndex(KEYS[3])"))
+                    .isEqualTo(2);
             byte[][] keysAndArgs = keysAndArgsCaptor.getValue();
             assertThat(new String(keysAndArgs[0], StandardCharsets.UTF_8))
                     .isEqualTo("refreshToken::member-1::session-1");
@@ -237,13 +252,23 @@ class TokenCacheServiceTest {
 
             Object result = callback.doInRedis(connection);
 
+            ArgumentCaptor<byte[]> scriptCaptor = ArgumentCaptor.forClass(byte[].class);
             ArgumentCaptor<byte[][]> keysAndArgsCaptor = ArgumentCaptor.forClass(byte[][].class);
             verify(scriptingCommands).eval(
-                    any(byte[].class),
+                    scriptCaptor.capture(),
                     org.mockito.ArgumentMatchers.eq(ReturnType.INTEGER),
                     org.mockito.ArgumentMatchers.eq(2),
                     keysAndArgsCaptor.capture()
             );
+            String script = new String(scriptCaptor.getValue(), StandardCharsets.UTF_8);
+            assertThat(script)
+                    .contains("if redis.call('EXISTS', sessionKey) == 0 then")
+                    .contains("redis.call('SREM', sessionIndexKey, sessionKey)")
+                    .containsSubsequence(
+                            "redis.call('SADD', KEYS[2], KEYS[1])",
+                            "pruneMissingSessionKeys(KEYS[2])",
+                            "redis.call('PEXPIRE', KEYS[2], ARGV[2])"
+                    );
             assertThat(Arrays.stream(keysAndArgsCaptor.getValue())
                     .map(value -> new String(value, StandardCharsets.UTF_8))
                     .toList())
@@ -257,6 +282,16 @@ class TokenCacheServiceTest {
         });
 
         tokenCacheService.saveRefreshToken("member-1", "session-1", "refresh-token");
+    }
+
+    private int occurrencesOf(String text, String fragment) {
+        int count = 0;
+        int index = 0;
+        while ((index = text.indexOf(fragment, index)) >= 0) {
+            count++;
+            index += fragment.length();
+        }
+        return count;
     }
 
     @Test

--- a/src/test/java/checkmo/authentication/internal/security/jwt/TokenCacheServiceTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/jwt/TokenCacheServiceTest.java
@@ -14,7 +14,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import checkmo.authentication.internal.config.properties.JwtProperties;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -63,7 +65,7 @@ class TokenCacheServiceTest {
             verify(scriptingCommands).eval(
                     any(byte[].class),
                     org.mockito.ArgumentMatchers.eq(ReturnType.INTEGER),
-                    org.mockito.ArgumentMatchers.eq(1),
+                    org.mockito.ArgumentMatchers.eq(3),
                     keysAndArgsCaptor.capture()
             );
             byte[][] keysAndArgs = keysAndArgsCaptor.getValue();
@@ -71,7 +73,9 @@ class TokenCacheServiceTest {
                     .map(value -> new String(value, StandardCharsets.UTF_8))
                     .toList())
                     .containsExactly(
+                            "refreshToken::member-1::session-1",
                             "refreshToken::member-1",
+                            "refreshTokenSessions::member-1",
                             "old-token",
                             new String(legacySerializer.serialize("old-token"), StandardCharsets.UTF_8),
                             "new-token",
@@ -82,6 +86,7 @@ class TokenCacheServiceTest {
 
         boolean rotated = tokenCacheService.compareAndRotateRefreshToken(
                 "member-1",
+                "session-1",
                 "old-token",
                 "new-token",
                 Duration.ofMillis(1_234L)
@@ -113,16 +118,17 @@ class TokenCacheServiceTest {
             verify(scriptingCommands).eval(
                     any(byte[].class),
                     org.mockito.ArgumentMatchers.eq(ReturnType.INTEGER),
-                    org.mockito.ArgumentMatchers.eq(1),
+                    org.mockito.ArgumentMatchers.eq(3),
                     keysAndArgsCaptor.capture()
             );
-            assertThat(keysAndArgsCaptor.getValue()[2])
+            assertThat(keysAndArgsCaptor.getValue()[4])
                     .isEqualTo(legacySerializer.serialize("old-token"));
             return result;
         });
 
         boolean rotated = tokenCacheService.compareAndRotateRefreshToken(
                 "member-1",
+                "session-1",
                 "old-token",
                 "new-token",
                 Duration.ofMillis(1_234L)
@@ -154,20 +160,28 @@ class TokenCacheServiceTest {
             verify(scriptingCommands).eval(
                     any(byte[].class),
                     org.mockito.ArgumentMatchers.eq(ReturnType.INTEGER),
-                    org.mockito.ArgumentMatchers.eq(1),
+                    org.mockito.ArgumentMatchers.eq(3),
                     keysAndArgsCaptor.capture()
             );
             byte[][] keysAndArgs = keysAndArgsCaptor.getValue();
             assertThat(new String(keysAndArgs[0], StandardCharsets.UTF_8))
+                    .isEqualTo("refreshToken::member-1::session-1");
+            assertThat(new String(keysAndArgs[1], StandardCharsets.UTF_8))
                     .isEqualTo("refreshToken::member-1");
-            assertThat(keysAndArgs[1])
+            assertThat(new String(keysAndArgs[2], StandardCharsets.UTF_8))
+                    .isEqualTo("refreshTokenSessions::member-1");
+            assertThat(keysAndArgs[3])
                     .isEqualTo("old-token".getBytes(StandardCharsets.UTF_8));
-            assertThat(keysAndArgs[2])
+            assertThat(keysAndArgs[4])
                     .isEqualTo(legacySerializer.serialize("old-token"));
             return result;
         });
 
-        boolean deleted = tokenCacheService.deleteRefreshTokenIfMatches("member-1", "old-token");
+        boolean deleted = tokenCacheService.deleteRefreshTokenIfMatches(
+                "member-1",
+                "session-1",
+                "old-token"
+        );
 
         assertThat(deleted).isTrue();
     }
@@ -177,13 +191,18 @@ class TokenCacheServiceTest {
         tokenCacheService = tokenCacheServiceWithRefreshTtl(1_234L);
         RedisSerializer<Object> legacySerializer = legacyValueSerializer();
         doReturn(legacySerializer).when(redisTemplate).getValueSerializer();
+        List<String> requestedKeys = new ArrayList<>();
 
         when(redisTemplate.execute(any(RedisCallback.class))).thenAnswer(invocation -> {
             RedisCallback<?> callback = invocation.getArgument(0);
             RedisConnection connection = mock(RedisConnection.class);
             RedisStringCommands stringCommands = mock(RedisStringCommands.class, getInvocation -> {
                 if ("get".equals(getInvocation.getMethod().getName())) {
-                    return legacySerializer.serialize("old-token");
+                    String key = new String(getInvocation.getArgument(0), StandardCharsets.UTF_8);
+                    requestedKeys.add(key);
+                    return key.endsWith("::session-1")
+                            ? null
+                            : legacySerializer.serialize("old-token");
                 }
                 return org.mockito.Mockito.RETURNS_DEFAULTS.answer(getInvocation);
             });
@@ -192,47 +211,89 @@ class TokenCacheServiceTest {
             return callback.doInRedis(connection);
         });
 
-        String refreshToken = tokenCacheService.getRefreshToken("member-1");
+        String refreshToken = tokenCacheService.getRefreshToken("member-1", "session-1");
 
         assertThat(refreshToken).isEqualTo("old-token");
+        assertThat(requestedKeys).containsExactly(
+                "refreshToken::member-1::session-1",
+                "refreshToken::member-1"
+        );
     }
 
     @Test
-    void saveRefreshTokenUsesRawStringValueWithMillisecondTtl() {
+    void saveRefreshTokenUsesSessionKeyAndMillisecondTtl() {
         tokenCacheService = tokenCacheServiceWithRefreshTtl(5_678L);
 
         when(redisTemplate.execute(any(RedisCallback.class))).thenAnswer(invocation -> {
             RedisCallback<?> callback = invocation.getArgument(0);
             RedisConnection connection = mock(RedisConnection.class);
-            RedisStringCommands stringCommands = mock(RedisStringCommands.class, setInvocation -> {
-                if ("set".equals(setInvocation.getMethod().getName())) {
-                    return true;
+            RedisScriptingCommands scriptingCommands = mock(RedisScriptingCommands.class, evalInvocation -> {
+                if ("eval".equals(evalInvocation.getMethod().getName())) {
+                    return 1L;
                 }
-                return org.mockito.Mockito.RETURNS_DEFAULTS.answer(setInvocation);
+                return org.mockito.Mockito.RETURNS_DEFAULTS.answer(evalInvocation);
             });
-            when(connection.stringCommands()).thenReturn(stringCommands);
+            when(connection.scriptingCommands()).thenReturn(scriptingCommands);
 
             Object result = callback.doInRedis(connection);
 
-            ArgumentCaptor<byte[]> keyCaptor = ArgumentCaptor.forClass(byte[].class);
-            ArgumentCaptor<byte[]> valueCaptor = ArgumentCaptor.forClass(byte[].class);
-            ArgumentCaptor<Expiration> expirationCaptor = ArgumentCaptor.forClass(Expiration.class);
-            verify(stringCommands).set(
-                    keyCaptor.capture(),
-                    valueCaptor.capture(),
-                    expirationCaptor.capture(),
-                    org.mockito.ArgumentMatchers.eq(RedisStringCommands.SetOption.upsert())
+            ArgumentCaptor<byte[][]> keysAndArgsCaptor = ArgumentCaptor.forClass(byte[][].class);
+            verify(scriptingCommands).eval(
+                    any(byte[].class),
+                    org.mockito.ArgumentMatchers.eq(ReturnType.INTEGER),
+                    org.mockito.ArgumentMatchers.eq(2),
+                    keysAndArgsCaptor.capture()
             );
-            assertThat(new String(keyCaptor.getValue(), StandardCharsets.UTF_8))
-                    .isEqualTo("refreshToken::member-1");
-            assertThat(new String(valueCaptor.getValue(), StandardCharsets.UTF_8))
-                    .isEqualTo("refresh-token");
-            assertThat(expirationCaptor.getValue().getExpirationTimeInMilliseconds())
-                    .isEqualTo(5_678L);
+            assertThat(Arrays.stream(keysAndArgsCaptor.getValue())
+                    .map(value -> new String(value, StandardCharsets.UTF_8))
+                    .toList())
+                    .containsExactly(
+                            "refreshToken::member-1::session-1",
+                            "refreshTokenSessions::member-1",
+                            "refresh-token",
+                            "5678"
+                    );
             return result;
         });
 
-        tokenCacheService.saveRefreshToken("member-1", "refresh-token");
+        tokenCacheService.saveRefreshToken("member-1", "session-1", "refresh-token");
+    }
+
+    @Test
+    void deleteRefreshTokenDeletesSessionIndexAndLegacyKey() {
+        tokenCacheService = tokenCacheServiceWithRefreshTtl(5_678L);
+
+        when(redisTemplate.execute(any(RedisCallback.class))).thenAnswer(invocation -> {
+            RedisCallback<?> callback = invocation.getArgument(0);
+            RedisConnection connection = mock(RedisConnection.class);
+            RedisScriptingCommands scriptingCommands = mock(RedisScriptingCommands.class, evalInvocation -> {
+                if ("eval".equals(evalInvocation.getMethod().getName())) {
+                    return 2L;
+                }
+                return org.mockito.Mockito.RETURNS_DEFAULTS.answer(evalInvocation);
+            });
+            when(connection.scriptingCommands()).thenReturn(scriptingCommands);
+
+            Object result = callback.doInRedis(connection);
+
+            ArgumentCaptor<byte[][]> keysCaptor = ArgumentCaptor.forClass(byte[][].class);
+            verify(scriptingCommands).eval(
+                    any(byte[].class),
+                    org.mockito.ArgumentMatchers.eq(ReturnType.INTEGER),
+                    org.mockito.ArgumentMatchers.eq(2),
+                    keysCaptor.capture()
+            );
+            assertThat(Arrays.stream(keysCaptor.getValue())
+                    .map(value -> new String(value, StandardCharsets.UTF_8))
+                    .toList())
+                    .containsExactly(
+                            "refreshTokenSessions::member-1",
+                            "refreshToken::member-1"
+                    );
+            return result;
+        });
+
+        tokenCacheService.deleteRefreshToken("member-1");
     }
 
     @Test

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
@@ -67,6 +67,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         when(jwtTokenProvider.generateToken(authentication)).thenReturn(JwtToken.builder()
+                .sessionId("session-1")
                 .accessToken("access-token")
                 .refreshToken("refresh-token")
                 .build());
@@ -88,7 +89,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
                             && header.contains("SameSite=None"));
         });
         verify(authReactivationCommandService).reactivateIfDeactivated(1L);
-        verify(tokenCacheService).saveRefreshToken(1L, "refresh-token");
+        verify(tokenCacheService).saveRefreshToken(1L, "session-1", "refresh-token");
     }
 
     @Test
@@ -120,6 +121,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         when(jwtTokenProvider.generateToken(authentication)).thenReturn(JwtToken.builder()
+                .sessionId("session-2")
                 .accessToken("access-token")
                 .refreshToken("refresh-token")
                 .build());
@@ -141,6 +143,6 @@ class OAuth2AuthenticationSuccessHandlerTest {
             softly.assertThat(codeCaptor.getValue()).isNotBlank();
         });
         verify(authReactivationCommandService).reactivateIfDeactivated(2L);
-        verify(tokenCacheService).saveRefreshToken(2L, "refresh-token");
+        verify(tokenCacheService).saveRefreshToken(2L, "session-2", "refresh-token");
     }
 }

--- a/src/test/java/checkmo/support/ApiTestSupport.java
+++ b/src/test/java/checkmo/support/ApiTestSupport.java
@@ -113,7 +113,7 @@ public abstract class ApiTestSupport {
     protected HashOperations<String, Object, Object> redisHashOperations;
     protected ValueOperations<String, String> stringRedisValueOperations;
     private final Map<String, Cache> testCaches = new ConcurrentHashMap<>();
-    private final Map<String, String> refreshTokensByUserId = new ConcurrentHashMap<>();
+    private final Map<String, String> refreshTokensBySession = new ConcurrentHashMap<>();
 
     @BeforeEach
     void setUpApiTestSupport() {
@@ -123,7 +123,7 @@ public abstract class ApiTestSupport {
         redisValueOperations = mock();
         redisHashOperations = mock();
         stringRedisValueOperations = mock();
-        refreshTokensByUserId.clear();
+        refreshTokensBySession.clear();
 
         when(redisTemplate.opsForValue()).thenReturn(redisValueOperations);
         when(redisTemplate.opsForHash()).thenReturn(redisHashOperations);
@@ -171,19 +171,32 @@ public abstract class ApiTestSupport {
         });
 
         when(tokenCacheService.isAccessTokenBlacklisted(anyString())).thenReturn(false);
-        when(tokenCacheService.getRefreshToken(anyString()))
-                .thenAnswer(invocation -> refreshTokensByUserId.get(refreshTokenKey(invocation.getArgument(0))));
-        when(tokenCacheService.getRefreshToken(anyLong()))
-                .thenAnswer(invocation -> refreshTokensByUserId.get(refreshTokenKey(invocation.getArgument(0))));
+        when(tokenCacheService.getRefreshToken(anyString(), anyString()))
+                .thenAnswer(invocation -> refreshTokensBySession.get(refreshTokenKey(
+                        invocation.getArgument(0),
+                        invocation.getArgument(1)
+                )));
+        when(tokenCacheService.getRefreshToken(anyLong(), anyString()))
+                .thenAnswer(invocation -> refreshTokensBySession.get(refreshTokenKey(
+                        invocation.getArgument(0),
+                        invocation.getArgument(1)
+                )));
         doAnswer(invocation -> {
-            refreshTokensByUserId.put(refreshTokenKey(invocation.getArgument(0)), invocation.getArgument(1));
+            refreshTokensBySession.put(
+                    refreshTokenKey(invocation.getArgument(0), invocation.getArgument(1)),
+                    invocation.getArgument(2)
+            );
             return null;
-        }).when(tokenCacheService).saveRefreshToken(anyString(), anyString());
+        }).when(tokenCacheService).saveRefreshToken(anyString(), anyString(), anyString());
         doAnswer(invocation -> {
-            refreshTokensByUserId.put(refreshTokenKey(invocation.getArgument(0)), invocation.getArgument(1));
+            refreshTokensBySession.put(
+                    refreshTokenKey(invocation.getArgument(0), invocation.getArgument(1)),
+                    invocation.getArgument(2)
+            );
             return null;
-        }).when(tokenCacheService).saveRefreshToken(anyLong(), anyString());
+        }).when(tokenCacheService).saveRefreshToken(anyLong(), anyString(), anyString());
         when(tokenCacheService.compareAndRotateRefreshToken(
+                anyString(),
                 anyString(),
                 anyString(),
                 anyString(),
@@ -192,32 +205,43 @@ public abstract class ApiTestSupport {
                 .thenAnswer(invocation -> rotateRefreshTokenIfCurrent(
                         invocation.getArgument(0),
                         invocation.getArgument(1),
-                        invocation.getArgument(2)
+                        invocation.getArgument(2),
+                        invocation.getArgument(3)
                 ));
         when(tokenCacheService.compareAndRotateRefreshToken(
                 anyLong(),
                 anyString(),
                 anyString(),
+                anyString(),
                 org.mockito.ArgumentMatchers.any(Duration.class)
         ))
                 .thenAnswer(invocation -> rotateRefreshTokenIfCurrent(
                         invocation.getArgument(0),
                         invocation.getArgument(1),
-                        invocation.getArgument(2)
+                        invocation.getArgument(2),
+                        invocation.getArgument(3)
                 ));
         when(tokenCacheService.saveBlacklistToken(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
         doAnswer(invocation -> {
-            refreshTokensByUserId.remove(refreshTokenKey(invocation.getArgument(0)));
+            deleteAllRefreshTokens(invocation.getArgument(0));
             return null;
         }).when(tokenCacheService).deleteRefreshToken(anyString());
         doAnswer(invocation -> {
-            refreshTokensByUserId.remove(refreshTokenKey(invocation.getArgument(0)));
+            deleteAllRefreshTokens(invocation.getArgument(0));
             return null;
         }).when(tokenCacheService).deleteRefreshToken(anyLong());
-        when(tokenCacheService.deleteRefreshTokenIfMatches(anyString(), anyString()))
-                .thenAnswer(invocation -> deleteRefreshTokenIfCurrent(invocation.getArgument(0), invocation.getArgument(1)));
-        when(tokenCacheService.deleteRefreshTokenIfMatches(anyLong(), anyString()))
-                .thenAnswer(invocation -> deleteRefreshTokenIfCurrent(invocation.getArgument(0), invocation.getArgument(1)));
+        when(tokenCacheService.deleteRefreshTokenIfMatches(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> deleteRefreshTokenIfCurrent(
+                        invocation.getArgument(0),
+                        invocation.getArgument(1),
+                        invocation.getArgument(2)
+                ));
+        when(tokenCacheService.deleteRefreshTokenIfMatches(anyLong(), anyString(), anyString()))
+                .thenAnswer(invocation -> deleteRefreshTokenIfCurrent(
+                        invocation.getArgument(0),
+                        invocation.getArgument(1),
+                        invocation.getArgument(2)
+                ));
     }
 
     @AfterEach
@@ -347,16 +371,18 @@ public abstract class ApiTestSupport {
     }
 
     protected void saveRefreshTokenInCacheFake(String userId, String refreshToken) {
-        refreshTokensByUserId.put(refreshTokenKey(userId), refreshToken);
+        String sessionId = jwtTokenProvider.getSessionIdFromToken(refreshToken);
+        refreshTokensBySession.put(refreshTokenKey(userId, sessionId), refreshToken);
     }
 
     protected boolean rotateRefreshTokenIfCurrent(
             Object userId,
+            String sessionId,
             String expectedRefreshToken,
             String newRefreshToken
     ) {
         AtomicBoolean rotated = new AtomicBoolean(false);
-        refreshTokensByUserId.compute(refreshTokenKey(userId), (ignored, currentRefreshToken) -> {
+        refreshTokensBySession.compute(refreshTokenKey(userId, sessionId), (ignored, currentRefreshToken) -> {
             if (expectedRefreshToken.equals(currentRefreshToken)) {
                 rotated.set(true);
                 return newRefreshToken;
@@ -366,9 +392,13 @@ public abstract class ApiTestSupport {
         return rotated.get();
     }
 
-    private boolean deleteRefreshTokenIfCurrent(Object userId, String expectedRefreshToken) {
+    private boolean deleteRefreshTokenIfCurrent(
+            Object userId,
+            String sessionId,
+            String expectedRefreshToken
+    ) {
         AtomicBoolean deleted = new AtomicBoolean(false);
-        refreshTokensByUserId.compute(refreshTokenKey(userId), (ignored, currentRefreshToken) -> {
+        refreshTokensBySession.compute(refreshTokenKey(userId, sessionId), (ignored, currentRefreshToken) -> {
             if (expectedRefreshToken.equals(currentRefreshToken)) {
                 deleted.set(true);
                 return null;
@@ -378,8 +408,13 @@ public abstract class ApiTestSupport {
         return deleted.get();
     }
 
-    private String refreshTokenKey(Object userId) {
-        return String.valueOf(userId);
+    private void deleteAllRefreshTokens(Object userId) {
+        String prefix = String.valueOf(userId) + "::";
+        refreshTokensBySession.keySet().removeIf(key -> key.startsWith(prefix));
+    }
+
+    private String refreshTokenKey(Object userId, Object sessionId) {
+        return userId + "::" + sessionId;
     }
 
     protected record TestUser(


### PR DESCRIPTION
## 문제

기존에는 Refresh Token을 회원별 단일 Redis 키(`refreshToken::{memberId}`)에 저장했습니다.

이로 인해 앱·웹·다른 기기에서 새로 로그인하면 기존 Refresh Token이 덮어써졌고, 기존 기기는 Access Token 만료 시점(최대 2시간)에 토큰 갱신이 실패하면서 로그아웃되는 문제가 있었습니다.

또한 앱에서는 Refresh Token을 SecureStore와 쿠키가 각각 갱신할 수 있어 토큰 상태가 불일치할 가능성이 있었습니다.

## 변경 사항

- JWT에 세션 식별자 `sid` 클레임 추가
- 로그인할 때마다 독립적인 세션 ID 발급
- Access Token과 Refresh Token이 동일한 세션 ID를 공유하도록 변경
- 토큰 갱신 시 세션 ID는 유지하고 토큰만 회전
- Refresh Token을 회원별이 아닌 세션별로 Redis에 저장
  - `refreshToken::{memberId}::{sessionId}`
- 회원의 전체 세션을 관리하는 Redis 인덱스 추가
  - `refreshTokenSessions::{memberId}`
- Lua Script를 이용해 토큰 저장·회전·삭제를 원자적으로 처리
- 앱과 웹, 여러 기기의 세션이 서로 영향을 주지 않도록 변경
- 로그아웃 시 현재 세션만 폐기
- 회원 탈퇴·비활성화 시 해당 회원의 전체 세션 폐기
- 앱 로그인 및 갱신 응답에서는 Refresh Token 쿠키를 제거하고 응답 Body만 사용
- 웹은 기존과 동일하게 HttpOnly 쿠키 기반 토큰 갱신 유지
- WebSocket 인증도 회원 및 세션 단위로 검증
- 기존 `sid` 없는 토큰과 Redis 데이터는 최초 갱신 시 지연 마이그레이션

## 검증

다음 시나리오를 테스트했습니다.

- 동일 회원의 여러 앱 세션이 각각 독립적으로 토큰 갱신
- 앱과 웹 세션이 서로의 로그인을 무효화하지 않음
- 앱·웹 로그아웃 시 현재 세션만 폐기
- 동일 Refresh Token 동시 갱신 시 한 요청만 성공
- 서로 다른 세션의 동시 갱신은 모두 성공
- 토큰 갱신 이후에도 동일한 `sid` 유지
- 기존 `sid` 없는 Refresh Token 호환 및 마이그레이션
- 회원 탈퇴 시 전체 세션 폐기

### 실행한 검증

- `./gradlew test`
- `./gradlew test --tests checkmo.support.ApiTestInfrastructureTest`
- `git diff --check`

## 배포 시 참고 사항

- API 경로와 기존 응답 필드는 변경하지 않아 현재 RN 코드와 호환됩니다.
- 이미 다른 로그인으로 덮어써진 Refresh Token은 복구할 수 없으므로 해당 기기에서는 한 번 다시 로그인해야 합니다.
- 현재 Redis에 남아 있는 기존 Refresh Token은 최초 갱신 시 새 세션 구조로 마이그레이션됩니다.
- 구버전 서버는 세션별 Redis 키를 인식하지 못하므로 배포 시 기존 인스턴스가 함께 요청을 처리하지 않도록 일괄 교체하거나 드레이닝하는 것을 권장합니다.

Closes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session-aware app authentication, enabling multiple independent app login sessions.
  * App login now follows an app-specific JWT flow and persists refresh tokens per session.
* **Bug Fixes**
  * Logout/deactivation now invalidates the correct refresh token for the targeted session.
  * Refresh-token rotation now operates within the correct session (reducing replay/mismatch issues).
  * App token cookie behavior was refined: refresh token is cleared via cookie expiration while returning the refresh token in the response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->