### PR TITLE
fix(auth): 소셜 신규 가입의 닉네임 엔티티 콜백을 제거한다

### DIFF
--- a/src/main/java/checkmo/authentication/internal/entity/AuthUser.java
+++ b/src/main/java/checkmo/authentication/internal/entity/AuthUser.java
@@ -9,8 +9,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
@@ -97,12 +95,6 @@ public class AuthUser extends BaseEntity {
     public void updateNickname(String nickName) {
         this.nickName = NicknamePolicy.normalizeForStorage(nickName);
         this.nickNameKey = NicknamePolicy.comparisonKey(this.nickName);
-    }
-
-    @PrePersist
-    @PreUpdate
-    private void synchronizeNicknameIdentity() {
-        updateNickname(nickName);
     }
 
     public boolean isAdmin() {

--- a/src/main/java/checkmo/member/internal/entity/Member.java
+++ b/src/main/java/checkmo/member/internal/entity/Member.java
@@ -16,8 +16,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.util.ArrayList;
@@ -111,12 +109,6 @@ public class Member extends BaseEntity {
 
     public boolean hasSameNicknameIdentity(String nickName) {
         return NicknamePolicy.isSameIdentity(this.nickName, nickName);
-    }
-
-    @PrePersist
-    @PreUpdate
-    private void synchronizeNicknameIdentity() {
-        updateNickname(nickName);
     }
 
     public void updateProfile(String description, String imgUrl, String phoneNumber) {

--- a/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreatorIntegrationTest.java
+++ b/src/test/java/checkmo/authentication/internal/security/oauth2/SocialAccountCreatorIntegrationTest.java
@@ -1,5 +1,6 @@
 package checkmo.authentication.internal.security.oauth2;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -8,9 +9,12 @@ import checkmo.authentication.internal.entity.Role;
 import checkmo.authentication.internal.repository.AuthRepository;
 import checkmo.book.internal.scheduler.BookRecommendationScheduler;
 import checkmo.bookStory.internal.scheduler.BookStoryViewScheduler;
+import checkmo.member.internal.entity.Member;
+import checkmo.member.internal.repository.MemberRepository;
 import checkmo.member.internal.scheduler.MemberCleanupScheduler;
 import checkmo.support.SpringTest;
 import jakarta.persistence.PersistenceException;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -28,6 +32,9 @@ class SocialAccountCreatorIntegrationTest {
 
     @Autowired
     private AuthRepository authRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
@@ -58,21 +65,37 @@ class SocialAccountCreatorIntegrationTest {
     }
 
     @Test
-    void persistsNewSocialUserWithAssignedProviderId() {
-        OAuth2Attributes attributes = OAuth2Attributes.of("apple", Map.of(
-                "sub", "apple-sub",
-                "email", "apple-user@example.com"
-        ));
+    void persistsNewSocialUsersForEveryProviderWithoutNicknameIdentity() {
+        List<SocialAccountFixture> fixtures = List.of(
+                new SocialAccountFixture("google", "google-sub", "google-user@example.com", OAuth2Attributes.of(
+                        "google",
+                        Map.of("sub", "google-sub", "email", "google-user@example.com")
+                )),
+                new SocialAccountFixture("kakao", "12345", "kakao-user@example.com", OAuth2Attributes.of(
+                        "kakao",
+                        Map.of(
+                                "id", 12345L,
+                                "kakao_account", Map.of("email", "kakao-user@example.com")
+                        )
+                )),
+                new SocialAccountFixture("naver", "naver-id", "naver-user@example.com", OAuth2Attributes.of(
+                        "naver",
+                        Map.of("response", Map.of(
+                                "id", "naver-id",
+                                "email", "naver-user@example.com"
+                        ))
+                )),
+                new SocialAccountFixture("apple", "apple-sub", "apple-user@example.com", OAuth2Attributes.of(
+                        "apple",
+                        Map.of("sub", "apple-sub", "email", "apple-user@example.com")
+                ))
+        );
 
-        AuthUser createdUser = socialAccountCreator.create(attributes, "apple");
-        AuthUser savedUser = authRepository.findByProviderAndProviderUserId("APPLE", "apple-sub").orElseThrow();
+        fixtures.forEach(fixture -> socialAccountCreator.create(fixture.attributes(), fixture.registrationId()));
 
-        assertSoftly(softly -> {
-            softly.assertThat(createdUser.getLegacyId()).isEqualTo("APPLE_apple-sub");
-            softly.assertThat(savedUser.getLegacyId()).isEqualTo("APPLE_apple-sub");
-            softly.assertThat(savedUser.getEmail()).isEqualTo("apple-user@example.com");
-            softly.assertThat(savedUser.isProfileCompleted()).isFalse();
-        });
+        assertThat(authRepository.count()).isEqualTo(fixtures.size());
+        assertThat(memberRepository.count()).isEqualTo(fixtures.size());
+        fixtures.forEach(this::assertIncompleteSocialAccountPersisted);
     }
 
     @Test
@@ -107,7 +130,34 @@ class SocialAccountCreatorIntegrationTest {
                 .build();
     }
 
+    private void assertIncompleteSocialAccountPersisted(SocialAccountFixture fixture) {
+        String provider = fixture.registrationId().toUpperCase();
+        AuthUser savedUser = authRepository
+                .findByProviderAndProviderUserId(provider, fixture.providerUserId())
+                .orElseThrow();
+        Member savedMember = memberRepository.findById(savedUser.getId()).orElseThrow();
+
+        assertSoftly(softly -> {
+            softly.assertThat(savedUser.getLegacyId()).isEqualTo(provider + "_" + fixture.providerUserId());
+            softly.assertThat(savedUser.getEmail()).isEqualTo(fixture.email());
+            softly.assertThat(savedUser.getNickName()).isNull();
+            softly.assertThat(savedUser.getNickNameKey()).isNull();
+            softly.assertThat(savedUser.isProfileCompleted()).isFalse();
+            softly.assertThat(savedMember.getEmail()).isEqualTo(fixture.email());
+            softly.assertThat(savedMember.getNickName()).isNull();
+            softly.assertThat(savedMember.getNickNameKey()).isNull();
+        });
+    }
+
     private String quoteIdentifier(String identifier) {
         return "\"" + identifier.replace("\"", "\"\"") + "\"";
+    }
+
+    private record SocialAccountFixture(
+            String registrationId,
+            String providerUserId,
+            String email,
+            OAuth2Attributes attributes
+    ) {
     }
 }

--- a/src/test/java/checkmo/member/TermsDomainServiceTest.java
+++ b/src/test/java/checkmo/member/TermsDomainServiceTest.java
@@ -216,15 +216,16 @@ class TermsDomainServiceTest {
 
     private Member saveMember() {
         String suffix = UUID.randomUUID().toString().substring(0, 8);
-        return memberRepository.save(Member.builder()
+        Member member = Member.builder()
                 .id(Math.abs(UUID.randomUUID().getMostSignificantBits()))
                 .legacyId("LOCAL_" + suffix)
                 .email(suffix + "@example.com")
                 .name("테스트")
                 .phoneNumber("01000000000")
-                .nickName("terms" + suffix)
                 .description("")
-                .build());
+                .build();
+        member.updateNickname("terms" + suffix);
+        return memberRepository.save(member);
     }
 
     private MemberTerms saveMemberTerms(Member member, Terms terms, boolean agreed) {

--- a/src/test/java/checkmo/member/internal/service/command/MemberCommandServiceTest.java
+++ b/src/test/java/checkmo/member/internal/service/command/MemberCommandServiceTest.java
@@ -50,7 +50,6 @@ class MemberCommandServiceTest {
         private TestFixture(String constraintName) {
             Member member = Member.builder()
                     .id(1L)
-                    .nickName("기존Nick")
                     .build();
             member.updateNickname("기존Nick");
 

--- a/src/test/java/checkmo/support/ApiTestSupport.java
+++ b/src/test/java/checkmo/support/ApiTestSupport.java
@@ -314,8 +314,10 @@ public abstract class ApiTestSupport {
                 .providerUserId(providerUserId)
                 .role(role)
                 .profileCompleted(profileCompleted)
-                .nickName(profileCompleted ? nickName : null)
                 .build();
+        if (profileCompleted) {
+            authUser.updateNickname(nickName);
+        }
         AuthUser savedAuthUser = authRepository.save(authUser);
 
         Member member = Member.builder()
@@ -324,9 +326,11 @@ public abstract class ApiTestSupport {
                 .email(email)
                 .name("테스트")
                 .phoneNumber("01012345678")
-                .nickName(profileCompleted ? nickName : null)
                 .description("api test fixture")
                 .build();
+        if (profileCompleted) {
+            member.updateNickname(nickName);
+        }
         memberRepository.save(member);
 
         JwtToken token = jwtTokenProvider.generateToken(jwtTokenProvider.getAuthenticationFromMemberId(savedAuthUser.getId()));


### PR DESCRIPTION
소셜 신규 회원 생성 시 닉네임이 없는 AuthUser와 Member에 전역 JPA 콜백이 개입하지 않도록 한다. 닉네임 변경 경로의 명시적 정규화와 비교 키 동기화는 유지한다.

Tested: ./gradlew test

## 🚀 변경사항
<!-- 뭘 구현했는지/수정했는지 간단히 -->

## 🔗 관련 이슈
- Closes #이슈번호

## ✅ 체크리스트
- [ ] 로컬에서 테스트 완료
- [ ] 코드 리뷰 준비 완료

## 📝 특이사항
<!-- 리뷰어가 특별히 봐줬으면 하는 부분 (선택사항) -->
