### PR TITLE
fix: 카카오 신규 로그인 및 OAuth 콜백 실패 처리를 보강

### DIFF
--- a/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
+++ b/src/main/java/checkmo/authentication/internal/config/SecurityConfig.java
@@ -8,9 +8,12 @@ import checkmo.authentication.internal.security.oauth2.AppleOidcUserService;
 import checkmo.authentication.internal.security.oauth2.AppleOAuth2AuthorizationRequestResolver;
 import checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationFailureHandler;
 import checkmo.authentication.internal.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import checkmo.authentication.internal.security.oauth2.OAuth2CallbackExceptionFilter;
 import checkmo.authentication.internal.security.oauth2.SocialOAuth2UserService;
+import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -26,6 +29,7 @@ import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResp
 import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
 import org.springframework.security.oauth2.client.endpoint.RestClientAuthorizationCodeTokenResponseClient;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -43,6 +47,7 @@ public class SecurityConfig {
     private final AppleOidcUserService appleOidcUserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+    private final OAuth2CallbackExceptionFilter oAuth2CallbackExceptionFilter;
 
     @Bean
     @Order(1)
@@ -72,6 +77,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용 안함
                 )
                 .authorizeHttpRequests(auth -> auth
+                        .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
                         .requestMatchers("/").permitAll() // 홈페이지 접근 허용
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/health").permitAll() // Swagger UI 접근 허용
                         .requestMatchers("/oauth2/authorization/**","/login/oauth2/**").permitAll() // OAuth2 로그인 허용
@@ -101,6 +107,8 @@ public class SecurityConfig {
                 )
                 .addFilterBefore(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class) // JWT 인증 필터 추가
+                .addFilterBefore(oAuth2CallbackExceptionFilter,
+                        OAuth2LoginAuthenticationFilter.class)
                 .addFilterAfter(profileCompletionAuthorizationFilter,
                         JwtAuthenticationFilter.class); // 프로필 완료 필터 추가
 
@@ -124,6 +132,15 @@ public class SecurityConfig {
                 );
 
         return http.build();
+    }
+
+    @Bean
+    public FilterRegistrationBean<OAuth2CallbackExceptionFilter> disableOAuth2CallbackFilterAutoRegistration(
+            OAuth2CallbackExceptionFilter filter
+    ) {
+        FilterRegistrationBean<OAuth2CallbackExceptionFilter> registration = new FilterRegistrationBean<>(filter);
+        registration.setEnabled(false);
+        return registration;
     }
 
     @Bean

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/KakaoEmailConsentRetryState.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/KakaoEmailConsentRetryState.java
@@ -1,0 +1,34 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+final class KakaoEmailConsentRetryState {
+
+    static final String SESSION_ATTRIBUTE = "checkmo.oauth2.kakao.email-consent-retry";
+
+    private KakaoEmailConsentRetryState() {
+    }
+
+    static boolean beginRetry(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return false;
+        }
+
+        if (Boolean.TRUE.equals(session.getAttribute(SESSION_ATTRIBUTE))) {
+            session.removeAttribute(SESSION_ATTRIBUTE);
+            return false;
+        }
+
+        session.setAttribute(SESSION_ATTRIBUTE, Boolean.TRUE);
+        return true;
+    }
+
+    static void clear(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.removeAttribute(SESSION_ATTRIBUTE);
+        }
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2Attributes.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2Attributes.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.util.StringUtils;
 
 @Getter
@@ -34,11 +35,59 @@ public class OAuth2Attributes {
     }
 
     private static OAuth2Attributes ofKakao(Map<String, Object> attributes) {
-        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get(Provider.Kakao.ACCOUNT);
+        String providerId = kakaoProviderId(attributes.get(Provider.Kakao.PROVIDER_ID));
+        Map<?, ?> kakaoAccount = kakaoAccount(attributes.get(Provider.Kakao.ACCOUNT));
+        String email = stringValue(kakaoAccount.get(Provider.Kakao.EMAIL));
+
+        if (!StringUtils.hasText(email)) {
+            boolean emailNeedsAgreement = Boolean.TRUE.equals(kakaoAccount.get("email_needs_agreement"));
+            String errorCode = emailNeedsAgreement
+                    ? OAuth2ErrorCodes.KAKAO_EMAIL_CONSENT_REQUIRED
+                    : OAuth2ErrorCodes.KAKAO_EMAIL_UNAVAILABLE;
+            throw kakaoAuthenticationException(errorCode, "카카오 계정 이메일을 사용할 수 없습니다");
+        }
+
         return OAuth2Attributes.builder()
-                .email((String) kakaoAccount.get(Provider.Kakao.EMAIL))
-                .providerId(String.valueOf(attributes.get(Provider.Kakao.PROVIDER_ID)))
+                .email(email)
+                .providerId(providerId)
                 .build();
+    }
+
+    private static String kakaoProviderId(Object value) {
+        if (value instanceof Number number && number.longValue() > 0) {
+            return String.valueOf(number.longValue());
+        }
+        if (value instanceof String string && StringUtils.hasText(string)) {
+            return string;
+        }
+        throw kakaoAuthenticationException(
+                OAuth2ErrorCodes.INVALID_KAKAO_USER_INFO,
+                "카카오 사용자 식별자를 가져올 수 없습니다"
+        );
+    }
+
+    private static Map<?, ?> kakaoAccount(Object value) {
+        if (value instanceof Map<?, ?> account) {
+            return account;
+        }
+        throw kakaoAuthenticationException(
+                OAuth2ErrorCodes.INVALID_KAKAO_USER_INFO,
+                "카카오 계정 정보를 가져올 수 없습니다"
+        );
+    }
+
+    private static String stringValue(Object value) {
+        return value instanceof String string ? string : null;
+    }
+
+    private static OAuth2AuthenticationException kakaoAuthenticationException(
+            String errorCode,
+            String description
+    ) {
+        return new OAuth2AuthenticationException(
+                new OAuth2Error(errorCode, description, null),
+                description
+        );
     }
 
     private static OAuth2Attributes ofNaver(Map<String, Object> attributes) {

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -21,6 +21,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Component
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
+    private static final String KAKAO_AUTHORIZATION_URI = "/oauth2/authorization/kakao";
+
     @Value("${app.oauth2.redirect.app-uri}")
     private String appUri;
 
@@ -32,12 +34,35 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
         logAuthenticationFailure(request, exception);
 
         if (AppleOAuth2AuthorizationRequestResolver.consumeAppClientType(request)) {
+            KakaoEmailConsentRetryState.clear(request);
             redirectAppFailure(request, response);
             return;
         }
 
+        if (shouldRetryKakaoEmailConsent(request, exception)) {
+            getRedirectStrategy().sendRedirect(request, response, KAKAO_AUTHORIZATION_URI);
+            return;
+        }
+
+        KakaoEmailConsentRetryState.clear(request);
+
         // 실패 시 리다이렉트 URL 설정
         getRedirectStrategy().sendRedirect(request, response, "/login?error=true");
+    }
+
+    private boolean shouldRetryKakaoEmailConsent(
+            HttpServletRequest request,
+            AuthenticationException exception
+    ) {
+        if (!(exception instanceof OAuth2AuthenticationException oauth2Exception)) {
+            return false;
+        }
+        if (!OAuth2ErrorCodes.KAKAO_EMAIL_CONSENT_REQUIRED.equals(
+                oauth2Exception.getError().getErrorCode()
+        )) {
+            return false;
+        }
+        return KakaoEmailConsentRetryState.beginRetry(request);
     }
 
     private void logAuthenticationFailure(HttpServletRequest request, AuthenticationException exception) {

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -23,6 +23,9 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
     private static final String KAKAO_AUTHORIZATION_URI = "/oauth2/authorization/kakao";
 
+    @Value("${app.oauth2.redirect.base-uri}")
+    private String baseUri;
+
     @Value("${app.oauth2.redirect.app-uri}")
     private String appUri;
 
@@ -46,8 +49,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
         KakaoEmailConsentRetryState.clear(request);
 
-        // 실패 시 리다이렉트 URL 설정
-        getRedirectStrategy().sendRedirect(request, response, "/login?error=true");
+        getRedirectStrategy().sendRedirect(request, response, webFailureUri());
     }
 
     private boolean shouldRetryKakaoEmailConsent(
@@ -68,14 +70,13 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
     private void logAuthenticationFailure(HttpServletRequest request, AuthenticationException exception) {
         if (exception instanceof OAuth2AuthenticationException oauth2Exception) {
             OAuth2Error error = oauth2Exception.getError();
-            log.error(
+            log.warn(
                     "소셜 로그인 인증 실패: type={}, uri={}, errorCode={}, description={}, message={}",
                     oauth2Exception.getClass().getSimpleName(),
                     request.getRequestURI(),
                     error.getErrorCode(),
                     sanitize(error.getDescription()),
-                    sanitize(exception.getMessage()),
-                    exception
+                    sanitize(exception.getMessage())
             );
             return;
         }
@@ -84,8 +85,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
                 "소셜 로그인 인증 실패: type={}, uri={}, message={}",
                 exception.getClass().getSimpleName(),
                 request.getRequestURI(),
-                sanitize(exception.getMessage()),
-                exception
+                sanitize(exception.getMessage())
         );
     }
 
@@ -97,6 +97,15 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
                 "(?i)(client_secret|code|id_token|access_token|refresh_token|token)=([^\\s&]+)",
                 "$1=***"
         );
+    }
+
+    private String webFailureUri() {
+        String normalizedBaseUri = baseUri.endsWith("/") ? baseUri : baseUri + "/";
+        return UriComponentsBuilder.fromUriString(normalizedBaseUri)
+                .queryParam("error", "login_failed")
+                .build()
+                .encode()
+                .toUriString();
     }
 
     private void redirectAppFailure(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -39,6 +39,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             Authentication authentication
     ) throws IOException {
 
+        KakaoEmailConsentRetryState.clear(request);
+
         PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
         AuthUser user = principalDetails.getUser();
 

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2CallbackExceptionFilter.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2CallbackExceptionFilter.java
@@ -1,0 +1,102 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import checkmo.authentication.internal.security.jwt.JwtCookieUtil;
+import checkmo.common.monitoring.SentryCaptureClient;
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2CallbackExceptionFilter extends OncePerRequestFilter {
+
+    private static final String OAUTH2_CALLBACK_PATH = "/login/oauth2/**";
+
+    private final OAuth2AuthenticationFailureHandler failureHandler;
+    private final SentryCaptureClient sentryCaptureClient;
+    private final JwtCookieUtil jwtCookieUtil;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    @Override
+    protected boolean shouldNotFilter(@Nonnull HttpServletRequest request) {
+        return !pathMatcher.match(OAUTH2_CALLBACK_PATH, request.getRequestURI());
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @Nonnull HttpServletRequest request,
+            @Nonnull HttpServletResponse response,
+            @Nonnull FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception exception) {
+            handleUnexpectedException(request, response, exception);
+        }
+    }
+
+    private void handleUnexpectedException(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Exception exception
+    ) throws ServletException, IOException {
+        sentryCaptureClient.captureException(exception);
+        log.error(
+                "OAuth2 콜백 처리 중 예상하지 못한 예외: provider={}, type={}, uri={}",
+                provider(request),
+                exception.getClass().getSimpleName(),
+                request.getRequestURI()
+        );
+        SecurityContextHolder.clearContext();
+
+        if (response.isCommitted()) {
+            rethrow(exception);
+            return;
+        }
+
+        jwtCookieUtil.deleteTokenFromCookie(response, "accessToken");
+        jwtCookieUtil.deleteTokenFromCookie(response, "refreshToken");
+        OAuth2AuthenticationException authenticationException = new OAuth2AuthenticationException(
+                new OAuth2Error(
+                        OAuth2ErrorCodes.OAUTH2_PROCESSING_FAILED,
+                        "소셜 로그인 처리 중 오류가 발생했습니다",
+                        null
+                ),
+                "소셜 로그인 처리 중 오류가 발생했습니다",
+                exception
+        );
+        failureHandler.onAuthenticationFailure(request, response, authenticationException);
+    }
+
+    private String provider(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        int separator = uri.lastIndexOf('/');
+        if (separator < 0 || separator == uri.length() - 1) {
+            return "unknown";
+        }
+        String candidate = uri.substring(separator + 1);
+        return candidate.matches("[A-Za-z0-9_-]+") ? candidate : "unknown";
+    }
+
+    private void rethrow(Exception exception) throws ServletException, IOException {
+        if (exception instanceof IOException ioException) {
+            throw ioException;
+        }
+        if (exception instanceof ServletException servletException) {
+            throw servletException;
+        }
+        throw new ServletException(exception);
+    }
+}

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2ErrorCodes.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2ErrorCodes.java
@@ -5,6 +5,7 @@ final class OAuth2ErrorCodes {
     static final String INVALID_KAKAO_USER_INFO = "invalid_kakao_user_info";
     static final String KAKAO_EMAIL_CONSENT_REQUIRED = "kakao_email_consent_required";
     static final String KAKAO_EMAIL_UNAVAILABLE = "kakao_email_unavailable";
+    static final String OAUTH2_PROCESSING_FAILED = "oauth2_processing_failed";
 
     private OAuth2ErrorCodes() {
     }

--- a/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2ErrorCodes.java
+++ b/src/main/java/checkmo/authentication/internal/security/oauth2/OAuth2ErrorCodes.java
@@ -1,0 +1,11 @@
+package checkmo.authentication.internal.security.oauth2;
+
+final class OAuth2ErrorCodes {
+
+    static final String INVALID_KAKAO_USER_INFO = "invalid_kakao_user_info";
+    static final String KAKAO_EMAIL_CONSENT_REQUIRED = "kakao_email_consent_required";
+    static final String KAKAO_EMAIL_UNAVAILABLE = "kakao_email_unavailable";
+
+    private OAuth2ErrorCodes() {
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/config/OAuthErrorDispatchApiTest.java
+++ b/src/test/java/checkmo/authentication/internal/config/OAuthErrorDispatchApiTest.java
@@ -1,0 +1,57 @@
+package checkmo.authentication.internal.config;
+
+import static io.restassured.RestAssured.given;
+
+import checkmo.support.ApiTestSupport;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.Filter;
+import jakarta.servlet.ServletException;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
+
+@Import(OAuthErrorDispatchApiTest.ErrorDispatchTestConfiguration.class)
+class OAuthErrorDispatchApiTest extends ApiTestSupport {
+
+    private static final String ERROR_TRIGGER_PATH = "/api/v1/test/oauth-error-dispatch";
+
+    @Test
+    void keepsInternalErrorDispatchAsServerError() {
+        given()
+                .redirects().follow(false)
+                .when()
+                .get(ERROR_TRIGGER_PATH)
+                .then()
+                .statusCode(500);
+    }
+
+    @Test
+    void directErrorEndpointRequestStillRequiresAuthentication() {
+        given()
+                .redirects().follow(false)
+                .when()
+                .get("/error")
+                .then()
+                .statusCode(401);
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class ErrorDispatchTestConfiguration {
+
+        @Bean
+        FilterRegistrationBean<Filter> errorDispatchTriggerFilter() {
+            Filter filter = (request, response, chain) -> {
+                throw new ServletException("expected test exception");
+            };
+            FilterRegistrationBean<Filter> registration = new FilterRegistrationBean<>(filter);
+            registration.setUrlPatterns(Set.of(ERROR_TRIGGER_PATH));
+            registration.setDispatcherTypes(DispatcherType.REQUEST);
+            registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+            return registration;
+        }
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AttributesTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AttributesTest.java
@@ -1,7 +1,8 @@
 package checkmo.authentication.internal.security.oauth2;
 
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -55,5 +56,52 @@ class OAuth2AttributesTest {
     void rejectsAppleWithoutSubject() {
         assertThatThrownBy(() -> OAuth2Attributes.of("apple", Map.of("email", "apple-user@example.com")))
                 .isInstanceOf(OAuth2AuthenticationException.class);
+    }
+
+    @Test
+    void rejectsKakaoWithoutAccountInformation() {
+        assertOAuthErrorCode(
+                () -> OAuth2Attributes.of("kakao", Map.of("id", 12345L)),
+                OAuth2ErrorCodes.INVALID_KAKAO_USER_INFO
+        );
+    }
+
+    @Test
+    void rejectsKakaoWithoutProviderId() {
+        assertOAuthErrorCode(
+                () -> OAuth2Attributes.of("kakao", Map.of(
+                        "kakao_account", Map.of("email", "kakao-user@example.com")
+                )),
+                OAuth2ErrorCodes.INVALID_KAKAO_USER_INFO
+        );
+    }
+
+    @Test
+    void requestsAdditionalConsentWhenKakaoEmailNeedsAgreement() {
+        assertOAuthErrorCode(
+                () -> OAuth2Attributes.of("kakao", Map.of(
+                        "id", 12345L,
+                        "kakao_account", Map.of("email_needs_agreement", true)
+                )),
+                OAuth2ErrorCodes.KAKAO_EMAIL_CONSENT_REQUIRED
+        );
+    }
+
+    @Test
+    void rejectsKakaoAccountWhenEmailIsUnavailable() {
+        assertOAuthErrorCode(
+                () -> OAuth2Attributes.of("kakao", Map.of(
+                        "id", 12345L,
+                        "kakao_account", Map.of("email_needs_agreement", false)
+                )),
+                OAuth2ErrorCodes.KAKAO_EMAIL_UNAVAILABLE
+        );
+    }
+
+    private void assertOAuthErrorCode(Runnable action, String errorCode) {
+        assertThatThrownBy(action::run)
+                .isInstanceOfSatisfying(OAuth2AuthenticationException.class, exception ->
+                        assertThat(exception.getError().getErrorCode()).isEqualTo(errorCode)
+                );
     }
 }

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandlerTest.java
@@ -14,6 +14,7 @@ class OAuth2AuthenticationFailureHandlerTest {
     @Test
     void redirectsWithoutSecretQuery() throws Exception {
         OAuth2AuthenticationFailureHandler handler = new OAuth2AuthenticationFailureHandler();
+        ReflectionTestUtils.setField(handler, "baseUri", "https://web.checkmo.test");
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpServletResponse response = new MockHttpServletResponse();
         OAuth2AuthenticationException exception = new OAuth2AuthenticationException(
@@ -23,7 +24,8 @@ class OAuth2AuthenticationFailureHandlerTest {
         handler.onAuthenticationFailure(request, response, exception);
 
         assertSoftly(softly -> {
-            softly.assertThat(response.getRedirectedUrl()).isEqualTo("/login?error=true");
+            softly.assertThat(response.getRedirectedUrl())
+                    .isEqualTo("https://web.checkmo.test/?error=login_failed");
             softly.assertThat(response.getRedirectedUrl()).doesNotContain("secret-value");
             softly.assertThat(response.getRedirectedUrl()).doesNotContain("token=");
         });
@@ -80,6 +82,7 @@ class OAuth2AuthenticationFailureHandlerTest {
     @Test
     void redirectsNormallyWhenKakaoEmailConsentRetryIsExhausted() throws Exception {
         OAuth2AuthenticationFailureHandler handler = new OAuth2AuthenticationFailureHandler();
+        ReflectionTestUtils.setField(handler, "baseUri", "https://web.checkmo.test/");
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setRequestURI("/login/oauth2/code/kakao");
         request.getSession().setAttribute(KakaoEmailConsentRetryState.SESSION_ATTRIBUTE, Boolean.TRUE);
@@ -92,7 +95,8 @@ class OAuth2AuthenticationFailureHandlerTest {
         );
 
         assertSoftly(softly -> {
-            softly.assertThat(response.getRedirectedUrl()).isEqualTo("/login?error=true");
+            softly.assertThat(response.getRedirectedUrl())
+                    .isEqualTo("https://web.checkmo.test/?error=login_failed");
             softly.assertThat(request.getSession().getAttribute(KakaoEmailConsentRetryState.SESSION_ATTRIBUTE))
                     .isNull();
         });

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationFailureHandlerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class OAuth2AuthenticationFailureHandlerTest {
@@ -53,5 +54,54 @@ class OAuth2AuthenticationFailureHandlerTest {
             softly.assertThat(request.getSession().getAttribute(
                     AppleOAuth2AuthorizationRequestResolver.sessionClientTypeKey("app-state"))).isNull();
         });
+    }
+
+    @Test
+    void retriesKakaoEmailConsentOnce() throws Exception {
+        OAuth2AuthenticationFailureHandler handler = new OAuth2AuthenticationFailureHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/login/oauth2/code/kakao");
+        request.getSession();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationFailure(
+                request,
+                response,
+                oauthException(OAuth2ErrorCodes.KAKAO_EMAIL_CONSENT_REQUIRED)
+        );
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.getRedirectedUrl()).isEqualTo("/oauth2/authorization/kakao");
+            softly.assertThat(request.getSession().getAttribute(KakaoEmailConsentRetryState.SESSION_ATTRIBUTE))
+                    .isEqualTo(Boolean.TRUE);
+        });
+    }
+
+    @Test
+    void redirectsNormallyWhenKakaoEmailConsentRetryIsExhausted() throws Exception {
+        OAuth2AuthenticationFailureHandler handler = new OAuth2AuthenticationFailureHandler();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/login/oauth2/code/kakao");
+        request.getSession().setAttribute(KakaoEmailConsentRetryState.SESSION_ATTRIBUTE, Boolean.TRUE);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationFailure(
+                request,
+                response,
+                oauthException(OAuth2ErrorCodes.KAKAO_EMAIL_CONSENT_REQUIRED)
+        );
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.getRedirectedUrl()).isEqualTo("/login?error=true");
+            softly.assertThat(request.getSession().getAttribute(KakaoEmailConsentRetryState.SESSION_ATTRIBUTE))
+                    .isNull();
+        });
+    }
+
+    private OAuth2AuthenticationException oauthException(String errorCode) {
+        return new OAuth2AuthenticationException(
+                new OAuth2Error(errorCode, "controlled oauth failure", null),
+                "controlled oauth failure"
+        );
     }
 }

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2AuthenticationSuccessHandlerTest.java
@@ -64,6 +64,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
         PrincipalDetails principal = new PrincipalDetails(user, Map.of("sub", "google-sub"), false);
         TestingAuthenticationToken authentication = new TestingAuthenticationToken(principal, null);
         MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute(KakaoEmailConsentRetryState.SESSION_ATTRIBUTE, Boolean.TRUE);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         when(jwtTokenProvider.generateToken(authentication)).thenReturn(JwtToken.builder()
@@ -90,6 +91,9 @@ class OAuth2AuthenticationSuccessHandlerTest {
         });
         verify(authReactivationCommandService).reactivateIfDeactivated(1L);
         verify(tokenCacheService).saveRefreshToken(1L, "session-1", "refresh-token");
+        assertSoftly(softly -> softly.assertThat(
+                request.getSession().getAttribute(KakaoEmailConsentRetryState.SESSION_ATTRIBUTE)
+        ).isNull());
     }
 
     @Test

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2CallbackExceptionFilterTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/OAuth2CallbackExceptionFilterTest.java
@@ -1,0 +1,77 @@
+package checkmo.authentication.internal.security.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import checkmo.authentication.internal.security.jwt.JwtCookieUtil;
+import checkmo.common.monitoring.SentryCaptureClient;
+import jakarta.servlet.ServletException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+class OAuth2CallbackExceptionFilterTest {
+
+    private final OAuth2AuthenticationFailureHandler failureHandler =
+            mock(OAuth2AuthenticationFailureHandler.class);
+    private final SentryCaptureClient sentryCaptureClient = mock(SentryCaptureClient.class);
+    private final OAuth2CallbackExceptionFilter filter = new OAuth2CallbackExceptionFilter(
+            failureHandler,
+            sentryCaptureClient,
+            new JwtCookieUtil()
+    );
+
+    @Test
+    void skipsNonOAuthCallbackRequests() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/v1/books");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean continued = new AtomicBoolean();
+
+        filter.doFilter(request, response, (servletRequest, servletResponse) -> continued.set(true));
+
+        assertThat(continued).isTrue();
+        verifyNoInteractions(failureHandler, sentryCaptureClient);
+    }
+
+    @Test
+    void capturesUnexpectedCallbackExceptionOnceAndDelegatesControlledFailure() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/login/oauth2/code/kakao");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        ServletException failure = new ServletException("token=secret-value");
+
+        filter.doFilter(request, response, (servletRequest, servletResponse) -> {
+            throw failure;
+        });
+
+        verify(sentryCaptureClient).captureException(failure);
+        ArgumentCaptor<AuthenticationException> exceptionCaptor =
+                ArgumentCaptor.forClass(AuthenticationException.class);
+        verify(failureHandler).onAuthenticationFailure(
+                org.mockito.ArgumentMatchers.same(request),
+                org.mockito.ArgumentMatchers.same(response),
+                exceptionCaptor.capture()
+        );
+
+        AuthenticationException delegated = exceptionCaptor.getValue();
+        String responseBody = response.getContentAsString();
+        assertSoftly(softly -> {
+            softly.assertThat(delegated).isInstanceOf(OAuth2AuthenticationException.class);
+            softly.assertThat(((OAuth2AuthenticationException) delegated).getError().getErrorCode())
+                    .isEqualTo(OAuth2ErrorCodes.OAUTH2_PROCESSING_FAILED);
+            softly.assertThat(delegated.getCause()).isSameAs(failure);
+            softly.assertThat(response.getHeaders("Set-Cookie"))
+                    .anyMatch(header -> header.startsWith("accessToken=") && header.contains("Max-Age=0"))
+                    .anyMatch(header -> header.startsWith("refreshToken=") && header.contains("Max-Age=0"));
+            softly.assertThat(responseBody).doesNotContain("secret-value");
+        });
+    }
+}

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreatorIntegrationTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreatorIntegrationTest.java
@@ -76,6 +76,30 @@ class SocialAccountCreatorIntegrationTest {
     }
 
     @Test
+    void persistsNewKakaoSocialUserAndMemberOnFirstLogin() {
+        OAuth2Attributes attributes = OAuth2Attributes.of("kakao", Map.of(
+                "id", 12345L,
+                "kakao_account", Map.of("email", "kakao-user@example.com")
+        ));
+
+        AuthUser createdUser = socialAccountCreator.create(attributes, "kakao");
+        AuthUser savedUser = authRepository.findByProviderAndProviderUserId("KAKAO", "12345").orElseThrow();
+        Integer memberCount = jdbcTemplate.queryForObject(
+                "select count(*) from member where id = ? and email = ?",
+                Integer.class,
+                createdUser.getId(),
+                "kakao-user@example.com"
+        );
+
+        assertSoftly(softly -> {
+            softly.assertThat(createdUser.getLegacyId()).isEqualTo("KAKAO_12345");
+            softly.assertThat(savedUser.getEmail()).isEqualTo("kakao-user@example.com");
+            softly.assertThat(savedUser.isProfileCompleted()).isFalse();
+            softly.assertThat(memberCount).isEqualTo(1);
+        });
+    }
+
+    @Test
     void duplicateProviderIdFailsInsteadOfMergingExistingUser() {
         authRepository.saveAndFlush(user("APPLE_apple-sub", "existing@example.com"));
         OAuth2Attributes attributes = OAuth2Attributes.of("apple", Map.of(

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolverTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountResolverTest.java
@@ -112,6 +112,27 @@ class SocialAccountResolverTest {
         });
     }
 
+    @Test
+    void createsIncompleteKakaoUserOnFirstLogin() {
+        OAuth2Attributes attributes = OAuth2Attributes.of("kakao", Map.of(
+                "id", 12345L,
+                "kakao_account", Map.of("email", "kakao-user@example.com")
+        ));
+        AuthUser createdUser = user("KAKAO_12345", "kakao-user@example.com");
+
+        when(authRepository.findByEmail("kakao-user@example.com")).thenReturn(Optional.empty());
+        when(socialAccountCreator.create(attributes, "kakao")).thenReturn(createdUser);
+
+        SocialAccountResolution result = resolver.resolve(attributes, "kakao");
+
+        assertSoftly(softly -> {
+            softly.assertThat(result.user()).isSameAs(createdUser);
+            softly.assertThat(result.newSocialSignUp()).isTrue();
+            softly.assertThat(result.user().isProfileCompleted()).isFalse();
+        });
+        verify(socialAccountCreator).create(attributes, "kakao");
+    }
+
     @ParameterizedTest
     @MethodSource("emailBasedSocialAttributes")
     void resolvesEmailBasedSocialLoginByEmailEvenWhenProviderIdDiffers(


### PR DESCRIPTION
## 🚀 변경사항

- 카카오 사용자 정보의 `id`, `kakao_account`, `email`을 안전하게 검증하도록 수정했습니다.
- 이메일 추가 동의가 필요한 경우 카카오 인증을 한 번만 자동 재요청하도록 구현했습니다.
- 이메일을 끝내 제공받지 못하면 회원을 생성하지 않고 로그인 실패 화면으로 이동하도록 처리했습니다.
- OAuth 콜백 처리 중 예상하지 못한 예외가 401 응답으로 덮이지 않도록 전용 예외 필터를 추가했습니다.
- 콜백 예외 발생 시 Sentry 기록, SecurityContext 초기화 및 JWT 쿠키 정리를 수행합니다.
- 웹 로그인 실패 시 프론트엔드의 `/?error=login_failed`로 이동하도록 통일했습니다.
- 내부 ERROR 디스패치는 정상적인 오류 상태를 유지하고, 외부 비인증 요청은 기존처럼 보호되도록 보안 설정을 보강했습니다.
- 카카오 신규 회원 생성, 이메일 추가 동의, 콜백 예외 및 보안 회귀 테스트를 추가했습니다.

## 🔗 관련 이슈

- Closes #303

## ✅ 체크리스트

- [x] 로컬에서 관련 테스트 완료
- [x] 전체 `./gradlew test` 통과
- [x] 코드 리뷰 준비 완료

## 📝 특이사항

- REST API, DB 스키마 및 JWT 형식 변경은 없습니다.
- 이메일을 제공하지 않는 카카오 계정은 임시 이메일로 가입시키지 않습니다.
- 운영 배포 후 신규 카카오 계정의 최초 로그인 및 이메일 추가 동의 흐름 확인이 필요합니다.
- Nginx 프록시 설정 변경은 이번 PR에 포함하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Kakao social login handling, including one-time retries when email consent is required.
  * Added clearer OAuth2 login failure redirects and standardized error handling.
  * Validated Kakao account information and provided more specific errors for missing or unavailable email data.
  * Prevented sensitive token details from appearing in OAuth2 error responses.

* **Bug Fixes**
  * Improved recovery from OAuth2 callback failures and authentication errors.
  * Ensured retry state is cleared after successful authentication or completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->