### PR TITLE
feat(monitoring): Prometheus/Grafana 모니터링 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: "compose.yml,nginx/,.env"
+          source: "compose.yml,nginx/,monitoring/,.env"
           target: "/home/ubuntu/app"
 
       # 6. EC2 접속 및 배포 실행 (SSH)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,20 +44,27 @@ jobs:
             --push .
 
       - name: Create .env file
+        env:
+          ENV_FILE: ${{ secrets.ENV_FILE }}
+          SENTRY_ENABLED: ${{ secrets.SENTRY_ENABLED }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: ${{ secrets.SENTRY_ENVIRONMENT }}
+          SENTRY_TRACES_SAMPLE_RATE: ${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}
+          GRAFANA_ADMIN_USER: ${{ secrets.GRAFANA_ADMIN_USER }}
+          GRAFANA_ADMIN_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+          GRAFANA_PORT: ${{ secrets.GRAFANA_PORT }}
+          GRAFANA_ROOT_URL: ${{ secrets.GRAFANA_ROOT_URL }}
         run: |
-          printf '%s\n' "${{ secrets.ENV_FILE }}" > .env
+          printf '%s\n' "${ENV_FILE}" > .env
           awk '!/^(SENTRY_ENABLED|SENTRY_DSN|SENTRY_ENVIRONMENT|SENTRY_RELEASE|SENTRY_AUTH_TOKEN|SENTRY_TRACES_SAMPLE_RATE|GRAFANA_ADMIN_USER|GRAFANA_ADMIN_PASSWORD|GRAFANA_PORT|GRAFANA_ROOT_URL)=/' .env > .env.tmp
           mv .env.tmp .env
-          printf 'SENTRY_ENABLED=%s\n' "${{ secrets.SENTRY_ENABLED }}" >> .env
-          printf 'SENTRY_DSN=%s\n' "${{ secrets.SENTRY_DSN }}" >> .env
-          printf 'SENTRY_ENVIRONMENT=%s\n' "${{ secrets.SENTRY_ENVIRONMENT }}" >> .env
+          printf 'SENTRY_ENABLED=%s\n' "${SENTRY_ENABLED}" >> .env
+          printf 'SENTRY_DSN=%s\n' "${SENTRY_DSN}" >> .env
+          printf 'SENTRY_ENVIRONMENT=%s\n' "${SENTRY_ENVIRONMENT}" >> .env
           printf 'SENTRY_RELEASE=checkmo-backend@%s\n' "${GITHUB_SHA}" >> .env
-          SENTRY_TRACES_SAMPLE_RATE="${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}"
           printf 'SENTRY_TRACES_SAMPLE_RATE=%s\n' "${SENTRY_TRACES_SAMPLE_RATE:-0.0}" >> .env
-          printf 'GRAFANA_ADMIN_USER=%s\n' "${{ secrets.GRAFANA_ADMIN_USER }}" >> .env
-          printf 'GRAFANA_ADMIN_PASSWORD=%s\n' "${{ secrets.GRAFANA_ADMIN_PASSWORD }}" >> .env
-          GRAFANA_PORT="${{ secrets.GRAFANA_PORT }}"
-          GRAFANA_ROOT_URL="${{ secrets.GRAFANA_ROOT_URL }}"
+          printf 'GRAFANA_ADMIN_USER=%s\n' "${GRAFANA_ADMIN_USER}" >> .env
+          printf 'GRAFANA_ADMIN_PASSWORD=%s\n' "${GRAFANA_ADMIN_PASSWORD}" >> .env
           if [ -n "${GRAFANA_PORT}" ]; then
             printf 'GRAFANA_PORT=%s\n' "${GRAFANA_PORT}" >> .env
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Create .env file
         run: |
           printf '%s\n' "${{ secrets.ENV_FILE }}" > .env
-          awk '!/^(SENTRY_ENABLED|SENTRY_DSN|SENTRY_ENVIRONMENT|SENTRY_RELEASE|SENTRY_AUTH_TOKEN|SENTRY_TRACES_SAMPLE_RATE)=/' .env > .env.tmp
+          awk '!/^(SENTRY_ENABLED|SENTRY_DSN|SENTRY_ENVIRONMENT|SENTRY_RELEASE|SENTRY_AUTH_TOKEN|SENTRY_TRACES_SAMPLE_RATE|GRAFANA_ADMIN_USER|GRAFANA_ADMIN_PASSWORD|GRAFANA_PORT|GRAFANA_ROOT_URL)=/' .env > .env.tmp
           mv .env.tmp .env
           printf 'SENTRY_ENABLED=%s\n' "${{ secrets.SENTRY_ENABLED }}" >> .env
           printf 'SENTRY_DSN=%s\n' "${{ secrets.SENTRY_DSN }}" >> .env
@@ -54,6 +54,16 @@ jobs:
           printf 'SENTRY_RELEASE=checkmo-backend@%s\n' "${GITHUB_SHA}" >> .env
           SENTRY_TRACES_SAMPLE_RATE="${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}"
           printf 'SENTRY_TRACES_SAMPLE_RATE=%s\n' "${SENTRY_TRACES_SAMPLE_RATE:-0.0}" >> .env
+          printf 'GRAFANA_ADMIN_USER=%s\n' "${{ secrets.GRAFANA_ADMIN_USER }}" >> .env
+          printf 'GRAFANA_ADMIN_PASSWORD=%s\n' "${{ secrets.GRAFANA_ADMIN_PASSWORD }}" >> .env
+          GRAFANA_PORT="${{ secrets.GRAFANA_PORT }}"
+          GRAFANA_ROOT_URL="${{ secrets.GRAFANA_ROOT_URL }}"
+          if [ -n "${GRAFANA_PORT}" ]; then
+            printf 'GRAFANA_PORT=%s\n' "${GRAFANA_PORT}" >> .env
+          fi
+          if [ -n "${GRAFANA_ROOT_URL}" ]; then
+            printf 'GRAFANA_ROOT_URL=%s\n' "${GRAFANA_ROOT_URL}" >> .env
+          fi
 
       # 5. 설정 파일 전송 (SCP)
       - name: Copy files to EC2

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
   </a>
 </div>
 
+* **[📊 Prometheus/Grafana 백엔드 모니터링 가이드](./docs/prometheus_grafana_monitoring.md)**
+
 ---
 
 ## 🚀 Deployment Architecture

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'io.sentry:sentry-spring-boot-starter-jakarta:8.43.1'
 
     // ============= 개발 도구 =============

--- a/compose.yml
+++ b/compose.yml
@@ -17,6 +17,44 @@ services:
     networks:
       - app-network
 
+  prometheus:
+    image: prom/prometheus:v3.4.2
+    container_name: checkmo-prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-lifecycle"
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    restart: unless-stopped
+    networks:
+      - app-network
+    depends_on:
+      app:
+        condition: service_healthy
+
+  grafana:
+    image: grafana/grafana-oss:12.0.2
+    container_name: checkmo-grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?GRAFANA_ADMIN_USER is required}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost:3000}
+      TZ: Asia/Seoul
+    ports:
+      - "127.0.0.1:${GRAFANA_PORT:-3000}:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    restart: unless-stopped
+    networks:
+      - app-network
+    depends_on:
+      - prometheus
+
   nginx:
     image: nginx:alpine
     container_name: nginx-proxy
@@ -50,3 +88,7 @@ services:
 networks:
   app-network:
     driver: bridge
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/docs/environment_setup.md
+++ b/docs/environment_setup.md
@@ -7,6 +7,17 @@
 1.  프로젝트 루트 디렉토리에 `.env` 파일을 생성하고 해당 파일에 환경변수들을 추가하기. (`.gitignore`에 등록되어 있어 깃허브에는 따로 올라가지 않음.)
 2.  백엔드 `[Notion 페이지]` -> `[필요한 자료들]` -> `.env` 페이지에 추가한 환경 변수들 업데이트하기.
 
+### 모니터링 환경 변수
+
+운영 compose에서 Grafana를 함께 실행하려면 아래 환경 변수가 필요하다. 값은 `.env` 또는 배포 환경에만 설정하고 저장소에는 커밋하지 않는다.
+
+| 변수 | 설명 |
+| --- | --- |
+| `GRAFANA_ADMIN_USER` | Grafana 관리자 계정 ID |
+| `GRAFANA_ADMIN_PASSWORD` | Grafana 관리자 계정 비밀번호 |
+| `GRAFANA_PORT` | Grafana localhost 바인딩 포트. 생략 시 `3000` |
+| `GRAFANA_ROOT_URL` | Grafana 외부 접근 URL. 생략 시 `http://localhost:3000` |
+
 ## 2. Spring 설정 파일 (application.yml)
 
 새로운 설정 정보(예: `aws`, `oauth`)를 추가할 때는 `application.yml`에 직접 작성하지 않기

--- a/docs/prometheus_grafana_monitoring.md
+++ b/docs/prometheus_grafana_monitoring.md
@@ -29,6 +29,20 @@ ssh ubuntu@<ec2-host>
 cd /home/ubuntu/app
 ```
 
+서버에는 아래가 준비되어 있어야 한다.
+
+| 필요 항목 | 이유 |
+| --- | --- |
+| Docker Engine | `app`, `prometheus`, `grafana`, `nginx` 컨테이너 실행 |
+| Docker Compose plugin | `docker compose up -d` 실행 |
+| AWS CLI | 배포 workflow가 EC2에서 ECR 로그인할 때 사용 |
+| ECR 접근 권한 | 백엔드 앱 이미지를 pull할 때 필요 |
+| Docker Hub 접근 가능 네트워크 | `prom/prometheus`, `grafana/grafana-oss` 이미지를 pull할 때 필요 |
+| `/home/ubuntu/app/monitoring` 디렉토리 | Prometheus/Grafana 설정 파일 마운트 |
+| 충분한 디스크 공간 | Prometheus/Grafana 데이터 volume 저장 |
+
+Prometheus와 Grafana를 서버 OS에 직접 설치할 필요는 없다. Docker Compose가 이미지를 받아서 컨테이너로 실행한다.
+
 Grafana 실행에는 `.env` 또는 배포 환경에 아래 값이 있어야 한다.
 
 ```text

--- a/docs/prometheus_grafana_monitoring.md
+++ b/docs/prometheus_grafana_monitoring.md
@@ -9,8 +9,8 @@ Branch: `feat/296/prometheus-grafana-monitoring`
 
 ```text
 1. Docker 컨테이너가 떠 있는지 확인
-2. Spring Boot가 /actuator/prometheus를 내보내는지 확인
-3. Prometheus가 app:8080/actuator/prometheus를 수집하는지 확인
+2. Spring Boot가 management port에서 /actuator/prometheus를 내보내는지 확인
+3. Prometheus가 app:8081/actuator/prometheus를 수집하는지 확인
 4. Grafana에 접속해서 대시보드가 보이는지 확인
 5. 실제 API를 한 번 호출하고 Grafana 숫자가 바뀌는지 확인
 ```
@@ -92,10 +92,10 @@ docker compose logs grafana
 
 ## 2. 백엔드 메트릭 endpoint 확인
 
-앱 컨테이너 안에서 `/actuator/prometheus`가 열리는지 확인한다.
+앱 컨테이너 안에서 management port의 `/actuator/prometheus`가 열리는지 확인한다.
 
 ```bash
-docker compose exec app curl -fsS http://localhost:8080/actuator/prometheus | head
+docker compose exec app curl -fsS http://localhost:8081/actuator/prometheus | head
 ```
 
 정상이면 이런 형태의 텍스트가 나온다.
@@ -138,7 +138,7 @@ docker compose exec prometheus promtool query instant http://localhost:9090 'up{
 정상 예시는 다음과 같다.
 
 ```text
-up{instance="app:8080", job="checkmo-app"} => 1
+up{instance="app:8081", job="checkmo-app"} => 1
 ```
 
 의미는 다음과 같다.
@@ -163,7 +163,7 @@ scrape_configs:
     metrics_path: /actuator/prometheus
     static_configs:
       - targets:
-          - app:8080
+          - app:8081
 ```
 
 그 다음 Prometheus 로그를 확인한다.
@@ -352,7 +352,7 @@ http://<ec2-public-ip>:9090
 http://<api-domain>/actuator/prometheus
 ```
 
-Grafana도 현재는 EC2 localhost에만 바인딩되어 있으므로, SSH 터널 없이 외부에서 바로 열리지 않는 것이 정상이다.
+Grafana도 현재는 EC2 localhost에만 바인딩되어 있으므로, SSH 터널 없이 외부에서 바로 열리지 않는 것이 정상이다. `/actuator/prometheus`는 app port `8080`이 아니라 management port `8081`에서만 제공되며, `8081`은 Docker 내부 network에서 Prometheus가 수집하는 용도로만 사용한다.
 
 운영자가 Grafana를 상시 접속해야 한다면 SSH 터널, VPN, 인증 reverse proxy, SSO 중 하나를 별도 결정해야 한다.
 

--- a/docs/prometheus_grafana_monitoring.md
+++ b/docs/prometheus_grafana_monitoring.md
@@ -1,0 +1,355 @@
+# Prometheus/Grafana 모니터링 확인 가이드
+
+Issue: #296
+Branch: `feat/296/prometheus-grafana-monitoring`
+
+이 문서는 모니터링이 실제로 동작하는지 확인하는 절차다. 운영 서버에 접속한 뒤 위에서부터 순서대로 확인하면 된다.
+
+## 한눈에 보는 흐름
+
+```text
+1. Docker 컨테이너가 떠 있는지 확인
+2. Spring Boot가 /actuator/prometheus를 내보내는지 확인
+3. Prometheus가 app:8080/actuator/prometheus를 수집하는지 확인
+4. Grafana에 접속해서 대시보드가 보이는지 확인
+5. 실제 API를 한 번 호출하고 Grafana 숫자가 바뀌는지 확인
+```
+
+## 0. 준비
+
+운영 EC2에 SSH로 접속한다.
+
+```bash
+ssh ubuntu@<ec2-host>
+```
+
+프로젝트가 배포된 디렉토리로 이동한다.
+
+```bash
+cd /home/ubuntu/app
+```
+
+Grafana 실행에는 `.env` 또는 배포 환경에 아래 값이 있어야 한다.
+
+```text
+GRAFANA_ADMIN_USER=<Grafana 로그인 ID>
+GRAFANA_ADMIN_PASSWORD=<Grafana 로그인 비밀번호>
+GRAFANA_PORT=3000
+```
+
+`GRAFANA_PORT`는 없으면 기본값 `3000`을 사용한다.
+
+## 1. 컨테이너 실행 확인
+
+```bash
+docker compose ps
+```
+
+정상이면 최소한 아래 컨테이너들이 `running` 또는 `healthy` 상태여야 한다.
+
+```text
+checkmo-app
+checkmo-prometheus
+checkmo-grafana
+```
+
+`checkmo-prometheus`나 `checkmo-grafana`가 없으면 모니터링 컨테이너를 올린다.
+
+```bash
+docker compose up -d prometheus grafana
+```
+
+Grafana가 바로 종료되면 환경 변수가 빠졌을 가능성이 높다.
+
+```bash
+docker compose logs grafana
+```
+
+`GRAFANA_ADMIN_USER is required` 또는 `GRAFANA_ADMIN_PASSWORD is required`가 보이면 `.env`에 Grafana 계정 값을 추가해야 한다.
+
+## 2. 백엔드 메트릭 endpoint 확인
+
+앱 컨테이너 안에서 `/actuator/prometheus`가 열리는지 확인한다.
+
+```bash
+docker compose exec app curl -fsS http://localhost:8080/actuator/prometheus | head
+```
+
+정상이면 이런 형태의 텍스트가 나온다.
+
+```text
+# HELP ...
+# TYPE ...
+```
+
+아래 이름 중 일부가 보이면 Actuator와 Micrometer가 정상 동작하는 상태다.
+
+```text
+http_server_requests_seconds_count
+jvm_memory_used_bytes
+hikaricp_connections_active
+```
+
+아무것도 안 나오거나 실패하면 앱 로그를 본다.
+
+```bash
+docker compose logs app
+```
+
+확인할 설정은 다음이다.
+
+| 확인할 것 | 정상 기준 |
+| --- | --- |
+| `build.gradle` | `spring-boot-starter-actuator`, `micrometer-registry-prometheus` 포함 |
+| `application.yml` | `spring.profiles.include`에 `monitoring` 포함 |
+| `application-monitoring.yml` | `management.endpoints.web.exposure.include`에 `prometheus` 포함 |
+
+## 3. Prometheus 수집 확인
+
+Prometheus가 백엔드에서 메트릭을 가져오는지 확인한다.
+
+```bash
+docker compose exec prometheus promtool query instant http://localhost:9090 'up{job="checkmo-app"}'
+```
+
+정상 예시는 다음과 같다.
+
+```text
+up{instance="app:8080", job="checkmo-app"} => 1
+```
+
+의미는 다음과 같다.
+
+| 값 | 의미 |
+| --- | --- |
+| `1` | Prometheus가 백엔드 메트릭을 정상 수집 중 |
+| `0` | target은 등록됐지만 수집 실패 |
+| 결과 없음 | Prometheus 설정에 `checkmo-app` job이 없거나 Prometheus가 아직 설정을 못 읽음 |
+
+수집이 실패하면 Prometheus 설정을 확인한다.
+
+```bash
+docker compose exec prometheus cat /etc/prometheus/prometheus.yml
+```
+
+아래 설정이 있어야 한다.
+
+```yaml
+scrape_configs:
+  - job_name: checkmo-app
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - app:8080
+```
+
+그 다음 Prometheus 로그를 확인한다.
+
+```bash
+docker compose logs prometheus
+```
+
+## 4. Grafana 접속 확인
+
+Grafana는 외부에 바로 열지 않고 EC2 localhost에만 열려 있다. 로컬 PC에서 보려면 SSH 터널을 연다.
+
+로컬 PC 터미널에서 실행한다.
+
+```bash
+ssh -L 3000:localhost:3000 ubuntu@<ec2-host>
+```
+
+그 다음 브라우저에서 접속한다.
+
+```text
+http://localhost:3000
+```
+
+로그인 정보는 `.env`에 넣은 값이다.
+
+```text
+ID: GRAFANA_ADMIN_USER
+PW: GRAFANA_ADMIN_PASSWORD
+```
+
+접속 후 아래 순서로 확인한다.
+
+```text
+Dashboards
+-> Checkmo
+-> Checkmo Backend Overview
+```
+
+대시보드가 보이면 Grafana provisioning이 정상 동작한 것이다.
+
+## 5. Grafana datasource 확인
+
+Grafana 화면에서 Prometheus 연결이 정상인지 확인한다.
+
+```text
+Connections
+-> Data sources
+-> Prometheus
+-> Save & test
+```
+
+정상이면 `Successfully queried the Prometheus API`와 비슷한 성공 메시지가 나온다.
+
+실패하면 datasource URL이 아래 값인지 확인한다.
+
+```text
+http://prometheus:9090
+```
+
+Grafana 컨테이너는 Prometheus와 같은 Docker network에 있기 때문에 `localhost:9090`이 아니라 `prometheus:9090`을 사용해야 한다.
+
+## 6. 실제 API 호출 후 숫자 변화 확인
+
+모니터링은 요청이 들어와야 숫자가 늘어난다. 서버에 안전한 요청을 몇 번 보낸다.
+
+운영 서버 안에서 확인한다.
+
+```bash
+docker compose exec app curl -fsS http://localhost:8080/health
+```
+
+외부 공개 API가 정상 배포되어 있다면 로컬 PC에서도 앱 API를 몇 번 호출한다.
+
+```bash
+curl -fsS https://<api-domain>/health
+```
+
+그 다음 Grafana 대시보드에서 시간 범위를 `Last 15 minutes`로 두고 새로고침한다.
+
+확인할 패널은 다음이다.
+
+| 패널 | 정상 확인 기준 |
+| --- | --- |
+| Request rate | API 호출 후 선이 움직이거나 값이 증가 |
+| Response time | 요청 처리 시간이 표시 |
+| 5xx rate | 정상 요청만 보냈다면 0에 가까움 |
+| JVM memory | 메모리 사용량이 표시 |
+| HikariCP | active/idle connection 값이 표시 |
+
+## 7. Custom metric 확인
+
+Custom metric은 해당 기능을 실제로 호출해야 생긴다.
+
+Prometheus에서 Aladin API metric이 쌓였는지 확인한다.
+
+```bash
+docker compose exec prometheus promtool query instant http://localhost:9090 'checkmo_aladin_client_requests_total'
+```
+
+추천 cache metric을 확인한다.
+
+```bash
+docker compose exec prometheus promtool query instant http://localhost:9090 'checkmo_book_recommendation_cache_requests_total'
+```
+
+배너성 API metric을 확인한다.
+
+```bash
+docker compose exec prometheus promtool query instant http://localhost:9090 'checkmo_banner_api_duration_seconds_count'
+```
+
+결과가 없으면 보통 둘 중 하나다.
+
+| 상황 | 의미 |
+| --- | --- |
+| 해당 API를 아직 호출하지 않음 | metric은 첫 호출 이후 생성됨 |
+| API 호출은 했는데 결과 없음 | 코드 경로가 다른 API를 탔거나 Prometheus scrape 전일 수 있음 |
+
+이 경우 해당 API를 한 번 호출한 뒤 15초 정도 기다리고 다시 확인한다. Prometheus scrape 주기가 15초이기 때문이다.
+
+## 8. 장애 상황에서 어디를 볼지
+
+### 서버가 느리다
+
+Grafana에서 먼저 본다.
+
+```text
+Checkmo Backend Overview
+-> Response time
+-> endpoint별 p95
+```
+
+같이 확인할 패널은 다음이다.
+
+| 같이 볼 것 | 판단 |
+| --- | --- |
+| Aladin API duration | 외부 API 때문에 느린지 확인 |
+| Recommendation cache hit/miss | cache miss 때문에 느린지 확인 |
+| HikariCP pending | DB connection을 기다리는지 확인 |
+| JVM memory / GC | Java 메모리나 GC 문제인지 확인 |
+
+### 500 에러가 늘어난다
+
+Grafana에서 5xx가 늘어난 endpoint를 확인한 뒤 Sentry로 이동한다.
+
+```text
+Grafana: 어떤 endpoint에서 5xx가 늘었는지 확인
+Sentry: 같은 시간대의 예외 상세 확인
+```
+
+Grafana는 "어디서 얼마나 자주 터졌는지"를 보고, Sentry는 "왜 터졌는지"를 본다.
+
+### Aladin timeout이 의심된다
+
+Prometheus에서 timeout 결과만 확인한다.
+
+```bash
+docker compose exec prometheus promtool query instant http://localhost:9090 'checkmo_aladin_client_requests_total{result="timeout"}'
+```
+
+값이 계속 증가하면 Aladin API timeout이 실제로 발생하고 있는 것이다.
+
+## 9. 최종 정상 기준
+
+아래가 모두 만족되면 1차 모니터링은 정상 도입된 상태로 보면 된다.
+
+| 체크 | 정상 기준 |
+| --- | --- |
+| 컨테이너 | `checkmo-app`, `checkmo-prometheus`, `checkmo-grafana` 실행 중 |
+| Actuator | `/actuator/prometheus`에서 Prometheus 형식 텍스트 출력 |
+| Prometheus | `up{job="checkmo-app"}` 값이 `1` |
+| Grafana 접속 | SSH 터널 후 `http://localhost:3000` 로그인 가능 |
+| Dashboard | `Checkmo Backend Overview` 표시 |
+| 기본 metric | 요청 수, 응답 시간, JVM, HikariCP 값 표시 |
+| custom metric | 관련 API 호출 후 Aladin/cache/banner metric 표시 |
+
+## 외부 공개 여부 확인
+
+Prometheus와 Actuator는 외부에 공개하면 안 된다.
+
+운영 서버 밖의 로컬 PC에서 아래 URL이 열리지 않아야 한다.
+
+```text
+http://<ec2-public-ip>:9090
+http://<api-domain>/actuator/prometheus
+```
+
+Grafana도 현재는 EC2 localhost에만 바인딩되어 있으므로, SSH 터널 없이 외부에서 바로 열리지 않는 것이 정상이다.
+
+운영자가 Grafana를 상시 접속해야 한다면 SSH 터널, VPN, 인증 reverse proxy, SSO 중 하나를 별도 결정해야 한다.
+
+## 자주 나는 문제
+
+| 증상 | 확인할 것 |
+| --- | --- |
+| Grafana 컨테이너가 바로 종료됨 | `GRAFANA_ADMIN_USER`, `GRAFANA_ADMIN_PASSWORD` 누락 |
+| Dashboard가 비어 있음 | 시간 범위가 너무 짧거나 API 요청이 아직 없음 |
+| Prometheus 값이 없음 | scrape 주기 15초 대기 후 재확인 |
+| `up{job="checkmo-app"}`가 0 | 앱 health, Docker network, `/actuator/prometheus` 응답 확인 |
+| custom metric이 없음 | 해당 기능 API를 실제로 호출했는지 확인 |
+| 앱이 로컬에서 안 뜸 | 모니터링 문제가 아니라 DB/Redis 운영 profile 환경 변수 문제일 수 있음 |
+
+## 중지
+
+모니터링만 중지하려면 Prometheus와 Grafana를 멈춘다.
+
+```bash
+docker compose stop prometheus grafana
+```
+
+백엔드 앱은 계속 동작한다.

--- a/docs/prometheus_grafana_monitoring.md
+++ b/docs/prometheus_grafana_monitoring.md
@@ -53,6 +53,15 @@ GRAFANA_PORT=3000
 
 `GRAFANA_PORT`는 없으면 기본값 `3000`을 사용한다.
 
+GitHub Actions 배포를 사용할 때는 repository Actions secrets에 최소한 아래 두 값을 추가한다.
+
+```text
+GRAFANA_ADMIN_USER
+GRAFANA_ADMIN_PASSWORD
+```
+
+`GRAFANA_PORT`, `GRAFANA_ROOT_URL`은 필요할 때만 Actions secrets에 추가한다. 배포 workflow가 이 값들을 `.env`에 기록한 뒤 EC2로 전송한다.
+
 ## 1. 컨테이너 실행 확인
 
 ```bash

--- a/monitoring/grafana/dashboards/checkmo-backend-overview.json
+++ b/monitoring/grafana/dashboards/checkmo-backend-overview.json
@@ -1,0 +1,452 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"checkmo-app\"}[5m]))",
+          "legendFormat": "RPS",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend RPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{job=\"checkmo-app\",status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_server_requests_seconds_count{job=\"checkmo-app\"}[5m])), 1)",
+          "legendFormat": "5xx ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_requests_seconds_bucket{job=\"checkmo-app\"}[5m])))",
+          "legendFormat": "p95",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend p95 Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, method, uri) (rate(http_server_requests_seconds_bucket{job=\"checkmo-app\",uri!=\"UNKNOWN\"}[5m]))))",
+          "legendFormat": "{{method}} {{uri}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Endpoint p95 Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "topk(10, sum by (method, uri, status) (rate(http_server_requests_seconds_count{job=\"checkmo-app\",uri!=\"UNKNOWN\"}[5m])))",
+          "legendFormat": "{{method}} {{uri}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Endpoint Traffic And Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 17
+      },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes{job=\"checkmo-app\",area=\"heap\"}",
+          "legendFormat": "{{id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "JVM Heap Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 17
+      },
+      "id": 7,
+      "targets": [
+        {
+          "expr": "sum by (action, cause) (rate(jvm_gc_pause_seconds_sum{job=\"checkmo-app\"}[5m]))",
+          "legendFormat": "{{action}} {{cause}}",
+          "refId": "A"
+        }
+      ],
+      "title": "GC Pause",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "id": 8,
+      "targets": [
+        {
+          "expr": "jvm_threads_live_threads{job=\"checkmo-app\"}",
+          "legendFormat": "live",
+          "refId": "A"
+        }
+      ],
+      "title": "JVM Live Threads",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 9,
+      "targets": [
+        {
+          "expr": "hikaricp_connections_active{job=\"checkmo-app\"}",
+          "legendFormat": "active",
+          "refId": "A"
+        },
+        {
+          "expr": "hikaricp_connections_idle{job=\"checkmo-app\"}",
+          "legendFormat": "idle",
+          "refId": "B"
+        },
+        {
+          "expr": "hikaricp_connections_pending{job=\"checkmo-app\"}",
+          "legendFormat": "pending",
+          "refId": "C"
+        }
+      ],
+      "title": "HikariCP Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 10,
+      "targets": [
+        {
+          "expr": "rate(hikaricp_connections_timeout_total{job=\"checkmo-app\"}[5m])",
+          "legendFormat": "timeout",
+          "refId": "A"
+        }
+      ],
+      "title": "HikariCP Timeout Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 33
+      },
+      "id": 11,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, operation) (rate(checkmo_aladin_client_duration_seconds_bucket{job=\"checkmo-app\"}[5m])))",
+          "legendFormat": "{{operation}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Aladin Client p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 33
+      },
+      "id": 12,
+      "targets": [
+        {
+          "expr": "sum(rate(checkmo_aladin_client_requests_total{job=\"checkmo-app\",result=\"timeout\"}[5m])) / clamp_min(sum(rate(checkmo_aladin_client_requests_total{job=\"checkmo-app\"}[5m])), 1)",
+          "legendFormat": "timeout ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Aladin Timeout Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 33
+      },
+      "id": 13,
+      "targets": [
+        {
+          "expr": "sum(rate(checkmo_book_recommendation_cache_requests_total{job=\"checkmo-app\",result=~\"fresh|stale\"}[5m])) / clamp_min(sum(rate(checkmo_book_recommendation_cache_requests_total{job=\"checkmo-app\"}[5m])), 1)",
+          "legendFormat": "recommendation cache hit",
+          "refId": "A"
+        }
+      ],
+      "title": "Recommendation Cache Hit Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 14,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, result) (rate(checkmo_banner_api_duration_seconds_bucket{job=\"checkmo-app\"}[5m])))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Banner API p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 15,
+      "targets": [
+        {
+          "expr": "sum(rate(checkmo_banner_cache_requests_total{job=\"checkmo-app\",result=\"hit\"}[5m])) / clamp_min(sum(rate(checkmo_banner_cache_requests_total{job=\"checkmo-app\"}[5m])), 1)",
+          "legendFormat": "banner cache hit",
+          "refId": "A"
+        }
+      ],
+      "title": "Banner Cache Hit Ratio",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": [
+    "checkmo",
+    "backend"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Checkmo Backend Overview",
+  "uid": "checkmo-backend-overview",
+  "version": 1
+}

--- a/monitoring/grafana/provisioning/dashboards/checkmo.yml
+++ b/monitoring/grafana/provisioning/dashboards/checkmo.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: Checkmo
+    orgId: 1
+    folder: Checkmo
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -7,4 +7,4 @@ scrape_configs:
     metrics_path: /actuator/prometheus
     static_configs:
       - targets:
-          - app:8080
+          - app:8081

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: checkmo-app
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - app:8080

--- a/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
+++ b/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/").permitAll() // 홈페이지 접근 허용
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/health").permitAll() // Swagger UI 접근 허용
+                        .requestMatchers("/actuator/health", "/actuator/prometheus").permitAll()
                         .requestMatchers("/oauth2/authorization/**","/login/oauth2/**").permitAll() // OAuth2 로그인 허용
                         .requestMatchers(HttpMethod.GET, "/api/v1/books/me/likes").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/books/**").permitAll()

--- a/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
+++ b/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
@@ -10,8 +10,10 @@ import checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationFailu
 import checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationSuccessHandler;
 import checkmo.authentication.internal.security.oauth2.SocialOAuth2UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -43,6 +45,21 @@ public class SecurityConfig {
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
 
     @Bean
+    @Order(1)
+    public SecurityFilterChain actuatorFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher(EndpointRequest.to("health", "prometheus"))
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityFilterChain filterChain(
             HttpSecurity http,
             ClientRegistrationRepository clientRegistrationRepository,
@@ -57,7 +74,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/").permitAll() // 홈페이지 접근 허용
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/health").permitAll() // Swagger UI 접근 허용
-                        .requestMatchers("/actuator/health", "/actuator/prometheus").permitAll()
                         .requestMatchers("/oauth2/authorization/**","/login/oauth2/**").permitAll() // OAuth2 로그인 허용
                         .requestMatchers(HttpMethod.GET, "/api/v1/books/me/likes").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/books/**").permitAll()

--- a/src/main/java/checkmo/book/internal/service/AladinRecommendationRefreshClient.java
+++ b/src/main/java/checkmo/book/internal/service/AladinRecommendationRefreshClient.java
@@ -6,6 +6,7 @@ import checkmo.book.internal.exception.BookErrorStatus;
 import checkmo.book.internal.exception.BookException;
 import checkmo.book.internal.service.query.AladinApiService;
 import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.common.monitoring.CheckmoMetrics;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,28 +24,33 @@ import org.springframework.web.client.RestClientException;
 public class AladinRecommendationRefreshClient {
 
     private final AladinApiService aladinApiService;
+    private final CheckmoMetrics checkmoMetrics;
     private final RetryTemplate retryTemplate;
 
     @Autowired
     public AladinRecommendationRefreshClient(
             AladinApiService aladinApiService,
-            AladinProperties aladinProperties
+            AladinProperties aladinProperties,
+            CheckmoMetrics checkmoMetrics
     ) {
-        this(aladinApiService, aladinProperties, Thread::sleep);
+        this(aladinApiService, aladinProperties, checkmoMetrics, Thread::sleep);
     }
 
     AladinRecommendationRefreshClient(
             AladinApiService aladinApiService,
             AladinProperties aladinProperties,
+            CheckmoMetrics checkmoMetrics,
             Sleeper sleeper
     ) {
         this.aladinApiService = aladinApiService;
+        this.checkmoMetrics = checkmoMetrics;
         this.retryTemplate = buildRetryTemplate(aladinProperties.getRecommendation().getRefresh().getRetry(), sleeper);
     }
 
     public BookResponseDTO.BookList retrieveRecommendedBooks() {
         return retryTemplate.execute(context -> {
             if (context.getRetryCount() > 0) {
+                checkmoMetrics.incrementAladinRecommendationRetry("retry");
                 log.warn("알라딘 추천 책 갱신 재시도. attempt={}", context.getRetryCount() + 1);
             }
             return aladinApiService.retrieveRecommendedBooks();

--- a/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
+++ b/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
@@ -128,7 +128,7 @@ public class BookRecommendationService {
                     .build();
         } catch (RuntimeException e) {
             if ("success".equals(result)) {
-                result = "unknown_error";
+                result = checkmoMetrics.classifyAladinResult(e);
             }
             throw e;
         } finally {

--- a/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
+++ b/src/main/java/checkmo/book/internal/service/BookRecommendationService.java
@@ -7,7 +7,9 @@ import checkmo.book.internal.service.query.AladinApiService;
 import checkmo.book.internal.util.DayOfWeekUtils;
 import checkmo.book.web.dto.BookResponseDTO;
 import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import checkmo.common.monitoring.CheckmoMetrics;
 import checkmo.common.monitoring.SentryCaptureClient;
+import io.micrometer.core.instrument.Timer;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -28,16 +30,19 @@ public class BookRecommendationService {
     private final AladinApiService aladinApiService;
     private final AladinRecommendationRefreshClient recommendationRefreshClient;
     private final SentryCaptureClient sentryCaptureClient;
+    private final CheckmoMetrics checkmoMetrics;
 
     public BookResponseDTO.BookList retrieveRecommendedBooks(Long memberId) {
-        BookResponseDTO.BookList cachedBooks = retrieveUsableCachedBooks();
+        CacheLookup cacheLookup = retrieveUsableCachedBooks();
+        BookResponseDTO.BookList cachedBooks = cacheLookup.bookList();
+        checkmoMetrics.incrementRecommendationCacheRequest(cacheLookup.result());
 
         if (cachedBooks != null && !isRecommendedBooksStale()) {
             return aladinApiService.applyLikedByMe(cachedBooks, memberId);
         }
 
         try {
-            BookResponseDTO.BookList refreshedBooks = retrieveAndSaveRecommendedBooksFromAladin();
+            BookResponseDTO.BookList refreshedBooks = retrieveAndSaveRecommendedBooksFromAladin("user_request");
             return aladinApiService.applyLikedByMe(refreshedBooks, memberId);
         } catch (Exception e) {
             if (cachedBooks != null) {
@@ -59,7 +64,7 @@ public class BookRecommendationService {
 
     public BookResponseDTO.BookList refreshDailyRecommendedBooks() {
         try {
-            return retrieveAndSaveRecommendedBooksFromAladin();
+            return retrieveAndSaveRecommendedBooksFromAladin("background");
         } catch (Exception e) {
             log.error(
                     "API에서 추천 책 가져오기 중 오류. exceptionType={}, errorStatus={}, message={}, causeType={}, causeMessage={}",
@@ -74,44 +79,61 @@ public class BookRecommendationService {
         }
     }
 
-    private BookResponseDTO.BookList retrieveUsableCachedBooks() {
+    private CacheLookup retrieveUsableCachedBooks() {
         try {
             Object cachedData = redisTemplate.opsForValue().get(REDIS_KEY);
 
             if (cachedData instanceof BookResponseDTO.BookList bookList && isUsableBookList(bookList)) {
-                return bookList;
+                String result = isRecommendedBooksStale() ? "stale" : "fresh";
+                return new CacheLookup(bookList, result);
             }
         } catch (Exception e) {
             log.error("Redis에서 추천 책 조회 중 오류 발생. API에서 데이터를 가져오기.", e);
+            return new CacheLookup(null, "redis_error");
         }
 
-        return null;
+        return new CacheLookup(null, "miss");
     }
 
-    private BookResponseDTO.BookList retrieveAndSaveRecommendedBooksFromAladin() {
-        BookResponseDTO.BookList bookList = recommendationRefreshClient.retrieveRecommendedBooks();
+    private BookResponseDTO.BookList retrieveAndSaveRecommendedBooksFromAladin(String source) {
+        Timer.Sample sample = checkmoMetrics.startTimer();
+        String result = "success";
+        try {
+            BookResponseDTO.BookList bookList = recommendationRefreshClient.retrieveRecommendedBooks();
 
-        if (!isUsableBookList(bookList)) {
-            log.error("알라딘 API에서 추천 책을 가져오지 못했습니다.");
-            throw new BookException(BookErrorStatus.ALADIN_API_ERROR);
+            if (!isUsableBookList(bookList)) {
+                result = "invalid_response";
+                log.error("알라딘 API에서 추천 책을 가져오지 못했습니다.");
+                throw new BookException(BookErrorStatus.ALADIN_API_ERROR);
+            }
+
+            int startIndex = DayOfWeekUtils.calculateStartIndexByDayOfWeek();
+            var allBooks = bookList.getDetailInfoList();
+            checkmoMetrics.recordRecommendationBooksCount("aladin", allBooks.size());
+
+            if (allBooks.size() < startIndex + 4) {
+                result = "invalid_response";
+                log.error("추천 책 목록 부족, 전체: {}개, 필요: {}개", allBooks.size(), startIndex + 4);
+                throw new BookException(BookErrorStatus.ALADIN_API_ERROR);
+            }
+
+            List<DetailInfo> booksForToday = List.copyOf(allBooks.subList(startIndex, startIndex + 4));
+            checkmoMetrics.recordRecommendationBooksCount("returned", booksForToday.size());
+            saveRecommendedBooks(booksForToday);
+
+            return BookResponseDTO.BookList.builder()
+                    .detailInfoList(booksForToday)
+                    .hasNext(false)
+                    .currentPage(null)
+                    .build();
+        } catch (RuntimeException e) {
+            if ("success".equals(result)) {
+                result = "unknown_error";
+            }
+            throw e;
+        } finally {
+            checkmoMetrics.recordAladinRecommendationRefresh(sample, result, source);
         }
-
-        int startIndex = DayOfWeekUtils.calculateStartIndexByDayOfWeek();
-        var allBooks = bookList.getDetailInfoList();
-
-        if (allBooks.size() < startIndex + 4) {
-            log.error("추천 책 목록 부족, 전체: {}개, 필요: {}개", allBooks.size(), startIndex + 4);
-            throw new BookException(BookErrorStatus.ALADIN_API_ERROR);
-        }
-
-        List<DetailInfo> booksForToday = List.copyOf(allBooks.subList(startIndex, startIndex + 4));
-        saveRecommendedBooks(booksForToday);
-
-        return BookResponseDTO.BookList.builder()
-                .detailInfoList(booksForToday)
-                .hasNext(false)
-                .currentPage(null)
-                .build();
     }
 
     private boolean isUsableBookList(BookResponseDTO.BookList bookList) {
@@ -172,6 +194,9 @@ public class BookRecommendationService {
                 .hasNext(false)
                 .currentPage(null)
                 .build();
+    }
+
+    private record CacheLookup(BookResponseDTO.BookList bookList, String result) {
     }
 
     private String safeErrorStatus(Exception exception) {

--- a/src/main/java/checkmo/book/internal/service/query/AladinApiService.java
+++ b/src/main/java/checkmo/book/internal/service/query/AladinApiService.java
@@ -8,7 +8,9 @@ import checkmo.book.internal.repository.BookLikedRepository;
 import checkmo.book.web.dto.AladinApiResponseDTO;
 import checkmo.book.web.dto.BookResponseDTO;
 import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import checkmo.common.monitoring.CheckmoMetrics;
 import checkmo.common.monitoring.SentryCaptureClient;
+import io.micrometer.core.instrument.Timer;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +38,7 @@ public class AladinApiService {
     private final AladinSearchClient aladinSearchClient;
     private final AladinSearchPrefetchService aladinSearchPrefetchService;
     private final SentryCaptureClient sentryCaptureClient;
+    private final CheckmoMetrics checkmoMetrics;
 
     public BookResponseDTO.BookList retrieveSearchBooks(String keyword, int page, Long memberId) {
         if (keyword == null || keyword.isBlank()) {
@@ -91,6 +94,9 @@ public class AladinApiService {
 
     public DetailInfo retrieveBookDetailInfo(String isbn) {
         String url = buildHttpUrl(isbn);
+        Timer.Sample sample = checkmoMetrics.startTimer();
+        String result = "success";
+        Exception failure = null;
         try {
             var response = restTemplate.getForObject(
                     url,
@@ -98,22 +104,34 @@ public class AladinApiService {
             );
 
             if (response == null || response.getItems() == null || response.getItems().isEmpty()) {
+                result = "invalid_response";
                 throw new BookException(BookErrorStatus.BOOK_NOT_FOUND);
             }
 
             return BookConverter.toBookInfoDetail(response);
 
         } catch (BookException e) {
+            failure = e;
+            if ("success".equals(result)) {
+                result = checkmoMetrics.classifyAladinResult(e);
+            }
             logAladinFailure("retrieveBookDetailInfo", url, e);
             throw new BookException(BookErrorStatus.BOOK_NOT_FOUND, e);
         } catch (Exception e) {
+            failure = e;
+            result = checkmoMetrics.classifyAladinResult(e);
             logAladinFailure("retrieveBookDetailInfo", url, e);
             throw new BookException(BookErrorStatus.ALADIN_API_ERROR, e);
+        } finally {
+            checkmoMetrics.recordAladinClientResult(sample, "detail", result, failure);
         }
     }
 
     public BookResponseDTO.BookList retrieveRecommendedBooks() {
         String url = buildHttpUrl();
+        Timer.Sample sample = checkmoMetrics.startTimer();
+        String result = "success";
+        Exception failure = null;
         try {
             var response = restTemplate.getForObject(
                     url,
@@ -121,14 +139,21 @@ public class AladinApiService {
             );
 
             if (response == null || response.getItems() == null || response.getItems().isEmpty()) {
+                result = "invalid_response";
                 throw new BookException(BookErrorStatus.ALADIN_API_ERROR);
             }
 
             return BookConverter.toBookList(response, 1);
 
         } catch (Exception e) {
+            failure = e;
+            if ("success".equals(result)) {
+                result = checkmoMetrics.classifyAladinResult(e);
+            }
             logAladinFailure("retrieveRecommendedBooks", url, e);
             throw new BookException(BookErrorStatus.ALADIN_API_ERROR, e);
+        } finally {
+            checkmoMetrics.recordAladinClientResult(sample, "recommendation", result, failure);
         }
     }
 

--- a/src/main/java/checkmo/book/internal/service/query/AladinSearchClient.java
+++ b/src/main/java/checkmo/book/internal/service/query/AladinSearchClient.java
@@ -4,6 +4,8 @@ import checkmo.book.internal.config.properties.AladinProperties;
 import checkmo.book.internal.converter.BookConverter;
 import checkmo.book.web.dto.AladinApiResponseDTO;
 import checkmo.book.web.dto.BookResponseDTO;
+import checkmo.common.monitoring.CheckmoMetrics;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
@@ -17,8 +19,10 @@ public class AladinSearchClient {
 
     private final RestTemplate restTemplate;
     private final AladinProperties aladinProperties;
+    private final CheckmoMetrics checkmoMetrics;
 
     public BookResponseDTO.BookList fetchSearchBooks(String keyword, int page) {
+        Timer.Sample sample = checkmoMetrics.startTimer();
         AladinApiResponseDTO.BookList response;
         try {
             response = restTemplate.getForObject(
@@ -26,9 +30,16 @@ public class AladinSearchClient {
                     AladinApiResponseDTO.BookList.class
             );
         } catch (RestClientException e) {
+            checkmoMetrics.recordAladinClientResult(
+                    sample,
+                    "search",
+                    checkmoMetrics.classifyAladinResult(e),
+                    e
+            );
             throw new IllegalStateException(sanitizedFailureMessage(e));
         }
 
+        checkmoMetrics.recordAladinClientResult(sample, "search", "success", null);
         return BookConverter.toBookList(response, page);
     }
 

--- a/src/main/java/checkmo/common/monitoring/CheckmoMetrics.java
+++ b/src/main/java/checkmo/common/monitoring/CheckmoMetrics.java
@@ -1,0 +1,116 @@
+package checkmo.common.monitoring;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeoutException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClientResponseException;
+
+@Component
+public class CheckmoMetrics {
+
+    private final MeterRegistry meterRegistry;
+
+    public CheckmoMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    public Timer.Sample startTimer() {
+        return Timer.start(meterRegistry);
+    }
+
+    public void recordAladinClientResult(Timer.Sample sample, String operation, String result, Throwable throwable) {
+        Counter.builder("checkmo.aladin.client.requests")
+                .tag("operation", operation)
+                .tag("result", result)
+                .tag("exception", exceptionName(throwable))
+                .register(meterRegistry)
+                .increment();
+
+        sample.stop(Timer.builder("checkmo.aladin.client.duration")
+                .tag("operation", operation)
+                .tag("result", result)
+                .register(meterRegistry));
+    }
+
+    public void recordAladinRecommendationRefresh(Timer.Sample sample, String result, String source) {
+        sample.stop(Timer.builder("checkmo.aladin.recommendation.refresh.duration")
+                .tag("result", result)
+                .tag("source", source)
+                .register(meterRegistry));
+    }
+
+    public void incrementAladinRecommendationRetry(String result) {
+        Counter.builder("checkmo.aladin.recommendation.retry.count")
+                .tag("result", result)
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public void incrementRecommendationCacheRequest(String result) {
+        Counter.builder("checkmo.book.recommendation.cache.requests")
+                .tag("result", result)
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public void recordRecommendationBooksCount(String source, int count) {
+        DistributionSummary.builder("checkmo.book.recommendation.books.count")
+                .tag("source", source)
+                .register(meterRegistry)
+                .record(count);
+    }
+
+    public void recordBannerApiDuration(Timer.Sample sample, String result) {
+        sample.stop(Timer.builder("checkmo.banner.api.duration")
+                .tag("result", result)
+                .register(meterRegistry));
+    }
+
+    public void incrementBannerCacheRequest(String result) {
+        Counter.builder("checkmo.banner.cache.requests")
+                .tag("result", result)
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public String classifyAladinResult(Throwable throwable) {
+        if (throwable == null) {
+            return "success";
+        }
+        if (containsType(throwable, SocketTimeoutException.class)
+                || containsType(throwable, TimeoutException.class)
+                || containsType(throwable, ResourceAccessException.class)) {
+            return "timeout";
+        }
+        if (containsType(throwable, RestClientResponseException.class)) {
+            return "http_error";
+        }
+        if (throwable instanceof IllegalArgumentException) {
+            return "invalid_response";
+        }
+        return "unknown_error";
+    }
+
+    private boolean containsType(Throwable throwable, Class<? extends Throwable> type) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (type.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private String exceptionName(Throwable throwable) {
+        if (throwable == null) {
+            return "none";
+        }
+        return throwable.getClass().getSimpleName();
+    }
+}

--- a/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
+++ b/src/main/java/checkmo/news/internal/service/NewsQueryFacade.java
@@ -2,6 +2,7 @@ package checkmo.news.internal.service;
 
 import checkmo.common.template.CursorPagingHelper;
 import checkmo.common.template.CursorResult;
+import checkmo.common.monitoring.CheckmoMetrics;
 import checkmo.member.MemberAPI;
 import checkmo.news.internal.converter.NewsConverter;
 import checkmo.news.internal.entity.News;
@@ -10,6 +11,7 @@ import checkmo.news.internal.exception.NewsException;
 import checkmo.news.internal.repository.projection.NewsSitemapProjection;
 import checkmo.news.internal.service.query.NewsQueryService;
 import checkmo.news.web.dto.NewsResponseDTO;
+import io.micrometer.core.instrument.Timer;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
@@ -30,24 +32,35 @@ public class NewsQueryFacade {
 
     private final NewsQueryService newsQueryService;
     private final MemberAPI memberAPI;
+    private final CheckmoMetrics checkmoMetrics;
 
     public NewsResponseDTO.NewsList fetchNewsList(Long cursorId) {
-        CursorResult<News> newsCursorResult = CursorPagingHelper.getPage(
-                (pageSize) -> newsQueryService.retrieveNewsList(cursorId, pageSize),
-                News::getId,
-                DEFAULT_PAGE_SIZE
-        );
+        Timer.Sample sample = checkmoMetrics.startTimer();
+        String result = "success";
+        try {
+            checkmoMetrics.incrementBannerCacheRequest("miss");
+            CursorResult<News> newsCursorResult = CursorPagingHelper.getPage(
+                    (pageSize) -> newsQueryService.retrieveNewsList(cursorId, pageSize),
+                    News::getId,
+                    DEFAULT_PAGE_SIZE
+            );
 
-        List<NewsResponseDTO.BasicInfo> basicInfoList = newsCursorResult.content().stream()
-                .map(NewsConverter::toBasicInfo)
-                .toList();
+            List<NewsResponseDTO.BasicInfo> basicInfoList = newsCursorResult.content().stream()
+                    .map(NewsConverter::toBasicInfo)
+                    .toList();
 
-        return NewsResponseDTO.NewsList.builder()
-                .basicInfoList(basicInfoList)
-                .hasNext(newsCursorResult.hasNext())
-                .nextCursor(newsCursorResult.nextCursor())
-                .pageSize(DEFAULT_PAGE_SIZE)
-                .build();
+            return NewsResponseDTO.NewsList.builder()
+                    .basicInfoList(basicInfoList)
+                    .hasNext(newsCursorResult.hasNext())
+                    .nextCursor(newsCursorResult.nextCursor())
+                    .pageSize(DEFAULT_PAGE_SIZE)
+                    .build();
+        } catch (RuntimeException e) {
+            result = "error";
+            throw e;
+        } finally {
+            checkmoMetrics.recordBannerApiDuration(sample, result);
+        }
     }
 
     public NewsResponseDTO.DetailInfo fetchNewsDetail(Long newsId) {

--- a/src/main/resources/application-monitoring.yml
+++ b/src/main/resources/application-monitoring.yml
@@ -1,0 +1,28 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-details: never
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+  metrics:
+    tags:
+      application: checkmo-backend
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+        checkmo.aladin.client.duration: true
+        checkmo.aladin.recommendation.refresh.duration: true
+        checkmo.banner.api.duration: true
+        checkmo.book.recommendation.books.count: true
+      slo:
+        http.server.requests: 100ms,300ms,500ms,1s,2s,5s
+        checkmo.aladin.client.duration: 100ms,300ms,500ms,1s,2s,5s
+        checkmo.banner.api.duration: 100ms,300ms,500ms,1s,2s

--- a/src/main/resources/application-monitoring.yml
+++ b/src/main/resources/application-monitoring.yml
@@ -1,4 +1,6 @@
 management:
+  server:
+    port: ${MANAGEMENT_SERVER_PORT:8081}
   endpoints:
     web:
       exposure:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,7 @@ spring:
       - jwt
       - oauth2
       - s3
+      - monitoring
   modulith:
     events:
       completion-mode: DELETE

--- a/src/test/java/checkmo/book/internal/service/BookRecommendationServiceTest.java
+++ b/src/test/java/checkmo/book/internal/service/BookRecommendationServiceTest.java
@@ -21,7 +21,9 @@ import checkmo.book.internal.service.query.AladinApiService;
 import checkmo.book.internal.util.DayOfWeekUtils;
 import checkmo.book.web.dto.BookResponseDTO;
 import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import checkmo.common.monitoring.CheckmoMetrics;
 import checkmo.common.monitoring.RecordingSentryCaptureClient;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -53,6 +55,7 @@ class BookRecommendationServiceTest {
     private ValueOperations<String, Object> valueOperations;
     private AladinApiService aladinApiService;
     private RecordingSentryCaptureClient captureClient;
+    private CheckmoMetrics checkmoMetrics;
     private BookRecommendationService service;
 
     @BeforeEach
@@ -62,13 +65,15 @@ class BookRecommendationServiceTest {
         valueOperations = mock(ValueOperations.class);
         aladinApiService = mock(AladinApiService.class);
         captureClient = new RecordingSentryCaptureClient();
+        checkmoMetrics = new CheckmoMetrics(new SimpleMeterRegistry());
         AladinRecommendationRefreshClient refreshClient = new AladinRecommendationRefreshClient(
                 aladinApiService,
                 retryProperties(),
+                checkmoMetrics,
                 backOffPeriod -> {
                 }
         );
-        service = new BookRecommendationService(redisTemplate, aladinApiService, refreshClient, captureClient);
+        service = new BookRecommendationService(redisTemplate, aladinApiService, refreshClient, captureClient, checkmoMetrics);
 
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
     }

--- a/src/test/java/checkmo/book/internal/service/query/AladinApiServiceTest.java
+++ b/src/test/java/checkmo/book/internal/service/query/AladinApiServiceTest.java
@@ -16,7 +16,9 @@ import checkmo.book.internal.exception.BookException;
 import checkmo.book.internal.repository.BookLikedRepository;
 import checkmo.book.web.dto.BookResponseDTO;
 import checkmo.book.web.dto.BookResponseDTO.DetailInfo;
+import checkmo.common.monitoring.CheckmoMetrics;
 import checkmo.common.monitoring.SentryCaptureClient;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,7 +53,8 @@ class AladinApiServiceTest {
                 bookSearchCacheService,
                 aladinSearchClient,
                 aladinSearchPrefetchService,
-                sentryCaptureClient
+                sentryCaptureClient,
+                new CheckmoMetrics(new SimpleMeterRegistry())
         );
     }
 

--- a/src/test/java/checkmo/book/internal/service/query/AladinSearchClientTest.java
+++ b/src/test/java/checkmo/book/internal/service/query/AladinSearchClientTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.when;
 
 import checkmo.book.internal.config.properties.AladinProperties;
 import checkmo.book.web.dto.AladinApiResponseDTO;
+import checkmo.common.monitoring.CheckmoMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -17,7 +19,11 @@ class AladinSearchClientTest {
     @Test
     void fetchSearchBooksThrowsSanitizedExceptionWhenRestTemplateFails() {
         RestTemplate restTemplate = mock(RestTemplate.class);
-        AladinSearchClient client = new AladinSearchClient(restTemplate, aladinProperties());
+        AladinSearchClient client = new AladinSearchClient(
+                restTemplate,
+                aladinProperties(),
+                new CheckmoMetrics(new SimpleMeterRegistry())
+        );
         RestClientException failure = new RestClientException(
                 "I/O error on GET request for \"https://example.com/ItemSearch.aspx?ttbkey=secret-key&Query=자바\""
         );

--- a/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
+++ b/src/test/java/checkmo/common/monitoring/SentryBackgroundCaptureTest.java
@@ -22,6 +22,7 @@ import checkmo.member.internal.entity.Member;
 import checkmo.member.internal.repository.MemberRepository;
 import checkmo.member.internal.scheduler.MemberCleanupScheduler;
 import checkmo.member.internal.service.command.MemberCommandService;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -38,6 +39,7 @@ class SentryBackgroundCaptureTest {
         ValueOperations<String, Object> valueOperations = mock(ValueOperations.class);
         AladinApiService aladinApiService = mock(AladinApiService.class);
         RecordingSentryCaptureClient captureClient = new RecordingSentryCaptureClient();
+        CheckmoMetrics checkmoMetrics = new CheckmoMetrics(new SimpleMeterRegistry());
         RuntimeException failure = new RuntimeException("aladin unavailable");
         BookResponseDTO.BookList staleCache = BookResponseDTO.BookList.builder()
                 .detailInfoList(List.of(BookResponseDTO.DetailInfo.builder()
@@ -59,8 +61,9 @@ class SentryBackgroundCaptureTest {
         BookRecommendationService service = new BookRecommendationService(
                 redisTemplate,
                 aladinApiService,
-                new AladinRecommendationRefreshClient(aladinApiService, new AladinProperties()),
-                captureClient
+                new AladinRecommendationRefreshClient(aladinApiService, new AladinProperties(), checkmoMetrics),
+                captureClient,
+                checkmoMetrics
         );
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get("book:recommendations:daily")).thenReturn(staleCache);

--- a/src/test/java/checkmo/support/ApiTestInfrastructureTest.java
+++ b/src/test/java/checkmo/support/ApiTestInfrastructureTest.java
@@ -38,6 +38,28 @@ class ApiTestInfrastructureTest extends ApiTestSupport {
     }
 
     @Test
+    void prometheusEndpointExposesBackendMetricsWithoutAuthentication() {
+        given()
+                .when()
+                .get("/api/v1/news")
+                .then()
+                .statusCode(200);
+
+        String body = given()
+                .when()
+                .get("/actuator/prometheus")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        assertThat(body)
+                .contains("jvm_memory_used_bytes")
+                .contains("checkmo_banner_api_duration_seconds_count")
+                .contains("application=\"checkmo-backend\"");
+    }
+
+    @Test
     void authenticatedFixtureCanCallProfileCompletedApi() {
         TestUser user = createUser();
 

--- a/src/test/java/checkmo/support/ApiTestInfrastructureTest.java
+++ b/src/test/java/checkmo/support/ApiTestInfrastructureTest.java
@@ -3,9 +3,11 @@ package checkmo.support;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.restassured.response.Response;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalManagementPort;
 import org.springframework.core.env.Environment;
 
 class ApiTestInfrastructureTest extends ApiTestSupport {
@@ -15,6 +17,9 @@ class ApiTestInfrastructureTest extends ApiTestSupport {
 
     @Autowired
     Environment environment;
+
+    @LocalManagementPort
+    int managementPort;
 
     @Test
     void testProfileUsesH2AndDoesNotIncludeProductionProfiles() throws Exception {
@@ -38,7 +43,20 @@ class ApiTestInfrastructureTest extends ApiTestSupport {
     }
 
     @Test
-    void prometheusEndpointExposesBackendMetricsWithoutAuthentication() {
+    void prometheusEndpointDoesNotExposeMetricsOnApplicationPort() {
+        Response response = given()
+                .when()
+                .get("/actuator/prometheus")
+                .then()
+                .extract()
+                .response();
+
+        assertThat(response.statusCode()).isNotEqualTo(200);
+        assertThat(response.asString()).doesNotContain("jvm_memory_used_bytes");
+    }
+
+    @Test
+    void prometheusEndpointExposesBackendMetricsOnManagementPort() {
         given()
                 .when()
                 .get("/api/v1/news")
@@ -46,6 +64,7 @@ class ApiTestInfrastructureTest extends ApiTestSupport {
                 .statusCode(200);
 
         String body = given()
+                .port(managementPort)
                 .when()
                 .get("/actuator/prometheus")
                 .then()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -59,6 +59,10 @@ events:
   retry:
     enabled: false
 
+management:
+  server:
+    port: 0
+
 app:
   oauth2:
     redirect:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,6 +4,8 @@ spring:
       completion-mode: DELETE
   profiles:
     active: test
+    include:
+      - monitoring
 
 server:
   forward-headers-strategy: NATIVE


### PR DESCRIPTION
## 🚀 변경사항
- Spring Boot Actuator와 Micrometer Prometheus registry를 추가하여 `/actuator/prometheus`에서 백엔드 메트릭을 노출했습니다.
- Prometheus와 Grafana를 Docker Compose에 추가하고, Prometheus가 내부 Docker network에서 `app:8080/actuator/prometheus`를 scrape하도록 설정했습니다.
- Grafana 기본 대시보드를 추가하여 요청 수, 응답 시간, 5xx 비율, JVM memory, HikariCP connection pool 상태를 확인할 수 있게 했습니다.
- Aladin API 호출 시간/timeout, 추천 cache hit/miss, 배너성 API 응답 시간 관련 custom metric을 추가했습니다.
- Prometheus UI는 외부에 공개하지 않고, Grafana만 localhost 바인딩 기반으로 운영자 접근이 가능하도록 제한했습니다.
- 모니터링 확인 가이드 문서를 추가했습니다.
- 배포 시 `monitoring/` 설정 파일과 Grafana Secret 값이 EC2 `.env`에 반영되도록 GitHub Actions workflow를 수정했습니다.

## 🔗 관련 이슈
- Closes #296

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [x] 코드 리뷰 준비 완료

## 📝 특이사항
- 배포 전 GitHub Actions secrets에 아래 값 추가가 필요합니다.
  - `GRAFANA_ADMIN_USER`
  - `GRAFANA_ADMIN_PASSWORD`
- `GRAFANA_PORT`, `GRAFANA_ROOT_URL`은 선택값입니다.
- 1~2주 baseline 수집 후 알림 기준, 추천 cache 정책, 배너 CDN/cache 적용 여부를 결정하면 됩니다.
- 로컬 검증:
  - `./gradlew test`
  - `./gradlew test --tests checkmo.support.ApiTestInfrastructureTest`
  - `./gradlew test --tests checkmo.CheckmoApplicationTests`
  - `docker compose config --no-env-resolution --quiet`
  - YAML/JSON 파싱 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus and Grafana monitoring for backend health, performance, JVM, database, cache, and external API metrics.
  * Added a preconfigured Grafana dashboard and automatic monitoring setup for deployments.
  * Exposed health and metrics endpoints for monitoring integrations.
  * Added application telemetry for recommendation, search, news, cache, retry, and external API activity.

* **Documentation**
  * Added setup and operational guidance for configuring and validating Prometheus/Grafana monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->